### PR TITLE
Refactor `JsObject` to always be size 8 

### DIFF
--- a/cli/src/debug/function.rs
+++ b/cli/src/debug/function.rs
@@ -134,9 +134,9 @@ fn trace(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsVal
 
     let arguments = args.get(2..).unwrap_or(&[]);
 
-    set_trace_flag_in_function_object(callable, true)?;
+    set_trace_flag_in_function_object(&callable, true)?;
     let result = callable.call(this, arguments, context);
-    set_trace_flag_in_function_object(callable, false)?;
+    set_trace_flag_in_function_object(&callable, false)?;
 
     result
 }
@@ -151,7 +151,7 @@ fn traceable(_: &JsValue, args: &[JsValue], _: &mut Context) -> JsResult<JsValue
             .into());
     };
 
-    set_trace_flag_in_function_object(callable, traceable)?;
+    set_trace_flag_in_function_object(&callable, traceable)?;
 
     Ok(value.clone())
 }

--- a/cli/src/debug/shape.rs
+++ b/cli/src/debug/shape.rs
@@ -3,7 +3,7 @@ use boa_engine::{
     object::ObjectInitializer,
 };
 
-fn get_object(args: &[JsValue], position: usize) -> JsResult<&JsObject> {
+fn get_object(args: &[JsValue], position: usize) -> JsResult<JsObject> {
     let value = args.get_or_undefined(position);
 
     let Some(object) = value.as_object() else {

--- a/core/engine/src/builtins/array/array_iterator.rs
+++ b/core/engine/src/builtins/array/array_iterator.rs
@@ -100,8 +100,9 @@ impl ArrayIterator {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-%arrayiteratorprototype%.next
     pub(crate) fn next(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let mut array_iterator = this
-            .as_object()
+        let object = this.as_object();
+        let mut array_iterator = object
+            .as_ref()
             .and_then(JsObject::downcast_mut::<Self>)
             .ok_or_else(|| JsNativeError::typ().with_message("`this` is not an ArrayIterator"))?;
         let index = array_iterator.next_index;

--- a/core/engine/src/builtins/array/from_async.rs
+++ b/core/engine/src/builtins/array/from_async.rs
@@ -47,7 +47,7 @@ impl Array {
             } else {
                 // b. Else,
                 //     i. If IsCallable(mapfn) is false, throw a TypeError exception.
-                let Some(callable) = mapfn.as_callable().cloned() else {
+                let Some(callable) = mapfn.as_callable() else {
                     return Err(JsNativeError::typ()
                         .with_message("Array.fromAsync: mapping function must be callable")
                         .into());

--- a/core/engine/src/builtins/array/mod.rs
+++ b/core/engine/src/builtins/array/mod.rs
@@ -481,7 +481,7 @@ impl Array {
 
             // c. If thisRealm and realmC are not the same Realm Record, then
             if this_realm != realm_c
-                && *c == realm_c.intrinsics().constructors().array().constructor()
+                && c == realm_c.intrinsics().constructors().array().constructor()
             {
                 // i. If SameValue(C, realmC.[[Intrinsics]].[[%Array%]]) is true, set C to undefined.
                 // Note: fast path to step 6.
@@ -510,7 +510,7 @@ impl Array {
 
         if let Some(c) = c.as_constructor() {
             // 8. Return ? Construct(C, « 𝔽(length) »).
-            return c.construct(&[JsValue::new(length)], Some(c), context);
+            return c.construct(&[JsValue::new(length)], Some(&c), context);
         }
 
         // 7. If IsConstructor(C) is false, throw a TypeError exception.
@@ -584,7 +584,7 @@ impl Array {
                 // b. Let kValue be ? Get(arrayLike, Pk).
                 let k_value = array_like.get(k, context)?;
 
-                let mapped_value = if let Some(mapfn) = mapping {
+                let mapped_value = if let Some(ref mapfn) = mapping {
                     // c. If mapping is true, then
                     //     i. Let mappedValue be ? Call(mapfn, thisArg, « kValue, 𝔽(k) »).
                     mapfn.call(this_arg, &[k_value, k.into()], context)?
@@ -634,7 +634,7 @@ impl Array {
             };
 
             // v. If mapping is true, then
-            let mapped_value = if let Some(mapfn) = mapping {
+            let mapped_value = if let Some(ref mapfn) = mapping {
                 // 1. Let mappedValue be Completion(Call(mapper, thisArg, « next, 𝔽(k) »)).
                 let mapped_value = mapfn.call(this_arg, &[next, k.into()], context);
 
@@ -1837,7 +1837,7 @@ impl Array {
             source_len,
             0,
             1,
-            Some(mapper_function),
+            Some(&mapper_function),
             args.get_or_undefined(1),
             context,
         )?;
@@ -1924,7 +1924,7 @@ impl Array {
                     // 4. Set targetIndex to ? FlattenIntoArray(target, element, elementLen, targetIndex, newDepth)
                     target_index = Self::flatten_into_array(
                         target,
-                        element,
+                        &element,
                         element_len,
                         target_index,
                         new_depth,
@@ -2698,7 +2698,7 @@ impl Array {
         let sort_compare =
             |x: &JsValue, y: &JsValue, context: &mut Context| -> JsResult<Ordering> {
                 // a. Return ? CompareArrayElements(x, y, comparefn).
-                compare_array_elements(x, y, comparefn, context)
+                compare_array_elements(x, y, comparefn.as_ref(), context)
             };
 
         // 5. Let sortedList be ? SortIndexedProperties(obj, len, SortCompare, skip-holes).
@@ -2764,7 +2764,7 @@ impl Array {
         let sort_compare =
             |x: &JsValue, y: &JsValue, context: &mut Context| -> JsResult<Ordering> {
                 // a. Return ? CompareArrayElements(x, y, comparefn).
-                compare_array_elements(x, y, comparefn, context)
+                compare_array_elements(x, y, comparefn.as_ref(), context)
             };
 
         // 6. Let sortedList be ? SortIndexedProperties(O, len, SortCompare, read-through-holes).

--- a/core/engine/src/builtins/array_buffer/mod.rs
+++ b/core/engine/src/builtins/array_buffer/mod.rs
@@ -487,8 +487,9 @@ impl ArrayBuffer {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[ArrayBufferData]]).
         // 3. If IsSharedArrayBuffer(O) is true, throw a TypeError exception.
-        let buf = this
-            .as_object()
+        let object = this.as_object();
+        let buf = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ()
@@ -512,8 +513,9 @@ impl ArrayBuffer {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[ArrayBufferData]]).
         // 3. If IsSharedArrayBuffer(O) is true, throw a TypeError exception.
-        let buf = this
-            .as_object()
+        let object = this.as_object();
+        let buf = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message(
@@ -545,8 +547,9 @@ impl ArrayBuffer {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[ArrayBufferData]]).
         // 3. If IsSharedArrayBuffer(O) is true, throw a TypeError exception.
-        let buf = this
-            .as_object()
+        let object = this.as_object();
+        let buf = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ()
@@ -569,8 +572,9 @@ impl ArrayBuffer {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[ArrayBufferData]]).
         // 3. If IsSharedArrayBuffer(O) is true, throw a TypeError exception.
-        let buf = this
-            .as_object()
+        let object = this.as_object();
+        let buf = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ()

--- a/core/engine/src/builtins/array_buffer/mod.rs
+++ b/core/engine/src/builtins/array_buffer/mod.rs
@@ -27,7 +27,7 @@ use crate::{
     context::intrinsics::{Intrinsics, StandardConstructor, StandardConstructors},
     error::JsNativeError,
     js_string,
-    object::{JsObject, Object, internal_methods::get_prototype_from_constructor},
+    object::{JsObject, JsObjectTyped, Object, internal_methods::get_prototype_from_constructor},
     property::Attribute,
     realm::Realm,
     string::StaticJsStrings,
@@ -121,8 +121,8 @@ where
 #[derive(Debug, Clone, Trace, Finalize)]
 #[boa_gc(unsafe_no_drop)]
 pub(crate) enum BufferObject {
-    Buffer(JsObject<ArrayBuffer>),
-    SharedBuffer(JsObject<SharedArrayBuffer>),
+    Buffer(JsObjectTyped<ArrayBuffer>),
+    SharedBuffer(JsObjectTyped<SharedArrayBuffer>),
 }
 
 impl From<BufferObject> for JsObject {
@@ -179,9 +179,11 @@ impl BufferObject {
     #[track_caller]
     pub(crate) fn equals(lhs: &Self, rhs: &Self) -> bool {
         match (lhs, rhs) {
-            (BufferObject::Buffer(lhs), BufferObject::Buffer(rhs)) => JsObject::equals(lhs, rhs),
+            (BufferObject::Buffer(lhs), BufferObject::Buffer(rhs)) => {
+                JsObjectTyped::equals(lhs, rhs)
+            }
             (BufferObject::SharedBuffer(lhs), BufferObject::SharedBuffer(rhs)) => {
-                if JsObject::equals(lhs, rhs) {
+                if JsObjectTyped::equals(lhs, rhs) {
                     return true;
                 }
 
@@ -693,7 +695,7 @@ impl ArrayBuffer {
         };
 
         // 20. If SameValue(new, O) is true, throw a TypeError exception.
-        if JsObject::equals(&buf, &new) {
+        if JsObjectTyped::equals(&buf, &new) {
             return Err(JsNativeError::typ()
                 .with_message("new ArrayBuffer is the same as this ArrayBuffer")
                 .into());
@@ -857,7 +859,7 @@ impl ArrayBuffer {
         byte_len: u64,
         max_byte_len: Option<u64>,
         context: &mut Context,
-    ) -> JsResult<JsObject<ArrayBuffer>> {
+    ) -> JsResult<JsObjectTyped<ArrayBuffer>> {
         // 1. Let slots be « [[ArrayBufferData]], [[ArrayBufferByteLength]], [[ArrayBufferDetachKey]] ».
         // 2. If maxByteLength is present and maxByteLength is not empty, let allocatingResizableBuffer be true; otherwise let allocatingResizableBuffer be false.
         // 3. If allocatingResizableBuffer is true, then
@@ -885,7 +887,7 @@ impl ArrayBuffer {
         //        throw if, for example, virtual memory cannot be reserved up front.
         let block = create_byte_data_block(byte_len, max_byte_len, context)?;
 
-        let obj = JsObject::new(
+        let obj = JsObjectTyped::new(
             context.root_shape(),
             prototype,
             Self {

--- a/core/engine/src/builtins/array_buffer/mod.rs
+++ b/core/engine/src/builtins/array_buffer/mod.rs
@@ -148,9 +148,9 @@ impl BufferObject {
         &self,
     ) -> BufferRef<GcRef<'_, ArrayBuffer>, GcRef<'_, SharedArrayBuffer>> {
         match self {
-            Self::Buffer(buf) => BufferRef::Buffer(GcRef::map(buf.borrow(), |o| &o.data)),
+            Self::Buffer(buf) => BufferRef::Buffer(GcRef::map(buf.borrow(), |o| o.data())),
             Self::SharedBuffer(buf) => {
-                BufferRef::SharedBuffer(GcRef::map(buf.borrow(), |o| &o.data))
+                BufferRef::SharedBuffer(GcRef::map(buf.borrow(), |o| o.data()))
             }
         }
     }
@@ -166,10 +166,10 @@ impl BufferObject {
     > {
         match self {
             Self::Buffer(buf) => {
-                BufferRefMut::Buffer(GcRefMut::map(buf.borrow_mut(), |o| &mut o.data))
+                BufferRefMut::Buffer(GcRefMut::map(buf.borrow_mut(), |o| o.data_mut()))
             }
             Self::SharedBuffer(buf) => {
-                BufferRefMut::SharedBuffer(GcRefMut::map(buf.borrow_mut(), |o| &mut o.data))
+                BufferRefMut::SharedBuffer(GcRefMut::map(buf.borrow_mut(), |o| o.data_mut()))
             }
         }
     }

--- a/core/engine/src/builtins/array_buffer/shared.rs
+++ b/core/engine/src/builtins/array_buffer/shared.rs
@@ -12,7 +12,7 @@ use crate::{
     builtins::{Array, BuiltInBuilder, BuiltInConstructor, BuiltInObject, IntrinsicObject},
     context::intrinsics::{Intrinsics, StandardConstructor, StandardConstructors},
     js_string,
-    object::internal_methods::get_prototype_from_constructor,
+    object::{JsObjectTyped, internal_methods::get_prototype_from_constructor},
     property::Attribute,
     realm::Realm,
     string::StaticJsStrings,
@@ -480,7 +480,7 @@ impl SharedArrayBuffer {
         byte_len: u64,
         max_byte_len: Option<u64>,
         context: &mut Context,
-    ) -> JsResult<JsObject<SharedArrayBuffer>> {
+    ) -> JsResult<JsObjectTyped<SharedArrayBuffer>> {
         // 1. Let slots be « [[ArrayBufferData]] ».
         // 2. If maxByteLength is present and maxByteLength is not empty, let allocatingGrowableBuffer
         //    be true; otherwise let allocatingGrowableBuffer be false.
@@ -524,7 +524,7 @@ impl SharedArrayBuffer {
 
         // 10. Else,
         //     a. Set obj.[[ArrayBufferByteLength]] to byteLength.
-        let obj = JsObject::new(
+        let obj = JsObjectTyped::new(
             context.root_shape(),
             prototype,
             Self {

--- a/core/engine/src/builtins/array_buffer/shared.rs
+++ b/core/engine/src/builtins/array_buffer/shared.rs
@@ -213,8 +213,9 @@ impl SharedArrayBuffer {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[ArrayBufferData]]).
         // 3. If IsSharedArrayBuffer(O) is true, throw a TypeError exception.
-        let buf = this
-            .as_object()
+        let object = this.as_object();
+        let buf = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ()
@@ -239,8 +240,9 @@ impl SharedArrayBuffer {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[ArrayBufferData]]).
         // 3. If IsSharedArrayBuffer(O) is false, throw a TypeError exception.
-        let buf = this
-            .as_object()
+        let object = this.as_object();
+        let buf = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ()
@@ -262,8 +264,9 @@ impl SharedArrayBuffer {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[ArrayBufferData]]).
         // 3. If IsSharedArrayBuffer(O) is false, throw a TypeError exception.
-        let buf = this
-            .as_object()
+        let object = this.as_object();
+        let buf = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ()

--- a/core/engine/src/builtins/array_buffer/shared.rs
+++ b/core/engine/src/builtins/array_buffer/shared.rs
@@ -12,7 +12,7 @@ use crate::{
     builtins::{Array, BuiltInBuilder, BuiltInConstructor, BuiltInObject, IntrinsicObject},
     context::intrinsics::{Intrinsics, StandardConstructor, StandardConstructors},
     js_string,
-    object::{JsObjectTyped, internal_methods::get_prototype_from_constructor},
+    object::internal_methods::get_prototype_from_constructor,
     property::Attribute,
     realm::Realm,
     string::StaticJsStrings,
@@ -480,7 +480,7 @@ impl SharedArrayBuffer {
         byte_len: u64,
         max_byte_len: Option<u64>,
         context: &mut Context,
-    ) -> JsResult<JsObjectTyped<SharedArrayBuffer>> {
+    ) -> JsResult<JsObject<SharedArrayBuffer>> {
         // 1. Let slots be « [[ArrayBufferData]] ».
         // 2. If maxByteLength is present and maxByteLength is not empty, let allocatingGrowableBuffer
         //    be true; otherwise let allocatingGrowableBuffer be false.
@@ -524,7 +524,7 @@ impl SharedArrayBuffer {
 
         // 10. Else,
         //     a. Set obj.[[ArrayBufferByteLength]] to byteLength.
-        let obj = JsObjectTyped::new(
+        let obj = JsObject::new(
             context.root_shape(),
             prototype,
             Self {

--- a/core/engine/src/builtins/array_buffer/utils.rs
+++ b/core/engine/src/builtins/array_buffer/utils.rs
@@ -5,7 +5,7 @@ use portable_atomic::AtomicU8;
 use crate::{
     Context, JsResult,
     builtins::typed_array::{ClampedU8, Element, TypedArrayElement, TypedArrayKind},
-    object::JsObjectTyped,
+    object::JsObject,
 };
 
 use super::ArrayBuffer;
@@ -137,7 +137,7 @@ impl SliceRef<'_> {
     /// [`CloneArrayBuffer ( srcBuffer, srcByteOffset, srcLength )`][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-clonearraybuffer
-    pub(crate) fn clone(&self, context: &mut Context) -> JsResult<JsObjectTyped<ArrayBuffer>> {
+    pub(crate) fn clone(&self, context: &mut Context) -> JsResult<JsObject<ArrayBuffer>> {
         // 1. Assert: IsDetachedBuffer(srcBuffer) is false.
 
         // 2. Let targetBuffer be ? AllocateArrayBuffer(%ArrayBuffer%, srcLength).

--- a/core/engine/src/builtins/array_buffer/utils.rs
+++ b/core/engine/src/builtins/array_buffer/utils.rs
@@ -3,8 +3,9 @@ use std::{ptr, slice::SliceIndex, sync::atomic::Ordering};
 use portable_atomic::AtomicU8;
 
 use crate::{
-    Context, JsObject, JsResult,
+    Context, JsResult,
     builtins::typed_array::{ClampedU8, Element, TypedArrayElement, TypedArrayKind},
+    object::JsObjectTyped,
 };
 
 use super::ArrayBuffer;
@@ -136,7 +137,7 @@ impl SliceRef<'_> {
     /// [`CloneArrayBuffer ( srcBuffer, srcByteOffset, srcLength )`][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-clonearraybuffer
-    pub(crate) fn clone(&self, context: &mut Context) -> JsResult<JsObject<ArrayBuffer>> {
+    pub(crate) fn clone(&self, context: &mut Context) -> JsResult<JsObjectTyped<ArrayBuffer>> {
         // 1. Assert: IsDetachedBuffer(srcBuffer) is false.
 
         // 2. Let targetBuffer be ? AllocateArrayBuffer(%ArrayBuffer%, srcLength).

--- a/core/engine/src/builtins/async_generator/mod.rs
+++ b/core/engine/src/builtins/async_generator/mod.rs
@@ -17,7 +17,7 @@ use crate::{
     error::JsNativeError,
     js_string,
     native_function::NativeFunction,
-    object::{CONSTRUCTOR, FunctionObjectBuilder, JsObject, JsObjectTyped},
+    object::{CONSTRUCTOR, FunctionObjectBuilder, JsObject},
     property::Attribute,
     realm::Realm,
     string::StaticJsStrings,
@@ -340,7 +340,7 @@ impl AsyncGenerator {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-asyncgeneratorenqueue
     pub(crate) fn enqueue(
-        generator: &JsObjectTyped<AsyncGenerator>,
+        generator: &JsObject<AsyncGenerator>,
         completion: CompletionRecord,
         promise_capability: PromiseCapability,
     ) {
@@ -366,7 +366,7 @@ impl AsyncGenerator {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-asyncgeneratorcompletestep
     pub(crate) fn complete_step(
-        generator: &JsObjectTyped<AsyncGenerator>,
+        generator: &JsObject<AsyncGenerator>,
         completion: JsResult<JsValue>,
         done: bool,
         realm: Option<Realm>,
@@ -439,7 +439,7 @@ impl AsyncGenerator {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-asyncgeneratorresume
     pub(crate) fn resume(
-        generator: &JsObjectTyped<AsyncGenerator>,
+        generator: &JsObject<AsyncGenerator>,
         completion: CompletionRecord,
         context: &mut Context,
     ) {
@@ -493,7 +493,7 @@ impl AsyncGenerator {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-asyncgeneratorawaitreturn
     pub(crate) fn await_return(
-        generator: &JsObjectTyped<AsyncGenerator>,
+        generator: &JsObject<AsyncGenerator>,
         value: JsValue,
         context: &mut Context,
     ) {
@@ -614,7 +614,7 @@ impl AsyncGenerator {
     /// Panics if `generator` is not in the `DrainingQueue` state.
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-asyncgeneratordrainqueue
-    pub(crate) fn drain_queue(generator: &JsObjectTyped<AsyncGenerator>, context: &mut Context) {
+    pub(crate) fn drain_queue(generator: &JsObject<AsyncGenerator>, context: &mut Context) {
         // 1. Assert: generator.[[AsyncGeneratorState]] is draining-queue.
         assert_eq!(
             generator.borrow().data.state,

--- a/core/engine/src/builtins/async_generator/mod.rs
+++ b/core/engine/src/builtins/async_generator/mod.rs
@@ -17,7 +17,7 @@ use crate::{
     error::JsNativeError,
     js_string,
     native_function::NativeFunction,
-    object::{CONSTRUCTOR, FunctionObjectBuilder, JsObject},
+    object::{CONSTRUCTOR, FunctionObjectBuilder, JsObject, JsObjectTyped},
     property::Attribute,
     realm::Realm,
     string::StaticJsStrings,
@@ -340,7 +340,7 @@ impl AsyncGenerator {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-asyncgeneratorenqueue
     pub(crate) fn enqueue(
-        generator: &JsObject<AsyncGenerator>,
+        generator: &JsObjectTyped<AsyncGenerator>,
         completion: CompletionRecord,
         promise_capability: PromiseCapability,
     ) {
@@ -366,7 +366,7 @@ impl AsyncGenerator {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-asyncgeneratorcompletestep
     pub(crate) fn complete_step(
-        generator: &JsObject<AsyncGenerator>,
+        generator: &JsObjectTyped<AsyncGenerator>,
         completion: JsResult<JsValue>,
         done: bool,
         realm: Option<Realm>,
@@ -439,7 +439,7 @@ impl AsyncGenerator {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-asyncgeneratorresume
     pub(crate) fn resume(
-        generator: &JsObject<AsyncGenerator>,
+        generator: &JsObjectTyped<AsyncGenerator>,
         completion: CompletionRecord,
         context: &mut Context,
     ) {
@@ -493,7 +493,7 @@ impl AsyncGenerator {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-asyncgeneratorawaitreturn
     pub(crate) fn await_return(
-        generator: &JsObject<AsyncGenerator>,
+        generator: &JsObjectTyped<AsyncGenerator>,
         value: JsValue,
         context: &mut Context,
     ) {
@@ -614,7 +614,7 @@ impl AsyncGenerator {
     /// Panics if `generator` is not in the `DrainingQueue` state.
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-asyncgeneratordrainqueue
-    pub(crate) fn drain_queue(generator: &JsObject<AsyncGenerator>, context: &mut Context) {
+    pub(crate) fn drain_queue(generator: &JsObjectTyped<AsyncGenerator>, context: &mut Context) {
         // 1. Assert: generator.[[AsyncGeneratorState]] is draining-queue.
         assert_eq!(
             generator.borrow().data.state,

--- a/core/engine/src/builtins/atomics/mod.rs
+++ b/core/engine/src/builtins/atomics/mod.rs
@@ -15,9 +15,16 @@ mod futex;
 use std::sync::atomic::Ordering;
 
 use crate::{
-    Context, JsArgs, JsNativeError, JsResult, JsString, JsValue, builtins::BuiltInObject,
-    context::intrinsics::Intrinsics, js_string, object::JsObject, property::Attribute,
-    realm::Realm, string::StaticJsStrings, symbol::JsSymbol, sys::time::Duration,
+    Context, JsArgs, JsNativeError, JsResult, JsString, JsValue,
+    builtins::BuiltInObject,
+    context::intrinsics::Intrinsics,
+    js_string,
+    object::{JsObject, JsObjectTyped},
+    property::Attribute,
+    realm::Realm,
+    string::StaticJsStrings,
+    symbol::JsSymbol,
+    sys::time::Duration,
     value::IntegerOrInfinity,
 };
 
@@ -563,7 +570,7 @@ impl Atomics {
 fn validate_integer_typed_array(
     array: &JsValue,
     waitable: bool,
-) -> JsResult<(JsObject<TypedArray>, usize)> {
+) -> JsResult<(JsObjectTyped<TypedArray>, usize)> {
     // 1. Let taRecord be ? ValidateTypedArray(typedArray, unordered).
     // 2. NOTE: Bounds checking is not a synchronizing operation when typedArray's backing buffer is a growable SharedArrayBuffer.
     let ta_record = TypedArray::validate(array, Ordering::Relaxed)?;
@@ -606,7 +613,7 @@ struct AtomicAccess {
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-validateatomicaccess
 fn validate_atomic_access(
-    array: &JsObject<TypedArray>,
+    array: &JsObjectTyped<TypedArray>,
     buf_len: usize,
     request_index: &JsValue,
     context: &mut Context,

--- a/core/engine/src/builtins/atomics/mod.rs
+++ b/core/engine/src/builtins/atomics/mod.rs
@@ -15,16 +15,9 @@ mod futex;
 use std::sync::atomic::Ordering;
 
 use crate::{
-    Context, JsArgs, JsNativeError, JsResult, JsString, JsValue,
-    builtins::BuiltInObject,
-    context::intrinsics::Intrinsics,
-    js_string,
-    object::{JsObject, JsObjectTyped},
-    property::Attribute,
-    realm::Realm,
-    string::StaticJsStrings,
-    symbol::JsSymbol,
-    sys::time::Duration,
+    Context, JsArgs, JsNativeError, JsResult, JsString, JsValue, builtins::BuiltInObject,
+    context::intrinsics::Intrinsics, js_string, object::JsObject, property::Attribute,
+    realm::Realm, string::StaticJsStrings, symbol::JsSymbol, sys::time::Duration,
     value::IntegerOrInfinity,
 };
 
@@ -570,7 +563,7 @@ impl Atomics {
 fn validate_integer_typed_array(
     array: &JsValue,
     waitable: bool,
-) -> JsResult<(JsObjectTyped<TypedArray>, usize)> {
+) -> JsResult<(JsObject<TypedArray>, usize)> {
     // 1. Let taRecord be ? ValidateTypedArray(typedArray, unordered).
     // 2. NOTE: Bounds checking is not a synchronizing operation when typedArray's backing buffer is a growable SharedArrayBuffer.
     let ta_record = TypedArray::validate(array, Ordering::Relaxed)?;
@@ -613,7 +606,7 @@ struct AtomicAccess {
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-validateatomicaccess
 fn validate_atomic_access(
-    array: &JsObjectTyped<TypedArray>,
+    array: &JsObject<TypedArray>,
     buf_len: usize,
     request_index: &JsValue,
     context: &mut Context,

--- a/core/engine/src/builtins/builder.rs
+++ b/core/engine/src/builtins/builder.rs
@@ -394,13 +394,17 @@ impl BuiltInConstructorWithPrototype<'_> {
             debug_assert_eq!(prototype_old_storage.len(), 0);
         }
 
+        {
+            let mut function = self
+                .object
+                .downcast_mut::<NativeFunctionObject>()
+                .expect("Builtin must be a function object");
+            function.f = NativeFunction::from_fn_ptr(self.function);
+            function.constructor = Some(ConstructorKind::Base);
+            function.realm = Some(self.realm.clone());
+        }
+
         let mut object = self.object.borrow_mut();
-        let function = object
-            .downcast_mut::<NativeFunctionObject>()
-            .expect("Builtin must be a function object");
-        function.f = NativeFunction::from_fn_ptr(self.function);
-        function.constructor = Some(ConstructorKind::Base);
-        function.realm = Some(self.realm.clone());
         object
             .properties_mut()
             .shape
@@ -420,13 +424,17 @@ impl BuiltInConstructorWithPrototype<'_> {
         self = self.static_property(js_string!("length"), length, Attribute::CONFIGURABLE);
         self = self.static_property(js_string!("name"), name, Attribute::CONFIGURABLE);
 
+        {
+            let mut function = self
+                .object
+                .downcast_mut::<NativeFunctionObject>()
+                .expect("Builtin must be a function object");
+            function.f = NativeFunction::from_fn_ptr(self.function);
+            function.constructor = Some(ConstructorKind::Base);
+            function.realm = Some(self.realm.clone());
+        }
+
         let mut object = self.object.borrow_mut();
-        let function = object
-            .downcast_mut::<NativeFunctionObject>()
-            .expect("Builtin must be a function object");
-        function.f = NativeFunction::from_fn_ptr(self.function);
-        function.constructor = Some(ConstructorKind::Base);
-        function.realm = Some(self.realm.clone());
         object
             .properties_mut()
             .shape

--- a/core/engine/src/builtins/dataview/mod.rs
+++ b/core/engine/src/builtins/dataview/mod.rs
@@ -325,8 +325,9 @@ impl DataView {
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[DataView]]).
-        let view = this
-            .as_object()
+        let object = this.as_object();
+        let view = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| JsNativeError::typ().with_message("`this` is not a DataView"))?;
         // 3. Assert: O has a [[ViewedArrayBuffer]] internal slot.
@@ -354,8 +355,9 @@ impl DataView {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[DataView]]).
         // 3. Assert: O has a [[ViewedArrayBuffer]] internal slot.
-        let view = this
-            .as_object()
+        let object = this.as_object();
+        let view = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| JsNativeError::typ().with_message("`this` is not a DataView"))?;
 
@@ -396,8 +398,9 @@ impl DataView {
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[DataView]]).
-        let view = this
-            .as_object()
+        let object = this.as_object();
+        let view = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| JsNativeError::typ().with_message("`this` is not a DataView"))?;
 
@@ -439,8 +442,9 @@ impl DataView {
     ) -> JsResult<JsValue> {
         // 1. Perform ? RequireInternalSlot(view, [[DataView]]).
         // 2. Assert: view has a [[ViewedArrayBuffer]] internal slot.
-        let view = view
-            .as_object()
+        let object = view.as_object();
+        let view = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| JsNativeError::typ().with_message("`this` is not a DataView"))?;
 
@@ -756,8 +760,9 @@ impl DataView {
     ) -> JsResult<JsValue> {
         // 1. Perform ? RequireInternalSlot(view, [[DataView]]).
         // 2. Assert: view has a [[ViewedArrayBuffer]] internal slot.
-        let view = view
-            .as_object()
+        let object = view.as_object();
+        let view = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| JsNativeError::typ().with_message("`this` is not a DataView"))?;
 

--- a/core/engine/src/builtins/date/mod.rs
+++ b/core/engine/src/builtins/date/mod.rs
@@ -222,34 +222,34 @@ impl BuiltInConstructor for Date {
             // a. Let value be values[0].
             [value] => {
                 // b. If value is an Object and value has a [[DateValue]] internal slot, then
-                let tv = if let Some(date) =
-                    value.as_object().and_then(JsObject::downcast_ref::<Self>)
-                {
-                    // i. Let tv be value.[[DateValue]].
-                    date.0
-                }
-                // c. Else,
-                else {
-                    // i. Let v be ? ToPrimitive(value).
-                    let v = value.to_primitive(context, PreferredType::Default)?;
-
-                    // ii. If v is a String, then
-                    if let Some(v) = v.as_string() {
-                        // 1. Assert: The next step never returns an abrupt completion because v is a String.
-                        // 2. Let tv be the result of parsing v as a date, in exactly the same manner as for the parse method (21.4.3.2).
-                        let tv = parse_date(v, context.host_hooks().as_ref());
-                        if let Some(tv) = tv {
-                            tv as f64
-                        } else {
-                            f64::NAN
-                        }
+                let object = value.as_object();
+                let tv =
+                    if let Some(date) = object.as_ref().and_then(JsObject::downcast_ref::<Self>) {
+                        // i. Let tv be value.[[DateValue]].
+                        date.0
                     }
-                    // iii. Else,
+                    // c. Else,
                     else {
-                        // 1. Let tv be ? ToNumber(v).
-                        v.to_number(context)?
-                    }
-                };
+                        // i. Let v be ? ToPrimitive(value).
+                        let v = value.to_primitive(context, PreferredType::Default)?;
+
+                        // ii. If v is a String, then
+                        if let Some(v) = v.as_string() {
+                            // 1. Assert: The next step never returns an abrupt completion because v is a String.
+                            // 2. Let tv be the result of parsing v as a date, in exactly the same manner as for the parse method (21.4.3.2).
+                            let tv = parse_date(v, context.host_hooks().as_ref());
+                            if let Some(tv) = tv {
+                                tv as f64
+                            } else {
+                                f64::NAN
+                            }
+                        }
+                        // iii. Else,
+                        else {
+                            // 1. Let tv be ? ToNumber(v).
+                            v.to_number(context)?
+                        }
+                    };
 
                 // d. Let dv be TimeClip(tv).
                 Self(time_clip(tv))
@@ -814,8 +814,9 @@ impl Date {
     ) -> JsResult<JsValue> {
         // 1. Let dateObject be the this value.
         // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
-        let date = this
-            .as_object()
+        let object = this.as_object();
+        let date = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Date>)
             .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?;
 
@@ -855,8 +856,9 @@ impl Date {
             time_clip(new_date)
         };
 
-        let mut date_mut = this
-            .as_object()
+        let object = this.as_object();
+        let mut date_mut = object
+            .as_ref()
             .and_then(JsObject::downcast_mut::<Date>)
             .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?;
 
@@ -882,8 +884,9 @@ impl Date {
     ) -> JsResult<JsValue> {
         // 1. Let dateObject be the this value.
         // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
-        let date = this
-            .as_object()
+        let object = this.as_object();
+        let date = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Date>)
             .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?;
 
@@ -936,8 +939,9 @@ impl Date {
             time_clip(new_date)
         };
 
-        let mut date_mut = this
-            .as_object()
+        let object = this.as_object();
+        let mut date_mut = object
+            .as_ref()
             .and_then(JsObject::downcast_mut::<Date>)
             .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?;
 
@@ -965,8 +969,9 @@ impl Date {
     ) -> JsResult<JsValue> {
         // 1. Let dateObject be the this value.
         // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
-        let date = this
-            .as_object()
+        let object = this.as_object();
+        let date = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Date>)
             .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?;
 
@@ -1021,8 +1026,9 @@ impl Date {
             time_clip(date)
         };
 
-        let mut date_mut = this
-            .as_object()
+        let object = this.as_object();
+        let mut date_mut = object
+            .as_ref()
             .and_then(JsObject::downcast_mut::<Date>)
             .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?;
 
@@ -1047,8 +1053,9 @@ impl Date {
     ) -> JsResult<JsValue> {
         // 1. Let dateObject be the this value.
         // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
-        let date = this
-            .as_object()
+        let object = this.as_object();
+        let date = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Date>)
             .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?;
 
@@ -1093,8 +1100,9 @@ impl Date {
             time_clip(make_date(day(t), time))
         };
 
-        let mut date_mut = this
-            .as_object()
+        let object = this.as_object();
+        let mut date_mut = object
+            .as_ref()
             .and_then(JsObject::downcast_mut::<Date>)
             .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?;
 
@@ -1119,8 +1127,9 @@ impl Date {
     ) -> JsResult<JsValue> {
         // 1. Let dateObject be the this value.
         // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
-        let date = this
-            .as_object()
+        let object = this.as_object();
+        let date = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Date>)
             .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?;
 
@@ -1169,8 +1178,9 @@ impl Date {
             time_clip(date)
         };
 
-        let mut date_mut = this
-            .as_object()
+        let object = this.as_object();
+        let mut date_mut = object
+            .as_ref()
             .and_then(JsObject::downcast_mut::<Date>)
             .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?;
 
@@ -1196,8 +1206,9 @@ impl Date {
     ) -> JsResult<JsValue> {
         // 1. Let dateObject be the this value.
         // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
-        let date = this
-            .as_object()
+        let object = this.as_object();
+        let date = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Date>)
             .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?;
 
@@ -1243,8 +1254,9 @@ impl Date {
             time_clip(new_date)
         };
 
-        let mut date_mut = this
-            .as_object()
+        let object = this.as_object();
+        let mut date_mut = object
+            .as_ref()
             .and_then(JsObject::downcast_mut::<Date>)
             .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?;
 
@@ -1269,8 +1281,9 @@ impl Date {
     ) -> JsResult<JsValue> {
         // 1. Let dateObject be the this value.
         // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
-        let date = this
-            .as_object()
+        let object = this.as_object();
+        let date = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Date>)
             .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?;
 
@@ -1316,8 +1329,9 @@ impl Date {
             time_clip(date)
         };
 
-        let mut date_mut = this
-            .as_object()
+        let object = this.as_object();
+        let mut date_mut = object
+            .as_ref()
             .and_then(JsObject::downcast_mut::<Date>)
             .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?;
 
@@ -1349,8 +1363,9 @@ impl Date {
     ) -> JsResult<JsValue> {
         // 1. Let dateObject be the this value.
         // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
-        let date = this
-            .as_object()
+        let object = this.as_object();
+        let date = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Date>)
             .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?;
 
@@ -1385,8 +1400,9 @@ impl Date {
         // 9. Let u be TimeClip(UTC(date)).
         let u = time_clip(utc_t(date, context.host_hooks().as_ref()));
 
-        let mut date_mut = this
-            .as_object()
+        let object = this.as_object();
+        let mut date_mut = object
+            .as_ref()
             .and_then(JsObject::downcast_mut::<Date>)
             .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?;
 
@@ -1414,8 +1430,9 @@ impl Date {
     ) -> JsResult<JsValue> {
         // 1. Let dateObject be the this value.
         // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
-        let date = this
-            .as_object()
+        let object = this.as_object();
+        let date = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Date>)
             .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?;
 
@@ -1431,8 +1448,9 @@ impl Date {
         // 4. Let v be TimeClip(t).
         let v = time_clip(t);
 
-        let mut date_mut = this
-            .as_object()
+        let object = this.as_object();
+        let mut date_mut = object
+            .as_ref()
             .and_then(JsObject::downcast_mut::<Date>)
             .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?;
 

--- a/core/engine/src/builtins/error/type.rs
+++ b/core/engine/src/builtins/error/type.rs
@@ -121,24 +121,24 @@ impl IntrinsicObject for ThrowTypeError {
             .static_property(js_string!("name"), js_string!(), Attribute::empty())
             .build();
 
-        let mut obj = obj.borrow_mut();
-
-        *obj.downcast_mut::<NativeFunctionObject>()
-            .expect("`%ThrowTypeError%` must be a function") = NativeFunctionObject {
-            f: NativeFunction::from_fn_ptr(|_, _, _| {
+        {
+            let mut obj = obj
+                .downcast_mut::<NativeFunctionObject>()
+                .expect("`%ThrowTypeError%` must be a function");
+            obj.f = NativeFunction::from_fn_ptr(|_, _, _| {
                 Err(JsNativeError::typ()
                     .with_message(
                         "'caller', 'callee', and 'arguments' properties may not be accessed on strict mode \
                         functions or the arguments objects for calls to them",
                     )
                     .into())
-            }),
-            name: js_string!(),
-            constructor: None,
-            realm: Some(realm.clone()),
-        };
+            });
+            obj.name = js_string!();
+            obj.constructor = None;
+            obj.realm = Some(realm.clone());
+        }
 
-        obj.extensible = false;
+        obj.borrow_mut().extensible = false;
     }
 
     fn get(intrinsics: &Intrinsics) -> JsObject {

--- a/core/engine/src/builtins/eval/mod.rs
+++ b/core/engine/src/builtins/eval/mod.rs
@@ -142,7 +142,11 @@ impl Eval {
             //     b. If thisEnvRec is a Function Environment Record, then
             Some(function_env) if direct => {
                 // i. Let F be thisEnvRec.[[FunctionObject]].
-                let function_object = function_env.slots().function_object().borrow();
+                let function_object = function_env
+                    .slots()
+                    .function_object()
+                    .downcast_ref::<OrdinaryFunction>()
+                    .expect("must be function object");
 
                 // ii. Set inFunction to true.
                 let mut flags = Flags::IN_FUNCTION;
@@ -151,10 +155,6 @@ impl Eval {
                 if function_env.has_super_binding() {
                     flags |= Flags::IN_METHOD;
                 }
-
-                let function_object = function_object
-                    .downcast_ref::<OrdinaryFunction>()
-                    .expect("must be function object");
 
                 // iv. If F.[[ConstructorKind]] is derived, set inDerivedConstructor to true.
                 if function_object.is_derived_constructor() {

--- a/core/engine/src/builtins/function/mod.rs
+++ b/core/engine/src/builtins/function/mod.rs
@@ -856,8 +856,7 @@ impl BuiltInFunctionObject {
             return Err(JsNativeError::typ().with_message("not a function").into());
         };
 
-        let object_borrow = object.borrow();
-        if object_borrow.is::<NativeFunctionObject>() {
+        if object.is::<NativeFunctionObject>() {
             let name = {
                 // Is there a case here where if there is no name field on a value
                 // name should default to None? Do all functions have names set?
@@ -871,11 +870,11 @@ impl BuiltInFunctionObject {
             return Ok(
                 js_string!(js_str!("function "), &name, js_str!("() { [native code] }")).into(),
             );
-        } else if object_borrow.is::<Proxy>() || object_borrow.is::<BoundFunction>() {
+        } else if object.is::<Proxy>() || object.is::<BoundFunction>() {
             return Ok(js_string!("function () { [native code] }").into());
         }
 
-        let function = object_borrow
+        let function = object
             .downcast_ref::<OrdinaryFunction>()
             .ok_or_else(|| JsNativeError::typ().with_message("not a function"))?;
 

--- a/core/engine/src/builtins/intl/collator/mod.rs
+++ b/core/engine/src/builtins/intl/collator/mod.rs
@@ -508,8 +508,9 @@ impl Collator {
     fn resolved_options(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let collator be the this value.
         // 2. Perform ? RequireInternalSlot(collator, [[InitializedCollator]]).
-        let collator = this
-            .as_object()
+        let object = this.as_object();
+        let collator = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ()

--- a/core/engine/src/builtins/intl/list_format/mod.rs
+++ b/core/engine/src/builtins/intl/list_format/mod.rs
@@ -226,8 +226,9 @@ impl ListFormat {
     fn format(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let lf be the this value.
         // 2. Perform ? RequireInternalSlot(lf, [[InitializedListFormat]]).
-        let lf = this
-            .as_object()
+        let object = this.as_object();
+        let lf = object
+            .as_ref()
             .and_then(|o| o.downcast_ref::<Self>())
             .ok_or_else(|| {
                 JsNativeError::typ()
@@ -343,8 +344,9 @@ impl ListFormat {
 
         // 1. Let lf be the this value.
         // 2. Perform ? RequireInternalSlot(lf, [[InitializedListFormat]]).
-        let lf = this
-            .as_object()
+        let object = this.as_object();
+        let lf = object
+            .as_ref()
             .and_then(|o| o.downcast_ref::<Self>())
             .ok_or_else(|| {
                 JsNativeError::typ()
@@ -416,8 +418,9 @@ impl ListFormat {
     fn resolved_options(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let lf be the this value.
         // 2. Perform ? RequireInternalSlot(lf, [[InitializedListFormat]]).
-        let lf = this
-            .as_object()
+        let object = this.as_object();
+        let lf = object
+            .as_ref()
             .and_then(|o| o.downcast_ref::<Self>())
             .ok_or_else(|| {
                 JsNativeError::typ()

--- a/core/engine/src/builtins/intl/list_format/mod.rs
+++ b/core/engine/src/builtins/intl/list_format/mod.rs
@@ -226,14 +226,13 @@ impl ListFormat {
     fn format(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let lf be the this value.
         // 2. Perform ? RequireInternalSlot(lf, [[InitializedListFormat]]).
-        let lf = this.as_object().map(JsObject::borrow).ok_or_else(|| {
-            JsNativeError::typ()
-                .with_message("`format` can only be called on a `ListFormat` object")
-        })?;
-        let lf = lf.downcast_ref::<Self>().ok_or_else(|| {
-            JsNativeError::typ()
-                .with_message("`format` can only be called on a `ListFormat` object")
-        })?;
+        let lf = this
+            .as_object()
+            .and_then(|o| o.downcast_ref::<Self>())
+            .ok_or_else(|| {
+                JsNativeError::typ()
+                    .with_message("`format` can only be called on a `ListFormat` object")
+            })?;
 
         // 3. Let stringList be ? StringListFromIterable(list).
         // TODO: support for UTF-16 unpaired surrogates formatting
@@ -344,14 +343,13 @@ impl ListFormat {
 
         // 1. Let lf be the this value.
         // 2. Perform ? RequireInternalSlot(lf, [[InitializedListFormat]]).
-        let lf = this.as_object().map(JsObject::borrow).ok_or_else(|| {
-            JsNativeError::typ()
-                .with_message("`formatToParts` can only be called on a `ListFormat` object")
-        })?;
-        let lf = lf.downcast_ref::<Self>().ok_or_else(|| {
-            JsNativeError::typ()
-                .with_message("`formatToParts` can only be called on a `ListFormat` object")
-        })?;
+        let lf = this
+            .as_object()
+            .and_then(|o| o.downcast_ref::<Self>())
+            .ok_or_else(|| {
+                JsNativeError::typ()
+                    .with_message("`formatToParts` can only be called on a `ListFormat` object")
+            })?;
 
         // 3. Let stringList be ? StringListFromIterable(list).
         // TODO: support for UTF-16 unpaired surrogates formatting
@@ -418,14 +416,13 @@ impl ListFormat {
     fn resolved_options(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let lf be the this value.
         // 2. Perform ? RequireInternalSlot(lf, [[InitializedListFormat]]).
-        let lf = this.as_object().map(JsObject::borrow).ok_or_else(|| {
-            JsNativeError::typ()
-                .with_message("`resolvedOptions` can only be called on a `ListFormat` object")
-        })?;
-        let lf = lf.downcast_ref::<Self>().ok_or_else(|| {
-            JsNativeError::typ()
-                .with_message("`resolvedOptions` can only be called on a `ListFormat` object")
-        })?;
+        let lf = this
+            .as_object()
+            .and_then(|o| o.downcast_ref::<Self>())
+            .ok_or_else(|| {
+                JsNativeError::typ()
+                    .with_message("`resolvedOptions` can only be called on a `ListFormat` object")
+            })?;
 
         // 3. Let options be OrdinaryObjectCreate(%Object.prototype%).
         let options = context

--- a/core/engine/src/builtins/intl/locale/mod.rs
+++ b/core/engine/src/builtins/intl/locale/mod.rs
@@ -348,8 +348,9 @@ impl Locale {
     ) -> JsResult<JsValue> {
         // 1. Let loc be the this value.
         // 2. Perform ? RequireInternalSlot(loc, [[InitializedLocale]]).
-        let mut loc = this
-            .as_object()
+        let object = this.as_object();
+        let mut loc = object
+            .as_ref()
             .and_then(|o| o.downcast_ref::<icu_locale::Locale>())
             .ok_or_else(|| {
                 JsNativeError::typ()
@@ -385,8 +386,9 @@ impl Locale {
     ) -> JsResult<JsValue> {
         // 1. Let loc be the this value.
         // 2. Perform ? RequireInternalSlot(loc, [[InitializedLocale]]).
-        let mut loc = this
-            .as_object()
+        let object = this.as_object();
+        let mut loc = object
+            .as_ref()
             .and_then(|o| o.downcast_ref::<icu_locale::Locale>())
             .ok_or_else(|| {
                 JsNativeError::typ().with_message(
@@ -419,8 +421,9 @@ impl Locale {
     pub(crate) fn to_string(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Let loc be the this value.
         // 2. Perform ? RequireInternalSlot(loc, [[InitializedLocale]]).
-        let loc = this
-            .as_object()
+        let object = this.as_object();
+        let loc = object
+            .as_ref()
             .and_then(|o| o.downcast_ref::<icu_locale::Locale>())
             .ok_or_else(|| {
                 JsNativeError::typ().with_message(
@@ -442,8 +445,9 @@ impl Locale {
     pub(crate) fn base_name(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Let loc be the this value.
         // 2. Perform ? RequireInternalSlot(loc, [[InitializedLocale]]).
-        let loc = this
-            .as_object()
+        let object = this.as_object();
+        let loc = object
+            .as_ref()
             .and_then(|o| o.downcast_ref::<icu_locale::Locale>())
             .ok_or_else(|| {
                 JsNativeError::typ().with_message(
@@ -466,8 +470,9 @@ impl Locale {
     pub(crate) fn calendar(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Let loc be the this value.
         // 2. Perform ? RequireInternalSlot(loc, [[InitializedLocale]]).
-        let loc = this
-            .as_object()
+        let object = this.as_object();
+        let loc = object
+            .as_ref()
             .and_then(|o| o.downcast_ref::<icu_locale::Locale>())
             .ok_or_else(|| {
                 JsNativeError::typ().with_message(
@@ -495,8 +500,9 @@ impl Locale {
     pub(crate) fn case_first(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Let loc be the this value.
         // 2. Perform ? RequireInternalSlot(loc, [[InitializedLocale]]).
-        let loc = this
-            .as_object()
+        let object = this.as_object();
+        let loc = object
+            .as_ref()
             .and_then(|o| o.downcast_ref::<icu_locale::Locale>())
             .ok_or_else(|| {
                 JsNativeError::typ().with_message(
@@ -524,8 +530,9 @@ impl Locale {
     pub(crate) fn collation(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Let loc be the this value.
         // 2. Perform ? RequireInternalSlot(loc, [[InitializedLocale]]).
-        let loc = this
-            .as_object()
+        let object = this.as_object();
+        let loc = object
+            .as_ref()
             .and_then(|o| o.downcast_ref::<icu_locale::Locale>())
             .ok_or_else(|| {
                 JsNativeError::typ().with_message(
@@ -553,8 +560,9 @@ impl Locale {
     pub(crate) fn hour_cycle(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Let loc be the this value.
         // 2. Perform ? RequireInternalSlot(loc, [[InitializedLocale]]).
-        let loc = this
-            .as_object()
+        let object = this.as_object();
+        let loc = object
+            .as_ref()
             .and_then(|o| o.downcast_ref::<icu_locale::Locale>())
             .ok_or_else(|| {
                 JsNativeError::typ().with_message(
@@ -582,8 +590,9 @@ impl Locale {
     pub(crate) fn numeric(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Let loc be the this value.
         // 2. Perform ? RequireInternalSlot(loc, [[InitializedLocale]]).
-        let loc = this
-            .as_object()
+        let object = this.as_object();
+        let loc = object
+            .as_ref()
             .and_then(|o| o.downcast_ref::<icu_locale::Locale>())
             .ok_or_else(|| {
                 JsNativeError::typ().with_message(
@@ -616,8 +625,9 @@ impl Locale {
     ) -> JsResult<JsValue> {
         // 1. Let loc be the this value.
         // 2. Perform ? RequireInternalSlot(loc, [[InitializedLocale]]).
-        let loc = this
-            .as_object()
+        let object = this.as_object();
+        let loc = object
+            .as_ref()
             .and_then(|o| o.downcast_ref::<icu_locale::Locale>())
             .ok_or_else(|| {
                 JsNativeError::typ().with_message(
@@ -645,8 +655,9 @@ impl Locale {
     pub(crate) fn language(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Let loc be the this value.
         // 2. Perform ? RequireInternalSlot(loc, [[InitializedLocale]]).
-        let loc = this
-            .as_object()
+        let object = this.as_object();
+        let loc = object
+            .as_ref()
             .and_then(|o| o.downcast_ref::<icu_locale::Locale>())
             .ok_or_else(|| {
                 JsNativeError::typ().with_message(
@@ -670,8 +681,9 @@ impl Locale {
     pub(crate) fn script(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Let loc be the this value.
         // 2. Perform ? RequireInternalSlot(loc, [[InitializedLocale]]).
-        let loc = this
-            .as_object()
+        let object = this.as_object();
+        let loc = object
+            .as_ref()
             .and_then(|o| o.downcast_ref::<icu_locale::Locale>())
             .ok_or_else(|| {
                 JsNativeError::typ().with_message(
@@ -700,8 +712,9 @@ impl Locale {
     pub(crate) fn region(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Let loc be the this value.
         // 2. Perform ? RequireInternalSlot(loc, [[InitializedLocale]]).
-        let loc = this
-            .as_object()
+        let object = this.as_object();
+        let loc = object
+            .as_ref()
             .and_then(|o| o.downcast_ref::<icu_locale::Locale>())
             .ok_or_else(|| {
                 JsNativeError::typ().with_message(
@@ -730,8 +743,9 @@ impl Locale {
     pub(crate) fn variants(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Let loc be the this value.
         // 2. Perform ? RequireInternalSlot(loc, [[InitializedLocale]]).
-        let loc = this
-            .as_object()
+        let loc = this.as_object();
+        let loc = loc
+            .as_ref()
             .and_then(|o| o.downcast_ref::<icu_locale::Locale>())
             .ok_or_else(|| {
                 JsNativeError::typ().with_message(

--- a/core/engine/src/builtins/intl/locale/utils.rs
+++ b/core/engine/src/builtins/intl/locale/utils.rs
@@ -49,13 +49,10 @@ pub(crate) fn locale_from_value(tag: &JsValue, context: &mut Context) -> JsResul
             .into());
     }
     // iii. If Type(kValue) is Object and kValue has an [[InitializedLocale]] internal slot, then
-    if let Some(tag) = tag
-        .as_object()
-        .and_then(|obj| obj.borrow().downcast_ref::<Locale>().cloned())
-    {
+    if let Some(tag) = tag.as_object().and_then(|obj| obj.downcast_ref::<Locale>()) {
         // 1. Let tag be kValue.[[Locale]].
         // No need to canonicalize since all `Locale` objects should already be canonicalized.
-        return Ok(tag);
+        return Ok(tag.clone());
     }
 
     // iv. Else,
@@ -113,11 +110,7 @@ pub(crate) fn canonicalize_locale_list(
     let mut seen = IndexSet::new();
 
     // 3. If Type(locales) is String or Type(locales) is Object and locales has an [[InitializedLocale]] internal slot, then
-    let o = if locales.is_string()
-        || locales
-            .as_object()
-            .is_some_and(|o| o.borrow().is::<Locale>())
-    {
+    let o = if locales.is_string() || locales.as_object().is_some_and(|o| o.is::<Locale>()) {
         // a. Let O be CreateArrayFromList(« locales »).
         Array::create_array_from_list([locales.clone()], context)
     } else {

--- a/core/engine/src/builtins/intl/locale/utils.rs
+++ b/core/engine/src/builtins/intl/locale/utils.rs
@@ -49,7 +49,8 @@ pub(crate) fn locale_from_value(tag: &JsValue, context: &mut Context) -> JsResul
             .into());
     }
     // iii. If Type(kValue) is Object and kValue has an [[InitializedLocale]] internal slot, then
-    if let Some(tag) = tag.as_object().and_then(|obj| obj.downcast_ref::<Locale>()) {
+    let object = tag.as_object();
+    if let Some(tag) = object.as_ref().and_then(|obj| obj.downcast_ref::<Locale>()) {
         // 1. Let tag be kValue.[[Locale]].
         // No need to canonicalize since all `Locale` objects should already be canonicalized.
         return Ok(tag.clone());

--- a/core/engine/src/builtins/intl/number_format/mod.rs
+++ b/core/engine/src/builtins/intl/number_format/mod.rs
@@ -24,6 +24,7 @@ use super::{
     locale::{canonicalize_locale_list, filter_locales, resolve_locale, validate_extension},
     options::{IntlOptions, coerce_options_to_object},
 };
+use crate::value::JsVariant;
 use crate::{
     Context, JsArgs, JsData, JsNativeError, JsObject, JsResult, JsString, JsSymbol, JsValue,
     NativeFunction,
@@ -42,7 +43,6 @@ use crate::{
     string::StaticJsStrings,
     value::PreferredType,
 };
-use crate::{object::JsObjectTyped, value::JsVariant};
 
 #[cfg(test)]
 mod tests;
@@ -729,10 +729,7 @@ impl NumberFormat {
 /// call to `RequireInternalSlot`.
 ///
 /// [spec]: https://tc39.es/ecma402/#sec-unwrapnumberformat
-fn unwrap_number_format(
-    nf: &JsValue,
-    context: &mut Context,
-) -> JsResult<JsObjectTyped<NumberFormat>> {
+fn unwrap_number_format(nf: &JsValue, context: &mut Context) -> JsResult<JsObject<NumberFormat>> {
     // 1. If Type(nf) is not Object, throw a TypeError exception.
     let nf_o = nf.as_object().ok_or_else(|| {
         JsNativeError::typ().with_message("value was not an `Intl.NumberFormat` object")

--- a/core/engine/src/builtins/intl/number_format/mod.rs
+++ b/core/engine/src/builtins/intl/number_format/mod.rs
@@ -760,7 +760,6 @@ fn unwrap_number_format(nf: &JsValue, context: &mut Context) -> JsResult<JsObjec
         if let Some(nf) = nf_o
             .get(fallback_symbol, context)?
             .as_object()
-            .cloned()
             .and_then(|o| o.downcast::<NumberFormat>().ok())
         {
             return Ok(nf);

--- a/core/engine/src/builtins/intl/number_format/mod.rs
+++ b/core/engine/src/builtins/intl/number_format/mod.rs
@@ -24,7 +24,6 @@ use super::{
     locale::{canonicalize_locale_list, filter_locales, resolve_locale, validate_extension},
     options::{IntlOptions, coerce_options_to_object},
 };
-use crate::value::JsVariant;
 use crate::{
     Context, JsArgs, JsData, JsNativeError, JsObject, JsResult, JsString, JsSymbol, JsValue,
     NativeFunction,
@@ -43,6 +42,7 @@ use crate::{
     string::StaticJsStrings,
     value::PreferredType,
 };
+use crate::{object::JsObjectTyped, value::JsVariant};
 
 #[cfg(test)]
 mod tests;
@@ -729,7 +729,10 @@ impl NumberFormat {
 /// call to `RequireInternalSlot`.
 ///
 /// [spec]: https://tc39.es/ecma402/#sec-unwrapnumberformat
-fn unwrap_number_format(nf: &JsValue, context: &mut Context) -> JsResult<JsObject<NumberFormat>> {
+fn unwrap_number_format(
+    nf: &JsValue,
+    context: &mut Context,
+) -> JsResult<JsObjectTyped<NumberFormat>> {
     // 1. If Type(nf) is not Object, throw a TypeError exception.
     let nf_o = nf.as_object().ok_or_else(|| {
         JsNativeError::typ().with_message("value was not an `Intl.NumberFormat` object")

--- a/core/engine/src/builtins/intl/plural_rules/mod.rs
+++ b/core/engine/src/builtins/intl/plural_rules/mod.rs
@@ -178,8 +178,9 @@ impl PluralRules {
     fn select(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let pr be the this value.
         // 2. Perform ? RequireInternalSlot(pr, [[InitializedPluralRules]]).
-        let plural_rules = this
-            .as_object()
+        let object = this.as_object();
+        let plural_rules = object
+            .as_ref()
             .and_then(|o| o.downcast_ref::<Self>())
             .ok_or_else(|| {
                 JsNativeError::typ()
@@ -204,8 +205,9 @@ impl PluralRules {
     fn select_range(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let pr be the this value.
         // 2. Perform ? RequireInternalSlot(pr, [[InitializedPluralRules]]).
-        let plural_rules = this
-            .as_object()
+        let object = this.as_object();
+        let plural_rules = object
+            .as_ref()
             .and_then(|o| o.downcast_ref::<Self>())
             .ok_or_else(|| {
                 JsNativeError::typ().with_message(
@@ -297,8 +299,9 @@ impl PluralRules {
     fn resolved_options(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let pr be the this value.
         // 2. Perform ? RequireInternalSlot(pr, [[InitializedPluralRules]]).
-        let plural_rules = this
-            .as_object()
+        let object = this.as_object();
+        let plural_rules = object
+            .as_ref()
             .and_then(|o| o.downcast_ref::<Self>())
             .ok_or_else(|| {
                 JsNativeError::typ().with_message(

--- a/core/engine/src/builtins/intl/plural_rules/mod.rs
+++ b/core/engine/src/builtins/intl/plural_rules/mod.rs
@@ -178,17 +178,17 @@ impl PluralRules {
     fn select(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let pr be the this value.
         // 2. Perform ? RequireInternalSlot(pr, [[InitializedPluralRules]]).
-        let plural_rules = this.as_object().map(JsObject::borrow).ok_or_else(|| {
-            JsNativeError::typ()
-                .with_message("`select` can only be called on an `Intl.PluralRules` object")
-        })?;
-        let plural_rules = plural_rules.downcast_ref::<Self>().ok_or_else(|| {
-            JsNativeError::typ()
-                .with_message("`select` can only be called on an `Intl.PluralRules` object")
-        })?;
+        let plural_rules = this
+            .as_object()
+            .and_then(|o| o.downcast_ref::<Self>())
+            .ok_or_else(|| {
+                JsNativeError::typ()
+                    .with_message("`select` can only be called on an `Intl.PluralRules` object")
+            })?;
 
         let n = args.get_or_undefined(0).to_number(context)?;
-        Ok(plural_category_to_js_string(resolve_plural(plural_rules, n).category).into())
+
+        Ok(plural_category_to_js_string(resolve_plural(&plural_rules, n).category).into())
     }
 
     /// [`Intl.PluralRules.prototype.selectRange ( start, end )`][spec].
@@ -204,14 +204,14 @@ impl PluralRules {
     fn select_range(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let pr be the this value.
         // 2. Perform ? RequireInternalSlot(pr, [[InitializedPluralRules]]).
-        let plural_rules = this.as_object().map(JsObject::borrow).ok_or_else(|| {
-            JsNativeError::typ()
-                .with_message("`select_range` can only be called on an `Intl.PluralRules` object")
-        })?;
-        let plural_rules = plural_rules.downcast_ref::<Self>().ok_or_else(|| {
-            JsNativeError::typ()
-                .with_message("`select_range` can only be called on an `Intl.PluralRules` object")
-        })?;
+        let plural_rules = this
+            .as_object()
+            .and_then(|o| o.downcast_ref::<Self>())
+            .ok_or_else(|| {
+                JsNativeError::typ().with_message(
+                    "`select_range` can only be called on an `Intl.PluralRules` object",
+                )
+            })?;
 
         // 3. If start is undefined or end is undefined, throw a TypeError exception.
         let x = args.get_or_undefined(0);
@@ -239,9 +239,9 @@ impl PluralRules {
         }
 
         // 2. Let xp be ResolvePlural(pluralRules, x).
-        let x = resolve_plural(plural_rules, x);
+        let x = resolve_plural(&plural_rules, x);
         // 3. Let yp be ResolvePlural(pluralRules, y).
-        let y = resolve_plural(plural_rules, y);
+        let y = resolve_plural(&plural_rules, y);
 
         // 4. If xp.[[FormattedString]] is yp.[[FormattedString]], then
         if x.formatted == y.formatted {
@@ -297,16 +297,14 @@ impl PluralRules {
     fn resolved_options(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let pr be the this value.
         // 2. Perform ? RequireInternalSlot(pr, [[InitializedPluralRules]]).
-        let plural_rules = this.as_object().map(JsObject::borrow).ok_or_else(|| {
-            JsNativeError::typ().with_message(
-                "`resolved_options` can only be called on an `Intl.PluralRules` object",
-            )
-        })?;
-        let plural_rules = plural_rules.downcast_ref::<Self>().ok_or_else(|| {
-            JsNativeError::typ().with_message(
-                "`resolved_options` can only be called on an `Intl.PluralRules` object",
-            )
-        })?;
+        let plural_rules = this
+            .as_object()
+            .and_then(|o| o.downcast_ref::<Self>())
+            .ok_or_else(|| {
+                JsNativeError::typ().with_message(
+                    "`resolved_options` can only be called on an `Intl.PluralRules` object",
+                )
+            })?;
 
         // 3. Let options be OrdinaryObjectCreate(%Object.prototype%).
         // 4. Let pluralCategories be a List of Strings containing all possible results of

--- a/core/engine/src/builtins/intl/segmenter/iterator.rs
+++ b/core/engine/src/builtins/intl/segmenter/iterator.rs
@@ -106,8 +106,9 @@ impl SegmentIterator {
     fn next(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let iterator be the this value.
         // 2. Perform ? RequireInternalSlot(iterator, [[IteratingSegmenter]]).
-        let mut iter = this
-            .as_object()
+        let object = this.as_object();
+        let mut iter = object
+            .as_ref()
             .and_then(JsObject::downcast_mut::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ()

--- a/core/engine/src/builtins/intl/segmenter/iterator.rs
+++ b/core/engine/src/builtins/intl/segmenter/iterator.rs
@@ -121,8 +121,8 @@ impl SegmentIterator {
         // 6. Let endIndex be ! FindBoundary(segmenter, string, startIndex, after).
         let Some((end, is_word_like)) = iter.string.get(start..).and_then(|string| {
             // 3. Let segmenter be iterator.[[IteratingSegmenter]].
-            let segmenter = iter.segmenter.borrow();
-            let segmenter = segmenter
+            let segmenter = iter
+                .segmenter
                 .downcast_ref::<Segmenter>()
                 .expect("segment iterator object should contain a segmenter");
             let mut segments = segmenter.native.segment(string);

--- a/core/engine/src/builtins/intl/segmenter/mod.rs
+++ b/core/engine/src/builtins/intl/segmenter/mod.rs
@@ -258,8 +258,9 @@ impl Segmenter {
     fn resolved_options(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let segmenter be the this value.
         // 2. Perform ? RequireInternalSlot(segmenter, [[InitializedSegmenter]]).
-        let segmenter = this
-            .as_object()
+        let object = this.as_object();
+        let segmenter = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message(

--- a/core/engine/src/builtins/intl/segmenter/mod.rs
+++ b/core/engine/src/builtins/intl/segmenter/mod.rs
@@ -298,14 +298,10 @@ impl Segmenter {
     fn segment(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let segmenter be the this value.
         // 2. Perform ? RequireInternalSlot(segmenter, [[InitializedSegmenter]]).
-        let segmenter = this
-            .as_object()
-            .filter(|o| o.borrow().is::<Self>())
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message(
-                    "`resolved_options` can only be called on an `Intl.Segmenter` object",
-                )
-            })?;
+        let segmenter = this.as_object().filter(|o| o.is::<Self>()).ok_or_else(|| {
+            JsNativeError::typ()
+                .with_message("`resolved_options` can only be called on an `Intl.Segmenter` object")
+        })?;
 
         // 3. Let string be ? ToString(string).
         let string = args.get_or_undefined(0).to_string(context)?;

--- a/core/engine/src/builtins/intl/segmenter/segments.rs
+++ b/core/engine/src/builtins/intl/segmenter/segments.rs
@@ -62,8 +62,8 @@ impl Segments {
             })?;
 
         // 3. Let segmenter be segments.[[SegmentsSegmenter]].
-        let segmenter = segments.segmenter.borrow();
-        let segmenter = segmenter
+        let segmenter = segments
+            .segmenter
             .downcast_ref::<Segmenter>()
             .expect("segments object should contain a segmenter");
 
@@ -107,14 +107,13 @@ impl Segments {
     fn iterator(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let segments be the this value.
         // 2. Perform ? RequireInternalSlot(segments, [[SegmentsSegmenter]]).
-        let segments = this.as_object().map(JsObject::borrow).ok_or_else(|| {
-            JsNativeError::typ()
-                .with_message("`containing` can only be called on a `Segments` object")
-        })?;
-        let segments = segments.downcast_ref::<Self>().ok_or_else(|| {
-            JsNativeError::typ()
-                .with_message("`containing` can only be called on a `Segments` object")
-        })?;
+        let segments = this
+            .as_object()
+            .and_then(|o| o.downcast_ref::<Self>())
+            .ok_or_else(|| {
+                JsNativeError::typ()
+                    .with_message("`containing` can only be called on a `Segments` object")
+            })?;
 
         // 3. Let segmenter be segments.[[SegmentsSegmenter]].
         // 4. Let string be segments.[[SegmentsString]].

--- a/core/engine/src/builtins/intl/segmenter/segments.rs
+++ b/core/engine/src/builtins/intl/segmenter/segments.rs
@@ -53,8 +53,9 @@ impl Segments {
     fn containing(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let segments be the this value.
         // 2. Perform ? RequireInternalSlot(segments, [[SegmentsSegmenter]]).
-        let segments = this
-            .as_object()
+        let object = this.as_object();
+        let segments = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ()
@@ -107,8 +108,9 @@ impl Segments {
     fn iterator(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let segments be the this value.
         // 2. Perform ? RequireInternalSlot(segments, [[SegmentsSegmenter]]).
-        let segments = this
-            .as_object()
+        let object = this.as_object();
+        let segments = object
+            .as_ref()
             .and_then(|o| o.downcast_ref::<Self>())
             .ok_or_else(|| {
                 JsNativeError::typ()

--- a/core/engine/src/builtins/iterable/async_from_sync_iterator.rs
+++ b/core/engine/src/builtins/iterable/async_from_sync_iterator.rs
@@ -94,8 +94,9 @@ impl AsyncFromSyncIterator {
         // 1. Let O be the this value.
         // 2. Assert: O is an Object that has a [[SyncIteratorRecord]] internal slot.
         // 4. Let syncIteratorRecord be O.[[SyncIteratorRecord]].
-        let mut sync_iterator_record = this
-            .as_object()
+        let object = this.as_object();
+        let mut sync_iterator_record = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .expect("async from sync iterator prototype must be object")
             .sync_iterator_record
@@ -137,8 +138,9 @@ impl AsyncFromSyncIterator {
         // 1. Let O be the this value.
         // 2. Assert: O is an Object that has a [[SyncIteratorRecord]] internal slot.
         // 4. Let syncIteratorRecord be O.[[SyncIteratorRecord]].
-        let sync_iterator_record = this
-            .as_object()
+        let object = this.as_object();
+        let sync_iterator_record = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .expect("async from sync iterator prototype must be object")
             .sync_iterator_record
@@ -214,8 +216,9 @@ impl AsyncFromSyncIterator {
         // 1. Let O be the this value.
         // 2. Assert: O is an Object that has a [[SyncIteratorRecord]] internal slot.
         // 4. Let syncIteratorRecord be O.[[SyncIteratorRecord]].
-        let sync_iterator_record = this
-            .as_object()
+        let object = this.as_object();
+        let sync_iterator_record = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .expect("async from sync iterator prototype must be object")
             .sync_iterator_record

--- a/core/engine/src/builtins/json/mod.rs
+++ b/core/engine/src/builtins/json/mod.rs
@@ -164,7 +164,7 @@ impl Json {
                 .expect("CreateDataPropertyOrThrow should never throw here");
 
             // d. Return ? InternalizeJSONProperty(root, rootName, reviver).
-            Self::internalize_json_property(&root, js_string!(), obj, context)
+            Self::internalize_json_property(&root, js_string!(), &obj, context)
         } else {
             // 12. Else,
             // a. Return unfiltered.
@@ -200,7 +200,7 @@ impl Json {
                     // 1. Let prop be ! ToString(𝔽(I)).
                     // 2. Let newElement be ? InternalizeJSONProperty(val, prop, reviver).
                     let new_element =
-                        Self::internalize_json_property(obj, i.into(), reviver, context)?;
+                        Self::internalize_json_property(&obj, i.into(), reviver, context)?;
 
                     // 3. If newElement is undefined, then
                     if new_element.is_undefined() {
@@ -229,7 +229,7 @@ impl Json {
 
                     // 1. Let newElement be ? InternalizeJSONProperty(val, P, reviver).
                     let new_element =
-                        Self::internalize_json_property(obj, p.clone(), reviver, context)?;
+                        Self::internalize_json_property(&obj, p.clone(), reviver, context)?;
 
                     // 2. If newElement is undefined, then
                     if new_element.is_undefined() {
@@ -442,7 +442,7 @@ impl Json {
         }
 
         // 4. If Type(value) is Object, then
-        if let Some(obj) = value.as_object().cloned() {
+        if let Some(obj) = value.as_object() {
             // a. If value has a [[NumberData]] internal slot, then
             if obj.is::<f64>() {
                 // i. Set value to ? ToNumber(value).
@@ -508,17 +508,17 @@ impl Json {
         }
 
         // 11. If Type(value) is Object and IsCallable(value) is false, then
-        if let Some(obj) = value.as_object()
-            && !obj.is_callable()
-        {
-            // a. Let isArray be ? IsArray(value).
-            // b. If isArray is true, return ? SerializeJSONArray(state, value).
-            // c. Return ? SerializeJSONObject(state, value).
-            return if obj.is_array_abstract()? {
-                Ok(Some(Self::serialize_json_array(state, obj, context)?))
-            } else {
-                Ok(Some(Self::serialize_json_object(state, obj, context)?))
-            };
+        if let Some(obj) = value.as_object() {
+            if !obj.is_callable() {
+                // a. Let isArray be ? IsArray(value).
+                // b. If isArray is true, return ? SerializeJSONArray(state, value).
+                // c. Return ? SerializeJSONObject(state, value).
+                return if obj.is_array_abstract()? {
+                    Ok(Some(Self::serialize_json_array(state, &obj, context)?))
+                } else {
+                    Ok(Some(Self::serialize_json_object(state, &obj, context)?))
+                };
+            }
         }
 
         // 12. Return undefined.

--- a/core/engine/src/builtins/map/map_iterator.rs
+++ b/core/engine/src/builtins/map/map_iterator.rs
@@ -105,8 +105,9 @@ impl MapIterator {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-%mapiteratorprototype%.next
     pub(crate) fn next(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let mut map_iterator = this
-            .as_object()
+        let object = this.as_object();
+        let mut map_iterator = object
+            .as_ref()
             .and_then(JsObject::downcast_mut::<Self>)
             .ok_or_else(|| JsNativeError::typ().with_message("`this` is not a MapIterator"))?;
 

--- a/core/engine/src/builtins/map/mod.rs
+++ b/core/engine/src/builtins/map/mod.rs
@@ -235,8 +235,10 @@ impl Map {
         // 1. Let M be the this value.
         // 2. Perform ? RequireInternalSlot(M, [[MapData]]).
         // 3. Let entries be the List that is M.[[MapData]].
-        let mut map = this
-            .as_downcast_mut::<OrderedMap<JsValue>>()
+        let map = this.as_object();
+        let mut map = map
+            .as_ref()
+            .and_then(|obj| obj.downcast_mut::<OrderedMap<JsValue>>())
             .ok_or_else(|| JsNativeError::typ().with_message("`this` is not a Map"))?;
 
         let key = match key.variant() {
@@ -276,8 +278,10 @@ impl Map {
         // 1. Let M be the this value.
         // 2. Perform ? RequireInternalSlot(M, [[MapData]]).
         // 3. Let entries be the List that is M.[[MapData]].
-        let map = this
-            .as_downcast_ref::<OrderedMap<JsValue>>()
+        let map = this.as_object();
+        let map = map
+            .as_ref()
+            .and_then(|obj| obj.downcast_mut::<OrderedMap<JsValue>>())
             .ok_or_else(|| JsNativeError::typ().with_message("`this` is not a Map"))?;
 
         // 4. Let count be 0.
@@ -302,8 +306,10 @@ impl Map {
         // 1. Let M be the this value.
         // 2. Perform ? RequireInternalSlot(M, [[MapData]]).
         // 3. Let entries be the List that is M.[[MapData]].
-        let mut map = this
-            .as_downcast_mut::<OrderedMap<JsValue>>()
+        let map = this.as_object();
+        let mut map = map
+            .as_ref()
+            .and_then(|obj| obj.downcast_mut::<OrderedMap<JsValue>>())
             .ok_or_else(|| JsNativeError::typ().with_message("`this` is not a Map"))?;
 
         let key = args.get_or_undefined(0);
@@ -334,8 +340,10 @@ impl Map {
         // 1. Let M be the this value.
         // 2. Perform ? RequireInternalSlot(M, [[MapData]]).
         // 3. Let entries be the List that is M.[[MapData]].
-        let map = this
-            .as_downcast_ref::<OrderedMap<JsValue>>()
+        let map = this.as_object();
+        let map = map
+            .as_ref()
+            .and_then(|obj| obj.downcast_mut::<OrderedMap<JsValue>>())
             .ok_or_else(|| JsNativeError::typ().with_message("`this` is not a Map"))?;
 
         let key = args.get_or_undefined(0);
@@ -364,8 +372,10 @@ impl Map {
         // 1. Let M be the this value.
         // 2. Perform ? RequireInternalSlot(M, [[MapData]]).
         // 3. Let entries be the List that is M.[[MapData]].
-        let mut map = this
-            .as_downcast_mut::<OrderedMap<JsValue>>()
+        let map = this.as_object();
+        let mut map = map
+            .as_ref()
+            .and_then(|obj| obj.downcast_mut::<OrderedMap<JsValue>>())
             .ok_or_else(|| JsNativeError::typ().with_message("`this` is not a Map"))?;
 
         // 4. For each Record { [[Key]], [[Value]] } p of entries, do
@@ -391,8 +401,10 @@ impl Map {
         // 1. Let M be the this value.
         // 2. Perform ? RequireInternalSlot(M, [[MapData]]).
         // 3. Let entries be the List that is M.[[MapData]].
-        let map = this
-            .as_downcast_ref::<OrderedMap<JsValue>>()
+        let map = this.as_object();
+        let map = map
+            .as_ref()
+            .and_then(|obj| obj.downcast_mut::<OrderedMap<JsValue>>())
             .ok_or_else(|| JsNativeError::typ().with_message("`this` is not a Map"))?;
 
         let key = args.get_or_undefined(0);
@@ -424,9 +436,8 @@ impl Map {
     ) -> JsResult<JsValue> {
         // 1. Let M be the this value.
         // 2. Perform ? RequireInternalSlot(M, [[MapData]]).
-        let map = this
-            .as_object()
-            .cloned()
+        let map = this.as_object();
+        let map = map
             .and_then(|obj| obj.downcast::<OrderedMap<JsValue>>().ok())
             .ok_or_else(|| JsNativeError::typ().with_message("`this` is not a Map"))?;
 
@@ -489,9 +500,8 @@ impl Map {
     {
         // See `Self::for_each` for comments on the algo.
 
-        let map = this
-            .as_object()
-            .cloned()
+        let map = this.as_object();
+        let map = map
             .and_then(|obj| obj.downcast::<OrderedMap<JsValue>>().ok())
             .ok_or_else(|| JsNativeError::typ().with_message("`this` is not a Map"))?;
 

--- a/core/engine/src/builtins/map/ordered_map.rs
+++ b/core/engine/src/builtins/map/ordered_map.rs
@@ -220,10 +220,9 @@ impl Finalize for MapLock {
     fn finalize(&self) {
         // Avoids panicking inside `Finalize`, with the downside of slightly increasing
         // memory usage if the map could not be borrowed.
-        let Ok(mut map) = self.0.try_borrow_mut() else {
-            return;
-        };
-        map.downcast_mut::<OrderedMap<JsValue>>()
+        // TODO: try_downcast_mut
+        self.0
+            .downcast_mut::<OrderedMap<JsValue>>()
             .expect("MapLock does not point to a map")
             .unlock();
     }

--- a/core/engine/src/builtins/object/for_in_iterator.rs
+++ b/core/engine/src/builtins/object/for_in_iterator.rs
@@ -95,9 +95,10 @@ impl ForInIterator {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-%foriniteratorprototype%.next
     pub(crate) fn next(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let mut iterator = this
-            .as_object()
-            .and_then(JsObject::downcast_mut::<Self>)
+        let object = this.as_object();
+        let mut iterator = object
+            .as_ref()
+            .and_then(|o| o.downcast_mut::<Self>())
             .ok_or_else(|| JsNativeError::typ().with_message("`this` is not a ForInIterator"))?;
         let mut object = iterator.object.to_object(context)?;
         loop {

--- a/core/engine/src/builtins/object/mod.rs
+++ b/core/engine/src/builtins/object/mod.rs
@@ -458,7 +458,7 @@ impl OrdinaryObject {
             JsVariant::Object(_) | JsVariant::Null => {
                 JsObject::from_proto_and_data_with_shared_shape(
                     context.root_shape(),
-                    prototype.as_object().cloned(),
+                    prototype.as_object(),
                     OrdinaryObject,
                 )
             }
@@ -790,7 +790,7 @@ impl OrdinaryObject {
         let arg = args.get_or_undefined(0);
         if let Some(obj) = arg.as_object() {
             let props = args.get_or_undefined(1);
-            object_define_properties(obj, props, context)?;
+            object_define_properties(&obj, props, context)?;
             Ok(arg.clone())
         } else {
             Err(JsNativeError::typ()

--- a/core/engine/src/builtins/object/mod.rs
+++ b/core/engine/src/builtins/object/mod.rs
@@ -16,6 +16,7 @@
 use super::{
     Array, BuiltInBuilder, BuiltInConstructor, Date, IntrinsicObject, RegExp, error::Error,
 };
+use crate::builtins::function::arguments::{MappedArguments, UnmappedArguments};
 use crate::value::JsVariant;
 use crate::{
     Context, JsArgs, JsData, JsResult, JsString,
@@ -838,37 +839,33 @@ impl OrdinaryObject {
         //  5. If isArray is true, let builtinTag be "Array".
         let builtin_tag = if o.is_array_abstract()? {
             js_str!("Array")
+        } else if o.is::<UnmappedArguments>() || o.is::<MappedArguments>() {
+            // 6. Else if O has a [[ParameterMap]] internal slot, let builtinTag be "Arguments".
+            js_str!("Arguments")
+        } else if o.is_callable() {
+            // 7. Else if O has a [[Call]] internal method, let builtinTag be "Function".
+            js_str!("Function")
+        } else if o.is::<Error>() {
+            // 8. Else if O has an [[ErrorData]] internal slot, let builtinTag be "Error".
+            js_str!("Error")
+        } else if o.is::<bool>() {
+            // 9. Else if O has a [[BooleanData]] internal slot, let builtinTag be "Boolean".
+            js_str!("Boolean")
+        } else if o.is::<f64>() {
+            // 10. Else if O has a [[NumberData]] internal slot, let builtinTag be "Number".
+            js_str!("Number")
+        } else if o.is::<JsString>() {
+            // 11. Else if O has a [[StringData]] internal slot, let builtinTag be "String".
+            js_str!("String")
+        } else if o.is::<Date>() {
+            // 12. Else if O has a [[DateValue]] internal slot, let builtinTag be "Date".
+            js_str!("Date")
+        } else if o.is::<RegExp>() {
+            // 13. Else if O has a [[RegExpMatcher]] internal slot, let builtinTag be "RegExp".
+            js_str!("RegExp")
         } else {
-            let o_borrow = o.borrow();
-
-            if o_borrow.is_arguments() {
-                // 6. Else if O has a [[ParameterMap]] internal slot, let builtinTag be "Arguments".
-                js_str!("Arguments")
-            } else if o.is_callable() {
-                // 7. Else if O has a [[Call]] internal method, let builtinTag be "Function".
-                js_str!("Function")
-            } else if o.is::<Error>() {
-                // 8. Else if O has an [[ErrorData]] internal slot, let builtinTag be "Error".
-                js_str!("Error")
-            } else if o.is::<bool>() {
-                // 9. Else if O has a [[BooleanData]] internal slot, let builtinTag be "Boolean".
-                js_str!("Boolean")
-            } else if o.is::<f64>() {
-                // 10. Else if O has a [[NumberData]] internal slot, let builtinTag be "Number".
-                js_str!("Number")
-            } else if o.is::<JsString>() {
-                // 11. Else if O has a [[StringData]] internal slot, let builtinTag be "String".
-                js_str!("String")
-            } else if o.is::<Date>() {
-                // 12. Else if O has a [[DateValue]] internal slot, let builtinTag be "Date".
-                js_str!("Date")
-            } else if o.is::<RegExp>() {
-                // 13. Else if O has a [[RegExpMatcher]] internal slot, let builtinTag be "RegExp".
-                js_str!("RegExp")
-            } else {
-                // 14. Else, let builtinTag be "Object".
-                js_str!("Object")
-            }
+            // 14. Else, let builtinTag be "Object".
+            js_str!("Object")
         };
 
         // 15. Let tag be ? Get(O, @@toStringTag).

--- a/core/engine/src/builtins/proxy/mod.rs
+++ b/core/engine/src/builtins/proxy/mod.rs
@@ -1232,7 +1232,7 @@ fn proxy_exotic_construct(
     )?;
 
     // 10. If Type(newObj) is not Object, throw a TypeError exception.
-    let new_obj = new_obj.as_object().cloned().ok_or_else(|| {
+    let new_obj = new_obj.as_object().ok_or_else(|| {
         JsNativeError::typ().with_message("Proxy trap constructor returned non-object value")
     })?;
 

--- a/core/engine/src/builtins/reflect/mod.rs
+++ b/core/engine/src/builtins/reflect/mod.rs
@@ -123,7 +123,7 @@ impl Reflect {
             })?
         } else {
             // 2. If newTarget is not present, set newTarget to target.
-            target
+            target.clone()
         };
 
         // 4. Let args be ? CreateListFromArrayLike(argumentsList).
@@ -133,7 +133,7 @@ impl Reflect {
 
         // 5. Return ? Construct(target, args, newTarget).
         target
-            .construct(&args, Some(new_target), context)
+            .construct(&args, Some(&new_target), context)
             .map(JsValue::from)
     }
 
@@ -157,7 +157,7 @@ impl Reflect {
         let key = args.get_or_undefined(1).to_property_key(context)?;
         let prop_desc: JsValue = args
             .get(2)
-            .and_then(|v| v.as_object().cloned())
+            .and_then(JsValue::as_object)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("property descriptor must be an object")
             })?

--- a/core/engine/src/builtins/regexp/mod.rs
+++ b/core/engine/src/builtins/regexp/mod.rs
@@ -15,9 +15,7 @@ use crate::{
     context::intrinsics::{Intrinsics, StandardConstructor, StandardConstructors},
     error::JsNativeError,
     js_string,
-    object::{
-        CONSTRUCTOR, JsObject, JsObjectTyped, internal_methods::get_prototype_from_constructor,
-    },
+    object::{CONSTRUCTOR, JsObject, internal_methods::get_prototype_from_constructor},
     property::Attribute,
     realm::Realm,
     string::{CodePoint, JsStrVariant, StaticJsStrings},
@@ -901,7 +899,7 @@ impl RegExp {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-regexpbuiltinexec
     pub(crate) fn abstract_builtin_exec(
-        this: JsObjectTyped<RegExp>,
+        this: JsObject<RegExp>,
         input: &JsString,
         context: &mut Context,
     ) -> JsResult<Option<JsObject>> {

--- a/core/engine/src/builtins/regexp/mod.rs
+++ b/core/engine/src/builtins/regexp/mod.rs
@@ -15,7 +15,9 @@ use crate::{
     context::intrinsics::{Intrinsics, StandardConstructor, StandardConstructors},
     error::JsNativeError,
     js_string,
-    object::{CONSTRUCTOR, JsObject, internal_methods::get_prototype_from_constructor},
+    object::{
+        CONSTRUCTOR, JsObject, JsObjectTyped, internal_methods::get_prototype_from_constructor,
+    },
     property::Attribute,
     realm::Realm,
     string::{CodePoint, JsStrVariant, StaticJsStrings},
@@ -899,7 +901,7 @@ impl RegExp {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-regexpbuiltinexec
     pub(crate) fn abstract_builtin_exec(
-        this: JsObject<RegExp>,
+        this: JsObjectTyped<RegExp>,
         input: &JsString,
         context: &mut Context,
     ) -> JsResult<Option<JsObject>> {

--- a/core/engine/src/builtins/regexp/regexp_string_iterator.rs
+++ b/core/engine/src/builtins/regexp/regexp_string_iterator.rs
@@ -120,8 +120,9 @@ impl RegExpStringIterator {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-%regexpstringiteratorprototype%.next
     pub(crate) fn next(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let mut iterator = this
-            .as_object()
+        let object = this.as_object();
+        let mut iterator = object
+            .as_ref()
             .and_then(JsObject::downcast_mut::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("`this` is not a RegExpStringIterator")

--- a/core/engine/src/builtins/regexp/tests.rs
+++ b/core/engine/src/builtins/regexp/tests.rs
@@ -1,6 +1,6 @@
 use crate::{
-    JsNativeErrorKind, JsObject, JsValue, TestAction, js_string,
-    native_function::NativeFunctionObject, run_test_actions,
+    JsNativeErrorKind, JsValue, TestAction, js_string, native_function::NativeFunctionObject,
+    run_test_actions,
 };
 use boa_macros::js_str;
 use indoc::indoc;
@@ -45,7 +45,7 @@ fn species() {
         TestAction::assert_eq("descriptor.set", JsValue::undefined()),
         TestAction::assert_with_op("accessor", |v, _| {
             v.as_object()
-                .map_or(false, JsObject::is::<NativeFunctionObject>)
+                .is_some_and(|o| o.is::<NativeFunctionObject>())
         }),
         TestAction::assert("!descriptor.enumerable"),
         TestAction::assert("descriptor.configurable"),

--- a/core/engine/src/builtins/set/mod.rs
+++ b/core/engine/src/builtins/set/mod.rs
@@ -1151,11 +1151,7 @@ impl Set {
     /// Helper function to get the size of the `Set` object.
     pub(crate) fn get_size(set: &JsValue) -> JsResult<usize> {
         set.as_object()
-            .and_then(|obj| {
-                obj.borrow()
-                    .downcast_ref::<OrderedSet>()
-                    .map(OrderedSet::len)
-            })
+            .and_then(|obj| obj.downcast_ref::<OrderedSet>().map(|o| o.len()))
             .ok_or_else(|| {
                 JsNativeError::typ()
                     .with_message("'this' is not a Set")
@@ -1166,11 +1162,7 @@ impl Set {
     /// Helper function to get the full size of the `Set` object.
     pub(crate) fn get_size_full(set: &JsValue) -> JsResult<usize> {
         set.as_object()
-            .and_then(|obj| {
-                obj.borrow()
-                    .downcast_ref::<OrderedSet>()
-                    .map(OrderedSet::full_len)
-            })
+            .and_then(|obj| obj.downcast_ref::<OrderedSet>().map(|o| o.full_len()))
             .ok_or_else(|| {
                 JsNativeError::typ()
                     .with_message("'this' is not a Set")

--- a/core/engine/src/builtins/set/mod.rs
+++ b/core/engine/src/builtins/set/mod.rs
@@ -331,8 +331,9 @@ impl Set {
     pub(crate) fn add(this: &JsValue, args: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Let S be the this value.
         // 2. Perform ? RequireInternalSlot(S, [[SetData]]).
-        let Some(mut set) = this
-            .as_object()
+        let object = this.as_object();
+        let Some(mut set) = object
+            .as_ref()
             .and_then(JsObject::downcast_mut::<OrderedSet>)
         else {
             return Err(JsNativeError::typ()
@@ -364,8 +365,9 @@ impl Set {
     /// [spec]: https://tc39.es/ecma262/#sec-set.prototype.clear
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/clear
     pub(crate) fn clear(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let Some(mut set) = this
-            .as_object()
+        let object = this.as_object();
+        let Some(mut set) = object
+            .as_ref()
             .and_then(JsObject::downcast_mut::<OrderedSet>)
         else {
             return Err(JsNativeError::typ()
@@ -392,8 +394,9 @@ impl Set {
     pub(crate) fn delete(this: &JsValue, args: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Let S be the this value.
         // 2. Perform ? RequireInternalSlot(S, [[SetData]]).
-        let Some(mut set) = this
-            .as_object()
+        let object = this.as_object();
+        let Some(mut set) = object
+            .as_ref()
             .and_then(JsObject::downcast_mut::<OrderedSet>)
         else {
             return Err(JsNativeError::typ()
@@ -490,8 +493,9 @@ impl Set {
         // 7. Repeat, while index < numEntries,
         while index < Self::get_size_full(this)? {
             // a. Let e be entries[index].
-            let Some(set) = this
-                .as_object()
+            let object = this.as_object();
+            let Some(set) = object
+                .as_ref()
                 .and_then(JsObject::downcast_ref::<OrderedSet>)
             else {
                 return Err(JsNativeError::typ()
@@ -537,8 +541,9 @@ impl Set {
     pub(crate) fn has(this: &JsValue, args: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Let M be the this value.
         // 2. Perform ? RequireInternalSlot(S, [[SetData]]).
-        let Some(set) = this
-            .as_object()
+        let object = this.as_object();
+        let Some(set) = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<OrderedSet>)
         else {
             return Err(JsNativeError::typ()
@@ -607,7 +612,7 @@ impl Set {
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[SetData]]).
-        if this.as_downcast_ref::<OrderedSet>().is_none() {
+        if !this.as_object().is_some_and(|o| o.is::<OrderedSet>()) {
             return Err(JsNativeError::typ()
                 .with_message("Method Set.prototype.isDisjointFrom called on incompatible receiver")
                 .into());
@@ -626,9 +631,10 @@ impl Set {
             // c. Repeat, while index < thisSize,
             while index < this_size {
                 // i. Let e be O.[[SetData]][index].
-                let e = this
-                    .as_downcast_ref::<OrderedSet>()
-                    .and_then(|o| o.get_index(index).cloned());
+                let e = this.as_object().and_then(|o| {
+                    o.downcast_ref::<OrderedSet>()
+                        .and_then(|o| o.get_index(index).cloned())
+                });
 
                 // ii. Set index to index + 1.
                 index += 1;
@@ -691,7 +697,7 @@ impl Set {
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[SetData]]).
-        if this.as_downcast_ref::<OrderedSet>().is_none() {
+        if !this.as_object().is_some_and(|o| o.is::<OrderedSet>()) {
             return Err(JsNativeError::typ()
                 .with_message("Method Set.prototype.isSubsetOf called on incompatible receiver")
                 .into());
@@ -713,8 +719,9 @@ impl Set {
         // 7. Repeat, while index < thisSize,
         while index < this_size {
             // a. Let e be O.[[SetData]][index].
-            let Some(set) = this
-                .as_object()
+            let object = this.as_object();
+            let Some(set) = object
+                .as_ref()
                 .and_then(JsObject::downcast_ref::<OrderedSet>)
             else {
                 return Err(JsNativeError::typ()
@@ -766,7 +773,7 @@ impl Set {
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[SetData]]).
-        if this.as_downcast_ref::<OrderedSet>().is_none() {
+        if !this.as_object().is_some_and(|o| o.is::<OrderedSet>()) {
             return Err(JsNativeError::typ()
                 .with_message("Method Set.prototype.isSupersetOf called on incompatible receiver")
                 .into());
@@ -820,7 +827,7 @@ impl Set {
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[SetData]]).
-        if this.as_downcast_ref::<OrderedSet>().is_none() {
+        if !this.as_object().is_some_and(|o| o.is::<OrderedSet>()) {
             return Err(JsNativeError::typ()
                 .with_message(
                     "Method Set.prototype.symmetricDifference called on incompatible receiver",
@@ -836,8 +843,10 @@ impl Set {
         let mut keys_iter = other.get_iterator_from_method(&other_rec.keys, context)?;
 
         // 5. Let resultSetData be a copy of O.[[SetData]].
-        let Some(result_set) = this
-            .as_downcast_ref::<OrderedSet>()
+        let object = this.as_object();
+        let Some(result_set) = object
+            .as_ref()
+            .and_then(JsObject::downcast_ref::<OrderedSet>)
             .map(|set| {
                 JsObject::from_proto_and_data_with_shared_shape(
                     context.root_shape(),
@@ -906,7 +915,7 @@ impl Set {
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[SetData]]).
-        if this.as_downcast_ref::<OrderedSet>().is_none() {
+        if !this.as_object().is_some_and(|o| o.is::<OrderedSet>()) {
             return Err(JsNativeError::typ()
                 .with_message("Method Set.prototype.union called on incompatible receiver")
                 .into());
@@ -920,8 +929,10 @@ impl Set {
         let mut keys_iter = other.get_iterator_from_method(&other_rec.keys, context)?;
 
         // 5. Let resultSetData be a copy of O.[[SetData]].
-        let Some(result_set) = this
-            .as_downcast_ref::<OrderedSet>()
+        let object = this.as_object();
+        let Some(result_set) = object
+            .as_ref()
+            .and_then(JsObject::downcast_ref::<OrderedSet>)
             .map(|set| {
                 JsObject::from_proto_and_data_with_shared_shape(
                     context.root_shape(),
@@ -973,7 +984,7 @@ impl Set {
     ) -> JsResult<JsValue> {
         // 1. Let S be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[SetData]]).
-        if this.as_downcast_ref::<OrderedSet>().is_none() {
+        if !this.as_object().is_some_and(|o| o.is::<OrderedSet>()) {
             return Err(JsNativeError::typ()
                 .with_message("Method Set.prototype.intersection called on incompatible receiver")
                 .into());
@@ -995,9 +1006,10 @@ impl Set {
             // c. Repeat, while index < thisSize,
             while index < this_size {
                 // i. Let e be O.[[SetData]][index].
-                let e = this
-                    .as_downcast_ref::<OrderedSet>()
-                    .and_then(|o| o.get_index(index).cloned());
+                let e = this.as_object().and_then(|o| {
+                    o.downcast_ref::<OrderedSet>()
+                        .and_then(|o| o.get_index(index).cloned())
+                });
                 // ii. Set index to index + 1.
                 index += 1;
 
@@ -1068,7 +1080,7 @@ impl Set {
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[SetData]]).
-        if this.as_downcast_ref::<OrderedSet>().is_none() {
+        if !this.as_object().is_some_and(|o| o.is::<OrderedSet>()) {
             return Err(JsNativeError::typ()
                 .with_message("Method Set.prototype.difference called on incompatible receiver")
                 .into());
@@ -1079,10 +1091,10 @@ impl Set {
         let other_rec = get_set_record(other, context)?;
 
         // 4. Let resultSetData be a copy of O.[[SetData]].
-        let Some(mut result_set_data) = this
-            .as_downcast_ref::<OrderedSet>()
-            .map(|set| OrderedSet::clone(&set))
-        else {
+        let Some(mut result_set_data) = this.as_object().and_then(|o| {
+            o.downcast_ref::<OrderedSet>()
+                .map(|set| OrderedSet::clone(&set))
+        }) else {
             return Err(JsNativeError::typ()
                 .with_message("Method Set.prototype.difference called on incompatible receiver")
                 .into());

--- a/core/engine/src/builtins/set/ordered_set.rs
+++ b/core/engine/src/builtins/set/ordered_set.rs
@@ -177,12 +177,10 @@ impl Finalize for SetLock {
     fn finalize(&self) {
         // Avoids panicking inside `Finalize`, with the downside of slightly increasing
         // memory usage if the set could not be borrowed.
-        let Ok(mut set) = self.0.try_borrow_mut() else {
-            return;
-        };
-        let set = set
+        // TODO: try_downcast_mut
+        self.0
             .downcast_mut::<OrderedSet>()
-            .expect("SetLock does not point to a set");
-        set.unlock();
+            .expect("SetLock does not point to a set")
+            .unlock();
     }
 }

--- a/core/engine/src/builtins/set/set_iterator.rs
+++ b/core/engine/src/builtins/set/set_iterator.rs
@@ -102,8 +102,9 @@ impl SetIterator {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-%setiteratorprototype%.next
     pub(crate) fn next(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let mut set_iterator = this
-            .as_object()
+        let object = this.as_object();
+        let mut set_iterator = object
+            .as_ref()
             .and_then(JsObject::downcast_mut::<Self>)
             .ok_or_else(|| JsNativeError::typ().with_message("`this` is not an SetIterator"))?;
 
@@ -124,8 +125,9 @@ impl SetIterator {
                 ));
             }
 
-            let entries = m
-                .as_object()
+            let object = m.as_object();
+            let entries = object
+                .as_ref()
                 .and_then(|o| o.downcast_ref::<OrderedSet>())
                 .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Set"))?;
 

--- a/core/engine/src/builtins/set/set_iterator.rs
+++ b/core/engine/src/builtins/set/set_iterator.rs
@@ -124,10 +124,9 @@ impl SetIterator {
                 ));
             }
 
-            let entries = m.as_object().map(JsObject::borrow);
-            let entries = entries
-                .as_ref()
-                .and_then(|obj| obj.downcast_ref::<OrderedSet>())
+            let entries = m
+                .as_object()
+                .and_then(|o| o.downcast_ref::<OrderedSet>())
                 .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Set"))?;
 
             let num_entries = entries.full_len();

--- a/core/engine/src/builtins/string/mod.rs
+++ b/core/engine/src/builtins/string/mod.rs
@@ -1441,17 +1441,16 @@ impl String {
 
                 let collator = collator
                     .as_object()
-                    .map(JsObject::borrow)
-                    .expect("constructor must return a JsObject");
-                let collator = collator
-                    .downcast_ref::<Collator>()
-                    .expect("constructor must return a `Collator` object")
-                    .collator();
+                    .and_then(|o| o.downcast_ref::<Collator>())
+                    .expect("constructor must return a `Collator` object");
 
                 let s = s.iter().collect::<Vec<_>>();
                 let that_value = that_value.iter().collect::<Vec<_>>();
 
-                collator.as_borrowed().compare_utf16(&s, &that_value) as i8
+                collator
+                    .collator()
+                    .as_borrowed()
+                    .compare_utf16(&s, &that_value) as i8
             }
 
             // Default to common comparison if the user doesn't have `Intl` enabled.

--- a/core/engine/src/builtins/string/mod.rs
+++ b/core/engine/src/builtins/string/mod.rs
@@ -1009,8 +1009,8 @@ impl String {
         context: &mut Context,
     ) -> JsResult<JsValue> {
         // Helper enum.
-        enum CallableOrString<'a> {
-            FunctionalReplace(&'a JsObject),
+        enum CallableOrString {
+            FunctionalReplace(JsObject),
             ReplaceValue(JsString),
         }
 
@@ -1209,7 +1209,7 @@ impl String {
             // c. Else,
             let replacement = match replace {
                 // b. If functionalReplace is true, then
-                Ok(replace_fn) => {
+                Ok(ref replace_fn) => {
                     // i. Let replacement be ? ToString(? Call(replaceValue, undefined, « searchString, 𝔽(p), string »)).
                     replace_fn
                         .call(
@@ -1439,8 +1439,9 @@ impl String {
                     context,
                 )?;
 
-                let collator = collator
-                    .as_object()
+                let object = collator.as_object();
+                let collator = object
+                    .as_ref()
                     .and_then(|o| o.downcast_ref::<Collator>())
                     .expect("constructor must return a `Collator` object");
 

--- a/core/engine/src/builtins/string/string_iterator.rs
+++ b/core/engine/src/builtins/string/string_iterator.rs
@@ -73,8 +73,9 @@ impl StringIterator {
 
     /// `StringIterator.prototype.next( )`
     pub(crate) fn next(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let mut string_iterator = this
-            .as_object()
+        let object = this.as_object();
+        let mut string_iterator = object
+            .as_ref()
             .and_then(JsObject::downcast_mut::<Self>)
             .ok_or_else(|| JsNativeError::typ().with_message("`this` is not an ArrayIterator"))?;
 

--- a/core/engine/src/builtins/temporal/calendar/mod.rs
+++ b/core/engine/src/builtins/temporal/calendar/mod.rs
@@ -42,19 +42,19 @@ pub(crate) fn to_temporal_calendar_slot_value(calendar_like: &JsValue) -> JsResu
     if calendar_like.is_undefined() {
         return Ok(Calendar::default());
     // 2. If Type(temporalCalendarLike) is Object, then
-    // a. If temporalCalendarLike has an [[InitializedTemporalDate]], [[InitializedTemporalDateTime]], [[InitializedTemporalMonthDay]], [[InitializedTemporalYearMonth]], or [[InitializedTemporalZonedDateTime]] internal slot, then
-    // i. Return temporalCalendarLike.[[Calendar]].
-    } else if let Some(calendar_like) = calendar_like.as_object()
-        && let Some(calendar) = extract_from_temporal_type(
-            calendar_like,
+    } else if let Some(calendar_like) = calendar_like.as_object() {
+        // a. If temporalCalendarLike has an [[InitializedTemporalDate]], [[InitializedTemporalDateTime]], [[InitializedTemporalMonthDay]], [[InitializedTemporalYearMonth]], or [[InitializedTemporalZonedDateTime]] internal slot, then
+        // i. Return temporalCalendarLike.[[Calendar]].
+        if let Some(calendar) = extract_from_temporal_type(
+            &calendar_like,
             |d| Ok(Some(d.inner.calendar().clone())),
             |dt| Ok(Some(dt.inner.calendar().clone())),
             |ym| Ok(Some(ym.inner.calendar().clone())),
             |md| Ok(Some(md.inner.calendar().clone())),
             |zdt| Ok(Some(zdt.inner.calendar().clone())),
-        )?
-    {
-        return Ok(calendar);
+        )? {
+            return Ok(calendar);
+        }
     }
 
     // 3. If temporalCalendarLike is not a String, throw a TypeError exception.

--- a/core/engine/src/builtins/temporal/duration/mod.rs
+++ b/core/engine/src/builtins/temporal/duration/mod.rs
@@ -323,8 +323,9 @@ impl BuiltInConstructor for Duration {
 impl Duration {
     // Internal utility function for getting `Duration` field values.
     fn get_internal_field(this: &JsValue, field: &DateTimeValues) -> JsResult<JsValue> {
-        let duration = this
-            .as_object()
+        let object = this.as_object();
+        let duration = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("this value must be a Duration object.")
@@ -403,8 +404,9 @@ impl Duration {
     fn get_sign(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Let duration be the this value.
         // 2. Perform ? RequireInternalSlot(duration, [[InitializedTemporalDuration]]).
-        let duration = this
-            .as_object()
+        let object = this.as_object();
+        let duration = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("this value must be a Duration object.")
@@ -420,8 +422,9 @@ impl Duration {
     fn get_blank(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Let duration be the this value.
         // 2. Perform ? RequireInternalSlot(duration, [[InitializedTemporalDuration]]).
-        let duration = this
-            .as_object()
+        let object = this.as_object();
+        let duration = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("this value must be a Duration object.")
@@ -442,7 +445,8 @@ impl Duration {
     fn from(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         let item = args.get_or_undefined(0);
         // 1. If item is an Object and item has an [[InitializedTemporalDuration]] internal slot, then
-        if let Some(duration) = item.as_object().and_then(JsObject::downcast_ref::<Self>) {
+        let object = item.as_object();
+        if let Some(duration) = object.as_ref().and_then(JsObject::downcast_ref::<Self>) {
             // a. Return ! CreateTemporalDuration(item.[[Years]], item.[[Months]], item.[[Weeks]],
             // item.[[Days]], item.[[Hours]], item.[[Minutes]], item.[[Seconds]], item.[[Milliseconds]],
             // item.[[Microseconds]], item.[[Nanoseconds]]).
@@ -479,8 +483,9 @@ impl Duration {
     ) -> JsResult<JsValue> {
         // 1. Let duration be the this value.
         // 2. Perform ? RequireInternalSlot(duration, [[InitializedTemporalDuration]]).
-        let duration = this
-            .as_object()
+        let object = this.as_object();
+        let duration = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("this value must be a Duration object.")
@@ -593,8 +598,9 @@ impl Duration {
         // 1. Let duration be the this value.
         // 2. Perform ? RequireInternalSlot(duration, [[InitializedTemporalDuration]]).
         // 3. Return ! CreateNegatedTemporalDuration(duration).
-        let duration = this
-            .as_object()
+        let object = this.as_object();
+        let duration = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("this value must be a Duration object.")
@@ -610,8 +616,9 @@ impl Duration {
         // 3. Return ! CreateTemporalDuration(abs(duration.[[Years]]), abs(duration.[[Months]]),
         //    abs(duration.[[Weeks]]), abs(duration.[[Days]]), abs(duration.[[Hours]]), abs(duration.[[Minutes]]),
         //    abs(duration.[[Seconds]]), abs(duration.[[Milliseconds]]), abs(duration.[[Microseconds]]), abs(duration.[[Nanoseconds]])).
-        let duration = this
-            .as_object()
+        let object = this.as_object();
+        let duration = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("this value must be a Duration object.")
@@ -628,8 +635,9 @@ impl Duration {
     ) -> JsResult<JsValue> {
         // 1.Let duration be the this value.
         // 2. Perform ? RequireInternalSlot(duration, [[InitializedTemporalDuration]]).
-        let duration = this
-            .as_object()
+        let object = this.as_object();
+        let duration = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("this value must be a Duration object.")
@@ -649,8 +657,9 @@ impl Duration {
     ) -> JsResult<JsValue> {
         // 1.Let duration be the this value.
         // 2. Perform ? RequireInternalSlot(duration, [[InitializedTemporalDuration]]).
-        let duration = this
-            .as_object()
+        let object = this.as_object();
+        let duration = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("this value must be a Duration object.")
@@ -670,8 +679,9 @@ impl Duration {
     ) -> JsResult<JsValue> {
         // 1. Let duration be the this value.
         // 2. Perform ? RequireInternalSlot(duration, [[InitializedTemporalDuration]]).
-        let duration = this
-            .as_object()
+        let object = this.as_object();
+        let duration = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("this value must be a Duration object.")
@@ -761,8 +771,9 @@ impl Duration {
     ) -> JsResult<JsValue> {
         // 1. Let duration be the this value.
         // 2. Perform ? RequireInternalSlot(duration, [[InitializedTemporalDuration]]).
-        let duration = this
-            .as_object()
+        let object = this.as_object();
+        let duration = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("this value must be a Duration object.")
@@ -826,8 +837,9 @@ impl Duration {
         args: &[JsValue],
         context: &mut Context,
     ) -> JsResult<JsValue> {
-        let duration = this
-            .as_object()
+        let object = this.as_object();
+        let duration = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("this value must be a Duration object.")
@@ -850,8 +862,9 @@ impl Duration {
 
     /// 7.3.23 `Temporal.Duration.prototype.toJSON ( )`
     pub(crate) fn to_json(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let duration = this
-            .as_object()
+        let object = this.as_object();
+        let duration = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("this value must be a Duration object.")
@@ -872,8 +885,9 @@ impl Duration {
         _: &mut Context,
     ) -> JsResult<JsValue> {
         // TODO: Update for ECMA-402 compliance
-        let duration = this
-            .as_object()
+        let object = this.as_object();
+        let duration = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("this value must be a Duration object.")
@@ -903,7 +917,8 @@ pub(crate) fn to_temporal_duration(
 ) -> JsResult<InnerDuration> {
     // 1a. If Type(item) is Object
     // 1b. and item has an [[InitializedTemporalDuration]] internal slot, then
-    if let Some(duration) = item.as_downcast_ref::<Duration>() {
+    let object = item.as_object();
+    if let Some(duration) = object.as_ref().and_then(JsObject::downcast_ref::<Duration>) {
         return Ok(duration.inner);
     }
 

--- a/core/engine/src/builtins/temporal/instant/mod.rs
+++ b/core/engine/src/builtins/temporal/instant/mod.rs
@@ -212,8 +212,9 @@ impl Instant {
     ) -> JsResult<JsValue> {
         // 1. Let instant be the this value.
         // 2. Perform ? RequireInternalSlot(instant, [[InitializedTemporalInstant]]).
-        let instant = this
-            .as_object()
+        let object = this.as_object();
+        let instant = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be an instant object.")
@@ -232,8 +233,9 @@ impl Instant {
     ) -> JsResult<JsValue> {
         // 1. Let instant be the this value.
         // 2. Perform ? RequireInternalSlot(instant, [[InitializedTemporalInstant]]).
-        let instant = this
-            .as_object()
+        let object = this.as_object();
+        let instant = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be an instant object.")
@@ -251,8 +253,9 @@ impl Instant {
     ) -> JsResult<JsValue> {
         // 1. Let instant be the this value.
         // 2. Perform ? RequireInternalSlot(instant, [[InitializedTemporalInstant]]).
-        let instant = this
-            .as_object()
+        let object = this.as_object();
+        let instant = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be an instant object.")
@@ -273,8 +276,9 @@ impl Instant {
     ) -> JsResult<JsValue> {
         // 1. Let instant be the this value.
         // 2. Perform ? RequireInternalSlot(instant, [[InitializedTemporalInstant]]).
-        let instant = this
-            .as_object()
+        let object = this.as_object();
+        let instant = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be an instant object.")
@@ -295,8 +299,9 @@ impl Instant {
     ) -> JsResult<JsValue> {
         // 1. Let instant be the this value.
         // 2. Perform ? RequireInternalSlot(instant, [[InitializedTemporalInstant]]).
-        let instant = this
-            .as_object()
+        let object = this.as_object();
+        let instant = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be an instant object.")
@@ -320,8 +325,9 @@ impl Instant {
     ) -> JsResult<JsValue> {
         // 1. Let instant be the this value.
         // 2. Perform ? RequireInternalSlot(instant, [[InitializedTemporalInstant]]).
-        let instant = this
-            .as_object()
+        let object = this.as_object();
+        let instant = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be an instant object.")
@@ -343,8 +349,9 @@ impl Instant {
     ) -> JsResult<JsValue> {
         // 1. Let instant be the this value.
         // 2. Perform ? RequireInternalSlot(instant, [[InitializedTemporalInstant]]).
-        let instant = this
-            .as_object()
+        let object = this.as_object();
+        let instant = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be an instant object.")
@@ -434,8 +441,9 @@ impl Instant {
         // 2. Perform ? RequireInternalSlot(instant, [[InitializedTemporalInstant]]).
         // 4. If instant.[[Nanoseconds]] ≠ other.[[Nanoseconds]], return false.
         // 5. Return true.
-        let instant = this
-            .as_object()
+        let object = this.as_object();
+        let instant = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be an instant object.")
@@ -453,8 +461,9 @@ impl Instant {
 
     /// 8.3.11 `Temporal.Instant.prototype.toString ( [ options ] )`
     fn to_string(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let instant = this
-            .as_object()
+        let object = this.as_object();
+        let instant = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ()
@@ -491,8 +500,9 @@ impl Instant {
     /// 8.3.12 `Temporal.Instant.prototype.toLocaleString ( [ locales [ , options ] ] )`
     fn to_locale_string(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // TODO: Update for ECMA-402 compliance
-        let instant = this
-            .as_object()
+        let object = this.as_object();
+        let instant = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ()
@@ -509,8 +519,9 @@ impl Instant {
 
     /// 8.3.13 `Temporal.Instant.prototype.toJSON ( )`
     fn to_json(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let instant = this
-            .as_object()
+        let object = this.as_object();
+        let instant = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ()
@@ -540,8 +551,9 @@ impl Instant {
     ) -> JsResult<JsValue> {
         // 1. Let instant be the this value.
         // 2. Perform ? RequireInternalSlot(instant, [[InitializedTemporalInstant]]).
-        let instant = this
-            .as_object()
+        let object = this.as_object();
+        let instant = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ()

--- a/core/engine/src/builtins/temporal/mod.rs
+++ b/core/engine/src/builtins/temporal/mod.rs
@@ -176,7 +176,7 @@ pub(crate) fn get_relative_to_option(
         }
         // d. Let calendar be ? GetTemporalCalendarIdentifierWithISODefault(value).
         // e. Let fields be ? PrepareCalendarFields(calendar, value, « year, month, month-code, day », « hour, minute, second, millisecond, microsecond, nanosecond, offset, time-zone », «»).
-        let partial = to_partial_zoneddatetime(object, context)?;
+        let partial = to_partial_zoneddatetime(&object, context)?;
         // f. Let result be ? InterpretTemporalDateTimeFields(calendar, fields, constrain).
         // g. Let timeZone be fields.[[TimeZone]].
         // h. Let offsetString be fields.[[OffsetString]].
@@ -214,10 +214,10 @@ pub(crate) fn get_relative_to_option(
 }
 
 // 13.26 IsPartialTemporalObject ( object )
-pub(crate) fn is_partial_temporal_object<'value>(
-    value: &'value JsValue,
+pub(crate) fn is_partial_temporal_object(
+    value: &JsValue,
     context: &mut Context,
-) -> JsResult<Option<&'value JsObject>> {
+) -> JsResult<Option<JsObject>> {
     // 1. If value is not an Object, return false.
     let Some(obj) = value.as_object() else {
         return Ok(None);

--- a/core/engine/src/builtins/temporal/plain_date/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_date/mod.rs
@@ -305,8 +305,9 @@ impl BuiltInConstructor for PlainDate {
 impl PlainDate {
     /// 3.3.3 get `Temporal.PlainDate.prototype.calendarId`
     fn get_calendar_id(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let date = this
-            .as_object()
+        let object = this.as_object();
+        let date = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a PlainDate object.")
@@ -553,7 +554,8 @@ impl PlainDate {
         let item = args.get_or_undefined(0);
         let options = args.get(1);
 
-        if let Some(date) = item.as_object().and_then(JsObject::downcast_ref::<Self>) {
+        let object = item.as_object();
+        if let Some(date) = object.as_ref().and_then(JsObject::downcast_ref::<Self>) {
             let options = get_options_object(options.unwrap_or(&JsValue::undefined()))?;
             let _ = get_option::<ArithmeticOverflow>(&options, js_string!("overflow"), context)?;
             return create_temporal_date(date.inner.clone(), None, context).map(Into::into);
@@ -582,8 +584,9 @@ impl PlainDate {
     ) -> JsResult<JsValue> {
         // 1. Let temporalDate be the this value.
         // 2. Perform ? RequireInternalSlot(temporalDate, [[InitializedTemporalDate]]).
-        let date = this
-            .as_object()
+        let object = this.as_object();
+        let date = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a PlainDate object.")
@@ -600,8 +603,9 @@ impl PlainDate {
     ) -> JsResult<JsValue> {
         // 1. Let temporalDate be the this value.
         // 2. Perform ? RequireInternalSlot(temporalDate, [[InitializedTemporalDate]]).
-        let date = this
-            .as_object()
+        let object = this.as_object();
+        let date = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a PlainDate object.")
@@ -614,8 +618,9 @@ impl PlainDate {
     fn add(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let temporalDate be the this value.
         // 2. Perform ? RequireInternalSlot(temporalDate, [[InitializedTemporalDate]]).
-        let date = this
-            .as_object()
+        let object = this.as_object();
+        let date = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a PlainDate object.")
@@ -638,8 +643,9 @@ impl PlainDate {
     fn subtract(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let temporalDate be the this value.
         // 2. Perform ? RequireInternalSlot(temporalDate, [[InitializedTemporalDate]]).
-        let date = this
-            .as_object()
+        let object = this.as_object();
+        let date = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a PlainDate object.")
@@ -663,8 +669,9 @@ impl PlainDate {
     fn with(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let temporalDate be the this value.
         // 2. Perform ? RequireInternalSlot(temporalDate, [[InitializedTemporalDate]]).
-        let date = this
-            .as_object()
+        let object = this.as_object();
+        let date = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a PlainDate object.")
@@ -687,7 +694,7 @@ impl PlainDate {
         // 8. Let resolvedOptions be ? GetOptionsObject(options).
         // 9. Let overflow be ? GetTemporalOverflowOption(resolvedOptions).
         let partial =
-            to_partial_date_record(partial_object, date.inner.calendar().clone(), context)?;
+            to_partial_date_record(&partial_object, date.inner.calendar().clone(), context)?;
 
         let options = get_options_object(args.get_or_undefined(1))?;
         let overflow = get_option::<ArithmeticOverflow>(&options, js_string!("overflow"), context)?;
@@ -699,8 +706,9 @@ impl PlainDate {
 
     /// 3.3.26 Temporal.PlainDate.prototype.withCalendar ( calendarLike )
     fn with_calendar(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let date = this
-            .as_object()
+        let object = this.as_object();
+        let date = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a PlainDate object.")
@@ -714,8 +722,9 @@ impl PlainDate {
     fn until(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let temporalDate be the this value.
         // 2. Perform ? RequireInternalSlot(temporalDate, [[InitializedTemporalDate]]).
-        let date = this
-            .as_object()
+        let object = this.as_object();
+        let date = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a PlainDate object.")
@@ -733,8 +742,9 @@ impl PlainDate {
     fn since(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let temporalDate be the this value.
         // 2. Perform ? RequireInternalSlot(temporalDate, [[InitializedTemporalDate]]).
-        let date = this
-            .as_object()
+        let object = this.as_object();
+        let date = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a PlainDate object.")
@@ -751,8 +761,9 @@ impl PlainDate {
 
     /// 3.3.27 `Temporal.PlainDate.prototype.equals ( other )`
     fn equals(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let date = this
-            .as_object()
+        let object = this.as_object();
+        let date = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a PlainDate object.")
@@ -771,8 +782,9 @@ impl PlainDate {
     ) -> JsResult<JsValue> {
         // 1. Let temporalDate be the this value.
         // 2. Perform ? RequireInternalSlot(temporalDate, [[InitializedTemporalDate]]).
-        let date = this
-            .as_object()
+        let object = this.as_object();
+        let date = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a PlainDate object.")
@@ -796,8 +808,9 @@ impl PlainDate {
     ) -> JsResult<JsValue> {
         // 1. Let temporalDate be the this value.
         // 2. Perform ? RequireInternalSlot(temporalDate, [[InitializedTemporalDate]]).
-        let date = this
-            .as_object()
+        let object = this.as_object();
+        let date = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a PlainDate object.")
@@ -845,8 +858,9 @@ impl PlainDate {
 
     /// 3.3.30 `Temporal.PlainDate.prototype.toString ( [ options ] )`
     fn to_string(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let date = this
-            .as_object()
+        let object = this.as_object();
+        let date = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a PlainDate object.")
@@ -862,8 +876,9 @@ impl PlainDate {
     /// 3.3.31 `Temporal.PlainDate.prototype.toLocaleString ( [ locales [ , options ] ] )`
     fn to_locale_string(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // TODO: Update for ECMA-402 compliance
-        let date = this
-            .as_object()
+        let object = this.as_object();
+        let date = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a PlainDate object.")
@@ -874,8 +889,9 @@ impl PlainDate {
 
     /// 3.3.32 `Temporal.PlainDate.prototype.toJSON ( )`
     fn to_json(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let date = this
-            .as_object()
+        let object = this.as_object();
+        let date = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a PlainDate object.")
@@ -980,9 +996,9 @@ pub(crate) fn to_temporal_date(
             return Ok(date);
         }
         // d. Let calendar be ? GetTemporalCalendarIdentifierWithISODefault(item).
-        let calendar = get_temporal_calendar_slot_value_with_default(object, context)?;
+        let calendar = get_temporal_calendar_slot_value_with_default(&object, context)?;
         // e. Let fields be ? PrepareCalendarFields(calendar, item, « year, month, month-code, day », «», «»).
-        let partial = to_partial_date_record(object, calendar, context)?;
+        let partial = to_partial_date_record(&object, calendar, context)?;
         // f. Let resolvedOptions be ? GetOptionsObject(options).
         let resolved_options = get_options_object(&options)?;
         // g. Let overflow be ? GetTemporalOverflowOption(resolvedOptions).

--- a/core/engine/src/builtins/temporal/plain_date_time/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_date_time/mod.rs
@@ -431,8 +431,9 @@ impl BuiltInConstructor for PlainDateTime {
 impl PlainDateTime {
     /// 5.3.3 get `Temporal.PlainDatedt.prototype.calendarId`
     fn get_calendar_id(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let dt = this
-            .as_object()
+        let object = this.as_object();
+        let dt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
@@ -443,8 +444,9 @@ impl PlainDateTime {
 
     /// 5.3.4 get `Temporal.PlainDatedt.prototype.year`
     fn get_era(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let dt = this
-            .as_object()
+        let object = this.as_object();
+        let dt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
@@ -459,8 +461,9 @@ impl PlainDateTime {
 
     /// 5.3.5 get `Temporal.PlainDatedt.prototype.eraYear`
     fn get_era_year(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let dt = this
-            .as_object()
+        let object = this.as_object();
+        let dt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
@@ -471,8 +474,9 @@ impl PlainDateTime {
 
     /// 5.3.6 get `Temporal.PlainDatedt.prototype.year`
     fn get_year(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let dt = this
-            .as_object()
+        let object = this.as_object();
+        let dt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
@@ -483,8 +487,9 @@ impl PlainDateTime {
 
     /// 5.3.7 get `Temporal.PlainDatedt.prototype.month`
     fn get_month(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let dt = this
-            .as_object()
+        let object = this.as_object();
+        let dt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
@@ -495,8 +500,9 @@ impl PlainDateTime {
 
     /// 5.3.8 get Temporal.PlainDatedt.prototype.monthCode
     fn get_month_code(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let dt = this
-            .as_object()
+        let object = this.as_object();
+        let dt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
@@ -507,8 +513,9 @@ impl PlainDateTime {
 
     /// 5.3.9 get `Temporal.PlainDatedt.prototype.day`
     fn get_day(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let dt = this
-            .as_object()
+        let object = this.as_object();
+        let dt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
@@ -521,8 +528,9 @@ impl PlainDateTime {
     fn get_hour(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Let dateTime be the this value.
         // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
-        let dt = this
-            .as_object()
+        let object = this.as_object();
+        let dt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
@@ -536,8 +544,9 @@ impl PlainDateTime {
     fn get_minute(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Let dateTime be the this value.
         // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
-        let dt = this
-            .as_object()
+        let object = this.as_object();
+        let dt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
@@ -551,8 +560,9 @@ impl PlainDateTime {
     fn get_second(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Let dateTime be the this value.
         // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
-        let dt = this
-            .as_object()
+        let object = this.as_object();
+        let dt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
@@ -566,8 +576,9 @@ impl PlainDateTime {
     fn get_millisecond(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Let dateTime be the this value.
         // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
-        let dt = this
-            .as_object()
+        let object = this.as_object();
+        let dt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
@@ -581,8 +592,9 @@ impl PlainDateTime {
     fn get_microsecond(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Let dateTime be the this value.
         // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
-        let dt = this
-            .as_object()
+        let object = this.as_object();
+        let dt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
@@ -596,8 +608,9 @@ impl PlainDateTime {
     fn get_nanosecond(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Let dateTime be the this value.
         // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
-        let dt = this
-            .as_object()
+        let object = this.as_object();
+        let dt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
@@ -609,8 +622,9 @@ impl PlainDateTime {
 
     /// 5.3.16 get `Temporal.PlainDatedt.prototype.dayOfWeek`
     fn get_day_of_week(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let dt = this
-            .as_object()
+        let object = this.as_object();
+        let dt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
@@ -621,8 +635,9 @@ impl PlainDateTime {
 
     /// 5.3.17 get `Temporal.PlainDatedt.prototype.dayOfYear`
     fn get_day_of_year(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let dt = this
-            .as_object()
+        let object = this.as_object();
+        let dt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
@@ -633,8 +648,9 @@ impl PlainDateTime {
 
     /// 5.3.18 get `Temporal.PlainDatedt.prototype.weekOfYear`
     fn get_week_of_year(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let dt = this
-            .as_object()
+        let object = this.as_object();
+        let dt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
@@ -645,8 +661,9 @@ impl PlainDateTime {
 
     /// 5.3.19 get `Temporal.PlainDatedt.prototype.yearOfWeek`
     fn get_year_of_week(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let dt = this
-            .as_object()
+        let object = this.as_object();
+        let dt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
@@ -657,8 +674,9 @@ impl PlainDateTime {
 
     /// 5.3.20 get `Temporal.PlainDatedt.prototype.daysInWeek`
     fn get_days_in_week(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let dt = this
-            .as_object()
+        let object = this.as_object();
+        let dt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
@@ -669,8 +687,9 @@ impl PlainDateTime {
 
     /// 5.3.21 get `Temporal.PlainDatedt.prototype.daysInMonth`
     fn get_days_in_month(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let dt = this
-            .as_object()
+        let object = this.as_object();
+        let dt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
@@ -681,8 +700,9 @@ impl PlainDateTime {
 
     /// 5.3.22 get `Temporal.PlainDatedt.prototype.daysInYear`
     fn get_days_in_year(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let dt = this
-            .as_object()
+        let object = this.as_object();
+        let dt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
@@ -693,8 +713,9 @@ impl PlainDateTime {
 
     /// 5.3.23 get `Temporal.PlainDatedt.prototype.monthsInYear`
     fn get_months_in_year(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let dt = this
-            .as_object()
+        let object = this.as_object();
+        let dt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
@@ -705,8 +726,9 @@ impl PlainDateTime {
 
     /// 5.3.24 get `Temporal.PlainDatedt.prototype.inLeapYear`
     fn get_in_leap_year(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let dt = this
-            .as_object()
+        let object = this.as_object();
+        let dt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
@@ -725,7 +747,8 @@ impl PlainDateTime {
         // 1. Set options to ? GetOptionsObject(options).
         let options = args.get(1);
         // 2. If item is an Object and item has an [[InitializedTemporalDateTime]] internal slot, then
-        let dt = if let Some(pdt) = item.as_object().and_then(JsObject::downcast_ref::<Self>) {
+        let object = item.as_object();
+        let dt = if let Some(pdt) = object.as_ref().and_then(JsObject::downcast_ref::<Self>) {
             // a. Perform ? GetTemporalOverflowOption(options).
             let options = get_options_object(args.get_or_undefined(1))?;
             let _ = get_option::<ArithmeticOverflow>(&options, js_string!("overflow"), context)?;
@@ -763,8 +786,9 @@ impl PlainDateTime {
 impl PlainDateTime {
     ///  5.3.25 Temporal.PlainDateTime.prototype.with ( temporalDateTimeLike [ , options ] )
     fn with(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let dt = this
-            .as_object()
+        let object = this.as_object();
+        let dt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
@@ -778,8 +802,8 @@ impl PlainDateTime {
                 .into());
         };
 
-        let date = to_partial_date_record(partial_object, dt.inner.calendar().clone(), context)?;
-        let time = to_partial_time_record(partial_object, context)?;
+        let date = to_partial_date_record(&partial_object, dt.inner.calendar().clone(), context)?;
+        let time = to_partial_time_record(&partial_object, context)?;
 
         let partial_dt = PartialDateTime { date, time };
 
@@ -796,8 +820,9 @@ impl PlainDateTime {
         args: &[JsValue],
         context: &mut Context,
     ) -> JsResult<JsValue> {
-        let dt = this
-            .as_object()
+        let object = this.as_object();
+        let dt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
@@ -813,8 +838,9 @@ impl PlainDateTime {
 
     /// 5.3.27 Temporal.PlainDateTime.prototype.withCalendar ( calendarLike )
     fn with_calendar(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let dt = this
-            .as_object()
+        let object = this.as_object();
+        let dt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
@@ -829,8 +855,9 @@ impl PlainDateTime {
     fn add(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let temporalDate be the this value.
         // 2. Perform ? RequireInternalSlot(temporalDate, [[InitializedTemporalDate]]).
-        let dt = this
-            .as_object()
+        let object = this.as_object();
+        let dt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
@@ -852,8 +879,9 @@ impl PlainDateTime {
     fn subtract(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let temporalDate be the this value.
         // 2. Perform ? RequireInternalSlot(temporalDate, [[InitializedTemporalDate]]).
-        let dt = this
-            .as_object()
+        let object = this.as_object();
+        let dt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
@@ -875,8 +903,9 @@ impl PlainDateTime {
 
     /// 5.3.30 Temporal.PlainDateTime.prototype.until ( other [ , options ] )
     fn until(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let dt = this
-            .as_object()
+        let object = this.as_object();
+        let dt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
@@ -892,8 +921,9 @@ impl PlainDateTime {
 
     /// 5.3.31 Temporal.PlainDateTime.prototype.since ( other [ , options ] )
     fn since(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let dt = this
-            .as_object()
+        let object = this.as_object();
+        let dt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
@@ -909,8 +939,9 @@ impl PlainDateTime {
 
     /// 5.3.32 Temporal.PlainDateTime.prototype.round ( roundTo )
     fn round(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let dt = this
-            .as_object()
+        let object = this.as_object();
+        let dt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a PlainTime object.")
@@ -969,8 +1000,9 @@ impl PlainDateTime {
     fn equals(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let dateTime be the this value.
         // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
-        let dt = this
-            .as_object()
+        let object = this.as_object();
+        let dt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
@@ -991,8 +1023,9 @@ impl PlainDateTime {
     }
 
     fn to_string(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let dt = this
-            .as_object()
+        let object = this.as_object();
+        let dt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
@@ -1022,8 +1055,9 @@ impl PlainDateTime {
     /// 5.3.35 `Temporal.PlainDateTime.prototype.toLocaleString ( [ locales [ , options ] ] )`
     fn to_locale_string(this: &JsValue, _args: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // TODO: Update for ECMA-402 compliance
-        let dt = this
-            .as_object()
+        let object = this.as_object();
+        let dt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
@@ -1037,8 +1071,9 @@ impl PlainDateTime {
 
     /// 5.3.36 `Temporal.PlainDateTime.prototype.toJSON ( )`
     fn to_json(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let dt = this
-            .as_object()
+        let object = this.as_object();
+        let dt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
@@ -1064,8 +1099,9 @@ impl PlainDateTime {
     ) -> JsResult<JsValue> {
         // 1. Let dateTime be the this value.
         // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
-        let dt = this
-            .as_object()
+        let object = this.as_object();
+        let dt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
@@ -1091,8 +1127,9 @@ impl PlainDateTime {
     }
 
     fn to_plain_date(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let dt = this
-            .as_object()
+        let object = this.as_object();
+        let dt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
@@ -1103,8 +1140,9 @@ impl PlainDateTime {
     }
 
     fn to_plain_time(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let dt = this
-            .as_object()
+        let object = this.as_object();
+        let dt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
@@ -1215,7 +1253,7 @@ pub(crate) fn to_temporal_datetime(
         // "monthCode", "year" », « "hour", "microsecond", "millisecond", "minute",
         // "nanosecond", "second" », «»)
         // TODO: Move validation to `temporal_rs`.
-        let partial_dt = to_partial_datetime(object, context)?;
+        let partial_dt = to_partial_datetime(&object, context)?;
         let resolved_options = get_options_object(&options.unwrap_or_default())?;
         // g. Let result be ? InterpretTemporalDateTimeFields(calendarRec, fields, resolvedOptions).
         let overflow =

--- a/core/engine/src/builtins/temporal/plain_month_day/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_month_day/mod.rs
@@ -178,8 +178,9 @@ impl PlainMonthDay {
 
 impl PlainMonthDay {
     fn get_internal_field(this: &JsValue, field: &DateTimeValues) -> JsResult<JsValue> {
-        let month_day = this
-            .as_object()
+        let object = this.as_object();
+        let month_day = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("this value must be a PlainMonthDay object.")
@@ -193,8 +194,9 @@ impl PlainMonthDay {
     }
 
     fn get_calendar_id(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let month_day = this
-            .as_object()
+        let object = this.as_object();
+        let month_day = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("this value must be a PlainMonthDay object.")
@@ -217,8 +219,9 @@ impl PlainMonthDay {
     fn with(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let monthDay be the this value.
         // 2. Perform ? RequireInternalSlot(monthDay, [[InitializedTemporalMonthDay]]).
-        let month_day = this
-            .as_object()
+        let object = this.as_object();
+        let month_day = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("this value must be a PlainMonthDay object.")
@@ -233,7 +236,7 @@ impl PlainMonthDay {
         // 4. Let calendar be monthDay.[[Calendar]].
         // 5. Let fields be ISODateToFields(calendar, monthDay.[[ISODate]], month-day).
         // 6. Let partialMonthDay be ? PrepareCalendarFields(calendar, temporalMonthDayLike, « year, month, month-code, day », « », partial).
-        let partial = to_partial_date_record(object, month_day.inner.calendar().clone(), context)?;
+        let partial = to_partial_date_record(&object, month_day.inner.calendar().clone(), context)?;
         // 7. Set fields to CalendarMergeFields(calendar, fields, partialMonthDay).
         // 8. Let resolvedOptions be ? GetOptionsObject(options).
         let resolved_options = get_options_object(args.get_or_undefined(1))?;
@@ -246,8 +249,9 @@ impl PlainMonthDay {
     }
 
     fn equals(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let month_day = this
-            .as_object()
+        let object = this.as_object();
+        let month_day = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("this value must be a PlainMonthDay object.")
@@ -262,8 +266,9 @@ impl PlainMonthDay {
     fn to_string(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let monthDay be the this value.
         // 2. Perform ? RequireInternalSlot(monthDay, [[InitializedTemporalMonthDay]]).
-        let month_day = this
-            .as_object()
+        let object = this.as_object();
+        let month_day = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("this value must be a PlainMonthDay object.")
@@ -288,8 +293,9 @@ impl PlainMonthDay {
         _: &mut Context,
     ) -> JsResult<JsValue> {
         // TODO: Update for ECMA-402 compliance
-        let month_day = this
-            .as_object()
+        let object = this.as_object();
+        let month_day = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("this value must be a PlainMonthDay object.")
@@ -300,8 +306,9 @@ impl PlainMonthDay {
 
     /// 10.3.10 `Temporal.PlainMonthDay.prototype.toJSON ( )`
     pub(crate) fn to_json(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let month_day = this
-            .as_object()
+        let object = this.as_object();
+        let month_day = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("this value must be a PlainMonthDay object.")
@@ -320,8 +327,9 @@ impl PlainMonthDay {
     fn to_plain_date(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let monthDay be the this value.
         // 2. Perform ? RequireInternalSlot(monthDay, [[InitializedTemporalMonthDay]]).
-        let month_day = this
-            .as_object()
+        let object = this.as_object();
+        let month_day = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("this value must be a PlainMonthDay object.")

--- a/core/engine/src/builtins/temporal/plain_time/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_time/mod.rs
@@ -204,8 +204,9 @@ impl PlainTime {
     fn get_hour(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Let temporalTime be the this value.
         // 2. Perform ? RequireInternalSlot(temporalTime, [[InitializedTemporalTime]]).
-        let time = this
-            .as_object()
+        let object = this.as_object();
+        let time = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a PlainTime object.")
@@ -219,8 +220,9 @@ impl PlainTime {
     fn get_minute(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Let temporalTime be the this value.
         // 2. Perform ? RequireInternalSlot(temporalTime, [[InitializedTemporalTime]]).
-        let time = this
-            .as_object()
+        let object = this.as_object();
+        let time = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a PlainTime object.")
@@ -234,8 +236,9 @@ impl PlainTime {
     fn get_second(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Let temporalTime be the this value.
         // 2. Perform ? RequireInternalSlot(temporalTime, [[InitializedTemporalTime]]).
-        let time = this
-            .as_object()
+        let object = this.as_object();
+        let time = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a PlainTime object.")
@@ -249,8 +252,9 @@ impl PlainTime {
     fn get_millisecond(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Let temporalTime be the this value.
         // 2. Perform ? RequireInternalSlot(temporalTime, [[InitializedTemporalTime]]).
-        let time = this
-            .as_object()
+        let object = this.as_object();
+        let time = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a PlainTime object.")
@@ -264,8 +268,9 @@ impl PlainTime {
     fn get_microsecond(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Let temporalTime be the this value.
         // 2. Perform ? RequireInternalSlot(temporalTime, [[InitializedTemporalTime]]).
-        let time = this
-            .as_object()
+        let object = this.as_object();
+        let time = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a PlainTime object.")
@@ -279,8 +284,9 @@ impl PlainTime {
     fn get_nanosecond(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Let temporalTime be the this value.
         // 2. Perform ? RequireInternalSlot(temporalTime, [[InitializedTemporalTime]]).
-        let time = this
-            .as_object()
+        let object = this.as_object();
+        let time = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a PlainTime object.")
@@ -300,8 +306,9 @@ impl PlainTime {
         // 1. Set options to ? GetOptionsObject(options).
         // 2. Let overflow be ? GetTemporalOverflowOption(options).
         // 3. If item is an Object and item has an [[InitializedTemporalTime]] internal slot, then
-        let time = if let Some(time) = item
-            .as_object()
+        let object = item.as_object();
+        let time = if let Some(time) = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<PlainTime>)
         {
             // a. Return ! CreateTemporalTime(item.[[ISOHour]], item.[[ISOMinute]],
@@ -337,8 +344,9 @@ impl PlainTime {
     fn add(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let temporalTime be the this value.
         // 2. Perform ? RequireInternalSlot(temporalTime, [[InitializedTemporalTime]]).
-        let time = this
-            .as_object()
+        let object = this.as_object();
+        let time = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a PlainTime object.")
@@ -355,8 +363,9 @@ impl PlainTime {
     fn subtract(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let temporalTime be the this value.
         // 2. Perform ? RequireInternalSlot(temporalTime, [[InitializedTemporalTime]]).
-        let time = this
-            .as_object()
+        let object = this.as_object();
+        let time = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a PlainTime object.")
@@ -372,8 +381,9 @@ impl PlainTime {
     fn with(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1.Let temporalTime be the this value.
         // 2. Perform ? RequireInternalSlot(temporalTime, [[InitializedTemporalTime]]).
-        let time = this
-            .as_object()
+        let object = this.as_object();
+        let time = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a PlainTime object.")
@@ -390,7 +400,7 @@ impl PlainTime {
         };
 
         // Steps 5-16 equate to the below
-        let partial = to_partial_time_record(partial_object, context)?;
+        let partial = to_partial_time_record(&partial_object, context)?;
         // 17. Let resolvedOptions be ? GetOptionsObject(options).
         // 18. Let overflow be ? GetTemporalOverflowOption(resolvedOptions).
         let options = get_options_object(args.get_or_undefined(1))?;
@@ -401,8 +411,9 @@ impl PlainTime {
 
     /// 4.3.12 Temporal.PlainTime.prototype.until ( other [ , options ] )
     fn until(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let time = this
-            .as_object()
+        let object = this.as_object();
+        let time = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a PlainTime object.")
@@ -420,8 +431,9 @@ impl PlainTime {
 
     /// 4.3.13 Temporal.PlainTime.prototype.since ( other [ , options ] )
     fn since(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let time = this
-            .as_object()
+        let object = this.as_object();
+        let time = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a PlainTime object.")
@@ -441,8 +453,9 @@ impl PlainTime {
     fn round(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let temporalTime be the this value.
         // 2. Perform ? RequireInternalSlot(temporalTime, [[InitializedTemporalTime]]).
-        let time = this
-            .as_object()
+        let object = this.as_object();
+        let time = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a PlainTime object.")
@@ -511,8 +524,9 @@ impl PlainTime {
     fn equals(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let temporalTime be the this value.
         // 2. Perform ? RequireInternalSlot(temporalTime, [[InitializedTemporalTime]]).
-        let time = this
-            .as_object()
+        let object = this.as_object();
+        let time = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a PlainTime object.")
@@ -532,8 +546,9 @@ impl PlainTime {
 
     /// 4.3.16 `Temporal.PlainTime.prototype.toString ( [ options ] )`
     fn to_string(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let time = this
-            .as_object()
+        let object = this.as_object();
+        let time = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a PlainTime object.")
@@ -560,8 +575,9 @@ impl PlainTime {
     /// 4.3.17 `Temporal.PlainTime.prototype.toLocaleString ( [ locales [ , options ] ] )`
     fn to_locale_string(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // TODO: Update for ECMA-402 compliance
-        let time = this
-            .as_object()
+        let object = this.as_object();
+        let time = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a PlainTime object.")
@@ -575,8 +591,9 @@ impl PlainTime {
 
     /// 4.3.18 `Temporal.PlainTime.prototype.toJSON ( )`
     fn to_json(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let time = this
-            .as_object()
+        let object = this.as_object();
+        let time = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a PlainTime object.")
@@ -684,7 +701,7 @@ pub(crate) fn to_temporal_time(
             // e. Set result to ? RegulateTime(result.[[Hour]], result.[[Minute]],
             // result.[[Second]], result.[[Millisecond]], result.[[Microsecond]],
             // result.[[Nanosecond]], overflow).
-            let partial = to_partial_time_record(object, context)?;
+            let partial = to_partial_time_record(&object, context)?;
 
             let options = get_options_object(options)?;
             let overflow =

--- a/core/engine/src/builtins/temporal/plain_year_month/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_year_month/mod.rs
@@ -245,8 +245,9 @@ impl PlainYearMonth {
 
 impl PlainYearMonth {
     fn get_internal_field(this: &JsValue, field: &DateTimeValues) -> JsResult<JsValue> {
-        let year_month = this
-            .as_object()
+        let object = this.as_object();
+        let year_month = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("this value must be a PlainYearMonth object.")
@@ -290,8 +291,9 @@ impl PlainYearMonth {
     }
 
     fn get_days_in_year(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let year_month = this
-            .as_object()
+        let object = this.as_object();
+        let year_month = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("this value must be a PlainYearMonth object.")
@@ -301,8 +303,9 @@ impl PlainYearMonth {
     }
 
     fn get_days_in_month(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let year_month = this
-            .as_object()
+        let object = this.as_object();
+        let year_month = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("this value must be a PlainYearMonth object.")
@@ -312,8 +315,9 @@ impl PlainYearMonth {
     }
 
     fn get_months_in_year(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let year_month = this
-            .as_object()
+        let object = this.as_object();
+        let year_month = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("this value must be a PlainYearMonth object.")
@@ -323,8 +327,9 @@ impl PlainYearMonth {
     }
 
     fn get_in_leap_year(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let year_month = this
-            .as_object()
+        let object = this.as_object();
+        let year_month = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("this value must be a PlainYearMonth object.")
@@ -340,8 +345,9 @@ impl PlainYearMonth {
     fn with(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let yearMonth be the this value.
         // 2. Perform ? RequireInternalSlot(yearMonth, [[InitializedTemporalYearMonth]]).
-        let year_month = this
-            .as_object()
+        let object = this.as_object();
+        let year_month = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("this value must be a PlainYearMonth object.")
@@ -357,7 +363,7 @@ impl PlainYearMonth {
         // 5. Let fields be ISODateToFields(calendar, yearMonth.[[ISODate]], year-month).
         // TODO: We may need to throw early on an empty partial for Order of operations, but ideally this is enforced by `temporal_rs`
         // 6. Let partialYearMonth be ? PrepareCalendarFields(calendar, temporalYearMonthLike, « year, month, month-code », « », partial).
-        let partial = to_partial_year_month(obj, context)?;
+        let partial = to_partial_year_month(&obj, context)?;
         // 7. Set fields to CalendarMergeFields(calendar, fields, partialYearMonth).
         // 8. Let resolvedOptions be ? GetOptionsObject(options).
         let resolved_options = get_options_object(args.get_or_undefined(1))?;
@@ -387,8 +393,9 @@ impl PlainYearMonth {
 
     /// 9.3.16 `Temporal.PlainYearMonth.prototype.until ( other [ , options ] )`
     fn until(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let year_month = this
-            .as_object()
+        let object = this.as_object();
+        let year_month = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("this value must be a PlainYearMonth object.")
@@ -411,8 +418,9 @@ impl PlainYearMonth {
 
     /// 9.3.17 `Temporal.PlainYearMonth.prototype.since ( other [ , options ] )`
     fn since(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let year_month = this
-            .as_object()
+        let object = this.as_object();
+        let year_month = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("this value must be a PlainYearMonth object.")
@@ -435,8 +443,9 @@ impl PlainYearMonth {
 
     /// 9.3.18 `Temporal.PlainYearMonth.prototype.equals ( other )`
     fn equals(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let year_month = this
-            .as_object()
+        let object = this.as_object();
+        let year_month = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("this value must be a PlainYearMonth object.")
@@ -451,8 +460,9 @@ impl PlainYearMonth {
     fn to_string(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let YearMonth be the this value.
         // 2. Perform ? RequireInternalSlot(yearMonth, [[InitializedTemporalYearMonth]]).
-        let year_month = this
-            .as_object()
+        let object = this.as_object();
+        let year_month = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("this value must be a PlainYearMonth object.")
@@ -477,8 +487,9 @@ impl PlainYearMonth {
         _: &mut Context,
     ) -> JsResult<JsValue> {
         // TODO: Update for ECMA-402 compliance
-        let year_month = this
-            .as_object()
+        let object = this.as_object();
+        let year_month = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("this value must be a PlainYearMonth object.")
@@ -489,8 +500,9 @@ impl PlainYearMonth {
 
     /// 9.3.21 `Temporal.PlainYearMonth.prototype.toJSON ( )`
     pub(crate) fn to_json(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let year_month = this
-            .as_object()
+        let object = this.as_object();
+        let year_month = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("this value must be a PlainYearMonth object.")
@@ -510,8 +522,9 @@ impl PlainYearMonth {
     fn to_plain_date(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let yearMonth be the this value.
         // 2. Perform ? RequireInternalSlot(yearMonth, [[InitializedTemporalYearMonth]]).
-        let year_month = this
-            .as_object()
+        let object = this.as_object();
+        let year_month = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("this value must be a PlainYearMonth object.")
@@ -577,7 +590,7 @@ fn to_temporal_year_month(
         }
         // b. Let calendar be ? GetTemporalCalendarIdentifierWithISODefault(item).
         // c. Let fields be ? PrepareCalendarFields(calendar, item, « year, month, month-code », «», «»).
-        let partial = to_partial_year_month(obj, context)?;
+        let partial = to_partial_year_month(&obj, context)?;
         // d. Let resolvedOptions be ? GetOptionsObject(options).
         let resolved_options = get_options_object(&options)?;
         // e. Let overflow be ? GetTemporalOverflowOption(resolvedOptions).
@@ -678,8 +691,9 @@ fn add_or_subtract_duration(
     let overflow = get_option(options, js_string!("overflow"), context)?
         .unwrap_or(ArithmeticOverflow::Constrain);
 
-    let year_month = this
-        .as_object()
+    let object = this.as_object();
+    let year_month = object
+        .as_ref()
         .and_then(JsObject::downcast_ref::<PlainYearMonth>)
         .ok_or_else(|| {
             JsNativeError::typ().with_message("this value must be a PlainYearMonth object.")

--- a/core/engine/src/builtins/temporal/zoneddatetime/mod.rs
+++ b/core/engine/src/builtins/temporal/zoneddatetime/mod.rs
@@ -452,8 +452,9 @@ impl BuiltInConstructor for ZonedDateTime {
 impl ZonedDateTime {
     /// 6.3.3 get `Temporal.ZonedDateTime.prototype.calendarId`
     fn get_calendar_id(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let zdt = this
-            .as_object()
+        let object = this.as_object();
+        let zdt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
@@ -464,8 +465,9 @@ impl ZonedDateTime {
 
     /// 6.3.4 get `Temporal.ZonedDateTime.prototype.timeZoneId`
     fn get_timezone_id(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let zdt = this
-            .as_object()
+        let object = this.as_object();
+        let zdt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
@@ -477,8 +479,9 @@ impl ZonedDateTime {
 
     /// 6.3.5 get `Temporal.ZonedDateTime.prototype.era`
     fn get_era(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let zdt = this
-            .as_object()
+        let object = this.as_object();
+        let zdt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
@@ -492,8 +495,9 @@ impl ZonedDateTime {
 
     /// 6.3.6 get `Temporal.ZonedDateTime.prototype.eraYear`
     fn get_era_year(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let zdt = this
-            .as_object()
+        let object = this.as_object();
+        let zdt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
@@ -507,8 +511,9 @@ impl ZonedDateTime {
 
     /// 6.3.7 get `Temporal.ZonedDateTime.prototype.year`
     fn get_year(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let zdt = this
-            .as_object()
+        let object = this.as_object();
+        let zdt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
@@ -519,8 +524,9 @@ impl ZonedDateTime {
 
     /// 6.3.8 get `Temporal.ZonedDateTime.prototype.month`
     fn get_month(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let zdt = this
-            .as_object()
+        let object = this.as_object();
+        let zdt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
@@ -531,8 +537,9 @@ impl ZonedDateTime {
 
     /// 6.3.9 get `Temporal.ZonedDateTime.prototype.monthCode`
     fn get_month_code(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let zdt = this
-            .as_object()
+        let object = this.as_object();
+        let zdt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
@@ -548,8 +555,9 @@ impl ZonedDateTime {
 
     /// 6.3.10 get `Temporal.ZonedDateTime.prototype.day`
     fn get_day(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let zdt = this
-            .as_object()
+        let object = this.as_object();
+        let zdt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
@@ -560,8 +568,9 @@ impl ZonedDateTime {
 
     /// 6.3.11 get `Temporal.ZonedDateTime.prototype.hour`
     fn get_hour(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let zdt = this
-            .as_object()
+        let object = this.as_object();
+        let zdt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
@@ -572,8 +581,9 @@ impl ZonedDateTime {
 
     /// 6.3.12 get `Temporal.ZonedDateTime.prototype.minute`
     fn get_minute(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let zdt = this
-            .as_object()
+        let object = this.as_object();
+        let zdt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
@@ -587,8 +597,9 @@ impl ZonedDateTime {
 
     /// 6.3.13 get `Temporal.ZonedDateTime.prototype.second`
     fn get_second(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let zdt = this
-            .as_object()
+        let object = this.as_object();
+        let zdt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
@@ -602,8 +613,9 @@ impl ZonedDateTime {
 
     /// 6.3.14 get `Temporal.ZonedDateTime.prototype.millisecond`
     fn get_millisecond(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let zdt = this
-            .as_object()
+        let object = this.as_object();
+        let zdt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
@@ -617,8 +629,9 @@ impl ZonedDateTime {
 
     /// 6.3.15 get `Temporal.ZonedDateTime.prototype.microsecond`
     fn get_microsecond(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let zdt = this
-            .as_object()
+        let object = this.as_object();
+        let zdt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
@@ -632,8 +645,9 @@ impl ZonedDateTime {
 
     /// 6.3.16 get `Temporal.ZonedDateTime.prototype.nanosecond`
     fn get_nanosecond(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let zdt = this
-            .as_object()
+        let object = this.as_object();
+        let zdt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
@@ -647,8 +661,9 @@ impl ZonedDateTime {
 
     /// 6.3.17 get `Temporal.ZonedDateTime.prototype.epochMilliseconds`
     fn get_epoch_millisecond(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let zdt = this
-            .as_object()
+        let object = this.as_object();
+        let zdt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
@@ -659,8 +674,9 @@ impl ZonedDateTime {
 
     /// 6.3.18 get `Temporal.ZonedDateTime.prototype.epochNanosecond`
     fn get_epoch_nanosecond(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let zdt = this
-            .as_object()
+        let object = this.as_object();
+        let zdt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
@@ -671,8 +687,9 @@ impl ZonedDateTime {
 
     /// 6.3.19 get `Temporal.ZonedDateTime.prototype.dayOfWeek`
     fn get_day_of_week(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let zdt = this
-            .as_object()
+        let object = this.as_object();
+        let zdt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
@@ -686,8 +703,9 @@ impl ZonedDateTime {
 
     /// 6.3.20 get `Temporal.ZonedDateTime.prototype.dayOfYear`
     fn get_day_of_year(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let zdt = this
-            .as_object()
+        let object = this.as_object();
+        let zdt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
@@ -701,8 +719,9 @@ impl ZonedDateTime {
 
     /// 6.3.21 get `Temporal.ZonedDateTime.prototype.weekOfYear`
     fn get_week_of_year(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let zdt = this
-            .as_object()
+        let object = this.as_object();
+        let zdt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
@@ -716,8 +735,9 @@ impl ZonedDateTime {
 
     /// 6.3.22 get `Temporal.ZonedDateTime.prototype.yearOfWeek`
     fn get_year_of_week(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let zdt = this
-            .as_object()
+        let object = this.as_object();
+        let zdt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
@@ -731,8 +751,9 @@ impl ZonedDateTime {
 
     /// 6.3.23 get `Temporal.ZonedDateTime.prototype.hoursInDay`
     fn get_hours_in_day(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let zdt = this
-            .as_object()
+        let object = this.as_object();
+        let zdt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
@@ -746,8 +767,9 @@ impl ZonedDateTime {
 
     /// 6.3.24 get `Temporal.ZonedDateTime.prototype.daysInWeek`
     fn get_days_in_week(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let zdt = this
-            .as_object()
+        let object = this.as_object();
+        let zdt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
@@ -765,8 +787,9 @@ impl ZonedDateTime {
         _: &[JsValue],
         context: &mut Context,
     ) -> JsResult<JsValue> {
-        let zdt = this
-            .as_object()
+        let object = this.as_object();
+        let zdt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
@@ -780,8 +803,9 @@ impl ZonedDateTime {
 
     /// 6.3.26 get `Temporal.ZonedDateTime.prototype.daysInYear`
     fn get_days_in_year(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let zdt = this
-            .as_object()
+        let object = this.as_object();
+        let zdt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
@@ -799,8 +823,9 @@ impl ZonedDateTime {
         _: &[JsValue],
         context: &mut Context,
     ) -> JsResult<JsValue> {
-        let zdt = this
-            .as_object()
+        let object = this.as_object();
+        let zdt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
@@ -814,8 +839,9 @@ impl ZonedDateTime {
 
     /// 6.3.28 get `Temporal.ZonedDateTime.prototype.inLeapYear`
     fn get_in_leap_year(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let zdt = this
-            .as_object()
+        let object = this.as_object();
+        let zdt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
@@ -833,8 +859,9 @@ impl ZonedDateTime {
         _: &[JsValue],
         context: &mut Context,
     ) -> JsResult<JsValue> {
-        let zdt = this
-            .as_object()
+        let object = this.as_object();
+        let zdt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
@@ -848,8 +875,9 @@ impl ZonedDateTime {
 
     /// 6.3.30 get Temporal.ZonedDateTime.prototype.offset
     fn get_offset(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let zdt = this
-            .as_object()
+        let object = this.as_object();
+        let zdt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
@@ -883,8 +911,9 @@ impl ZonedDateTime {
     fn with(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let zonedDateTime be the this value.
         // 2. Perform ? RequireInternalSlot(zonedDateTime, [[InitializedTemporalZonedDateTime]]).
-        let zdt = this
-            .as_object()
+        let object = this.as_object();
+        let zdt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
@@ -896,7 +925,7 @@ impl ZonedDateTime {
                 .into());
         };
 
-        let partial = to_partial_zoneddatetime(obj, context)?;
+        let partial = to_partial_zoneddatetime(&obj, context)?;
 
         // 19. Let resolvedOptions be ? GetOptionsObject(options).
         let resolved_options = get_options_object(args.get_or_undefined(1))?;
@@ -926,8 +955,9 @@ impl ZonedDateTime {
         args: &[JsValue],
         context: &mut Context,
     ) -> JsResult<JsValue> {
-        let zdt = this
-            .as_object()
+        let object = this.as_object();
+        let zdt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
@@ -946,8 +976,9 @@ impl ZonedDateTime {
 
     /// 6.3.33 `Temporal.ZonedDateTime.prototype.withTimeZone ( timeZoneLike )`
     fn with_timezone(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let zdt = this
-            .as_object()
+        let object = this.as_object();
+        let zdt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
@@ -961,8 +992,9 @@ impl ZonedDateTime {
 
     /// 6.3.34 `Temporal.ZonedDateTime.prototype.withCalendar ( calendarLike )`
     fn with_calendar(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let zdt = this
-            .as_object()
+        let object = this.as_object();
+        let zdt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
@@ -976,8 +1008,9 @@ impl ZonedDateTime {
 
     /// 6.3.35 `Temporal.ZonedDateTime.prototype.add ( temporalDurationLike [ , options ] )`
     fn add(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let zdt = this
-            .as_object()
+        let object = this.as_object();
+        let zdt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
@@ -996,8 +1029,9 @@ impl ZonedDateTime {
 
     /// 6.3.36 `Temporal.ZonedDateTime.prototype.subtract ( temporalDurationLike [ , options ] )`
     fn subtract(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let zdt = this
-            .as_object()
+        let object = this.as_object();
+        let zdt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
@@ -1015,8 +1049,9 @@ impl ZonedDateTime {
     }
 
     fn since(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let zdt = this
-            .as_object()
+        let object = this.as_object();
+        let zdt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
@@ -1034,8 +1069,9 @@ impl ZonedDateTime {
     }
 
     fn until(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let zdt = this
-            .as_object()
+        let object = this.as_object();
+        let zdt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
@@ -1056,8 +1092,9 @@ impl ZonedDateTime {
     fn round(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let zonedDateTime be the this value.
         // 2. Perform ? RequireInternalSlot(zonedDateTime, [[InitializedTemporalZonedDateTime]]).
-        let zdt = this
-            .as_object()
+        let object = this.as_object();
+        let zdt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
@@ -1122,8 +1159,9 @@ impl ZonedDateTime {
 
     /// 6.3.40 `Temporal.ZonedDateTime.prototype.equals ( other )`
     fn equals(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let zdt = this
-            .as_object()
+        let object = this.as_object();
+        let zdt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
@@ -1134,8 +1172,9 @@ impl ZonedDateTime {
     }
 
     fn to_string(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let zdt = this
-            .as_object()
+        let object = this.as_object();
+        let zdt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
@@ -1176,8 +1215,9 @@ impl ZonedDateTime {
     /// 6.3.42 `Temporal.ZonedDateTime.prototype.toLocaleString ( [ locales [ , options ] ] )`
     fn to_locale_string(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // TODO: Update for ECMA-402 compliance
-        let zdt = this
-            .as_object()
+        let object = this.as_object();
+        let zdt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
@@ -1196,8 +1236,9 @@ impl ZonedDateTime {
 
     /// 6.3.43 `Temporal.ZonedDateTime.prototype.toJSON ( )`
     fn to_json(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let zdt = this
-            .as_object()
+        let object = this.as_object();
+        let zdt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
@@ -1223,8 +1264,9 @@ impl ZonedDateTime {
 
     /// 6.3.45 `Temporal.ZonedDateTime.prototype.startOfDay ( )`
     fn start_of_day(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let zdt = this
-            .as_object()
+        let object = this.as_object();
+        let zdt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
@@ -1245,8 +1287,9 @@ impl ZonedDateTime {
         // 1. Let zonedDateTime be the this value.
         // 2. Perform ? RequireInternalSlot(zonedDateTime, [[InitializedTemporalZonedDateTime]]).
         // 3. Let timeZone be zonedDateTime.[[TimeZone]].
-        let zdt = this
-            .as_object()
+        let object = this.as_object();
+        let zdt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
@@ -1298,8 +1341,9 @@ impl ZonedDateTime {
 
     /// 6.3.47 `Temporal.ZonedDateTime.prototype.toInstant ( )`
     fn to_instant(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let zdt = this
-            .as_object()
+        let object = this.as_object();
+        let zdt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
@@ -1310,8 +1354,9 @@ impl ZonedDateTime {
 
     /// 6.3.48 `Temporal.ZonedDateTime.prototype.toPlainDate ( )`
     fn to_plain_date(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let zdt = this
-            .as_object()
+        let object = this.as_object();
+        let zdt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
@@ -1325,8 +1370,9 @@ impl ZonedDateTime {
 
     /// 6.3.49 `Temporal.ZonedDateTime.prototype.toPlainTime ( )`
     fn to_plain_time(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let zdt = this
-            .as_object()
+        let object = this.as_object();
+        let zdt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
@@ -1344,8 +1390,9 @@ impl ZonedDateTime {
         _: &[JsValue],
         context: &mut Context,
     ) -> JsResult<JsValue> {
-        let zdt = this
-            .as_object()
+        let object = this.as_object();
+        let zdt = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
@@ -1425,7 +1472,7 @@ pub(crate) fn to_temporal_zoneddatetime(
                 // vi. Return ! CreateTemporalZonedDateTime(item.[[EpochNanoseconds]], item.[[TimeZone]], item.[[Calendar]]).
                 return Ok(zdt.inner.clone());
             }
-            let partial = to_partial_zoneddatetime(object, context)?;
+            let partial = to_partial_zoneddatetime(&object, context)?;
             // f. If offsetString is unset, the
             // i. Set offsetBehaviour to wall.
             // g. Let resolvedOptions be ? GetOptionsObject(options).

--- a/core/engine/src/builtins/typed_array/builtin.rs
+++ b/core/engine/src/builtins/typed_array/builtin.rs
@@ -21,7 +21,7 @@ use crate::{
     },
     context::intrinsics::{Intrinsics, StandardConstructor, StandardConstructors},
     js_string,
-    object::internal_methods::get_prototype_from_constructor,
+    object::{JsObjectTyped, internal_methods::get_prototype_from_constructor},
     property::{Attribute, PropertyNameKind},
     realm::Realm,
     string::StaticJsStrings,
@@ -308,7 +308,7 @@ impl BuiltinTypedArray {
         let constructor =
             kind.standard_constructor()(context.intrinsics().constructors()).constructor();
 
-        Self::create(&constructor, &[length.into()], context).map(JsObject::upcast)
+        Self::create(&constructor, &[length.into()], context).map(JsObjectTyped::upcast)
     }
 
     /// `%TypedArray%.of ( ...items )`
@@ -1712,9 +1712,9 @@ impl BuiltinTypedArray {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-settypedarrayfromtypedarray
     fn set_typed_array_from_typed_array(
-        target: &JsObject<TypedArray>,
+        target: &JsObjectTyped<TypedArray>,
         target_offset: &U64OrPositiveInfinity,
-        source: &JsObject<TypedArray>,
+        source: &JsObjectTyped<TypedArray>,
         context: &mut Context,
     ) -> JsResult<()> {
         // 1. Let targetBuffer be target.[[ViewedArrayBuffer]].
@@ -1925,7 +1925,7 @@ impl BuiltinTypedArray {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-settypedarrayfromarraylike
     fn set_typed_array_from_array_like(
-        target: &JsObject<TypedArray>,
+        target: &JsObjectTyped<TypedArray>,
         target_offset: &U64OrPositiveInfinity,
         source: &JsValue,
         context: &mut Context,
@@ -2661,7 +2661,7 @@ impl BuiltinTypedArray {
         kind: TypedArrayKind,
         args: &[JsValue],
         context: &mut Context,
-    ) -> JsResult<JsObject<TypedArray>> {
+    ) -> JsResult<JsObjectTyped<TypedArray>> {
         // 1. Let defaultConstructor be the intrinsic object listed in column one of Table 73 for exemplar.[[TypedArrayName]].
         let default_constructor = kind.standard_constructor();
 
@@ -2690,7 +2690,7 @@ impl BuiltinTypedArray {
         constructor: &JsObject,
         args: &[JsValue],
         context: &mut Context,
-    ) -> JsResult<JsObject<TypedArray>> {
+    ) -> JsResult<JsObjectTyped<TypedArray>> {
         // 1. Let newTypedArray be ? Construct(constructor, argumentList).
         let new_typed_array = constructor.construct(args, Some(constructor), context)?;
 
@@ -2840,7 +2840,7 @@ impl BuiltinTypedArray {
     /// [spec]: https://tc39.es/ecma262/#sec-initializetypedarrayfromtypedarray
     pub(super) fn initialize_from_typed_array<T: TypedArrayMarker>(
         proto: JsObject,
-        src_array: &JsObject<TypedArray>,
+        src_array: &JsObjectTyped<TypedArray>,
         context: &mut Context,
     ) -> JsResult<JsObject> {
         let src_array = src_array.borrow();

--- a/core/engine/src/builtins/typed_array/builtin.rs
+++ b/core/engine/src/builtins/typed_array/builtin.rs
@@ -21,7 +21,7 @@ use crate::{
     },
     context::intrinsics::{Intrinsics, StandardConstructor, StandardConstructors},
     js_string,
-    object::{JsObjectTyped, internal_methods::get_prototype_from_constructor},
+    object::internal_methods::get_prototype_from_constructor,
     property::{Attribute, PropertyNameKind},
     realm::Realm,
     string::StaticJsStrings,
@@ -308,7 +308,7 @@ impl BuiltinTypedArray {
         let constructor =
             kind.standard_constructor()(context.intrinsics().constructors()).constructor();
 
-        Self::create(&constructor, &[length.into()], context).map(JsObjectTyped::upcast)
+        Self::create(&constructor, &[length.into()], context).map(JsObject::upcast)
     }
 
     /// `%TypedArray%.of ( ...items )`
@@ -1712,9 +1712,9 @@ impl BuiltinTypedArray {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-settypedarrayfromtypedarray
     fn set_typed_array_from_typed_array(
-        target: &JsObjectTyped<TypedArray>,
+        target: &JsObject<TypedArray>,
         target_offset: &U64OrPositiveInfinity,
-        source: &JsObjectTyped<TypedArray>,
+        source: &JsObject<TypedArray>,
         context: &mut Context,
     ) -> JsResult<()> {
         // 1. Let targetBuffer be target.[[ViewedArrayBuffer]].
@@ -1925,7 +1925,7 @@ impl BuiltinTypedArray {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-settypedarrayfromarraylike
     fn set_typed_array_from_array_like(
-        target: &JsObjectTyped<TypedArray>,
+        target: &JsObject<TypedArray>,
         target_offset: &U64OrPositiveInfinity,
         source: &JsValue,
         context: &mut Context,
@@ -2661,7 +2661,7 @@ impl BuiltinTypedArray {
         kind: TypedArrayKind,
         args: &[JsValue],
         context: &mut Context,
-    ) -> JsResult<JsObjectTyped<TypedArray>> {
+    ) -> JsResult<JsObject<TypedArray>> {
         // 1. Let defaultConstructor be the intrinsic object listed in column one of Table 73 for exemplar.[[TypedArrayName]].
         let default_constructor = kind.standard_constructor();
 
@@ -2690,7 +2690,7 @@ impl BuiltinTypedArray {
         constructor: &JsObject,
         args: &[JsValue],
         context: &mut Context,
-    ) -> JsResult<JsObjectTyped<TypedArray>> {
+    ) -> JsResult<JsObject<TypedArray>> {
         // 1. Let newTypedArray be ? Construct(constructor, argumentList).
         let new_typed_array = constructor.construct(args, Some(constructor), context)?;
 
@@ -2840,7 +2840,7 @@ impl BuiltinTypedArray {
     /// [spec]: https://tc39.es/ecma262/#sec-initializetypedarrayfromtypedarray
     pub(super) fn initialize_from_typed_array<T: TypedArrayMarker>(
         proto: JsObject,
-        src_array: &JsObjectTyped<TypedArray>,
+        src_array: &JsObject<TypedArray>,
         context: &mut Context,
     ) -> JsResult<JsObject> {
         let src_array = src_array.borrow();

--- a/core/engine/src/builtins/typed_array/builtin.rs
+++ b/core/engine/src/builtins/typed_array/builtin.rs
@@ -234,7 +234,7 @@ impl BuiltinTypedArray {
 
             // b. Let len be the number of elements in values.
             // c. Let targetObj be ? TypedArrayCreate(C, « 𝔽(len) »).
-            let target_obj = Self::create(constructor, &[values.len().into()], context)?.upcast();
+            let target_obj = Self::create(&constructor, &[values.len().into()], context)?.upcast();
 
             // d. Let k be 0.
             // e. Repeat, while k < len,
@@ -270,7 +270,7 @@ impl BuiltinTypedArray {
         let len = array_like.length_of_array_like(context)?;
 
         // 10. Let targetObj be ? TypedArrayCreate(C, « 𝔽(len) »).
-        let target_obj = Self::create(constructor, &[len.into()], context)?.upcast();
+        let target_obj = Self::create(&constructor, &[len.into()], context)?.upcast();
 
         // 11. Let k be 0.
         // 12. Repeat, while k < len,
@@ -332,7 +332,7 @@ impl BuiltinTypedArray {
         };
 
         // 4. Let newObj be ? TypedArrayCreate(C, « 𝔽(len) »).
-        let new_obj = Self::create(constructor, &[args.len().into()], context)?.upcast();
+        let new_obj = Self::create(&constructor, &[args.len().into()], context)?.upcast();
 
         // 5. Let k be 0.
         // 6. Repeat, while k < len,
@@ -408,8 +408,9 @@ impl BuiltinTypedArray {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[TypedArrayName]]).
         // 3. Assert: O has a [[ViewedArrayBuffer]] internal slot.
-        let ta = this
-            .as_object()
+        let object = this.as_object();
+        let ta = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<TypedArray>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("`this` is not a typed array object")
@@ -430,8 +431,9 @@ impl BuiltinTypedArray {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[TypedArrayName]]).
         // 3. Assert: O has a [[ViewedArrayBuffer]] internal slot.
-        let ta = this
-            .as_object()
+        let object = this.as_object();
+        let ta = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<TypedArray>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("`this` is not a typed array object")
@@ -460,8 +462,9 @@ impl BuiltinTypedArray {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[TypedArrayName]]).
         // 3. Assert: O has a [[ViewedArrayBuffer]] internal slot.
-        let ta = this
-            .as_object()
+        let object = this.as_object();
+        let ta = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<TypedArray>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("Value is not a typed array object")
@@ -1319,8 +1322,9 @@ impl BuiltinTypedArray {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[TypedArrayName]]).
         // 3. Assert: O has [[ViewedArrayBuffer]] and [[ArrayLength]] internal slots.
-        let ta = this
-            .as_object()
+        let object = this.as_object();
+        let ta = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<TypedArray>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("`this` is not a typed array object")
@@ -2270,7 +2274,7 @@ impl BuiltinTypedArray {
         let sort_compare =
             |x: &JsValue, y: &JsValue, context: &mut Context| -> JsResult<cmp::Ordering> {
                 // a. Return ? CompareTypedArrayElements(x, y, comparefn).
-                compare_typed_array_elements(x, y, compare_fn, context)
+                compare_typed_array_elements(x, y, compare_fn.as_ref(), context)
             };
 
         let ta = ta.upcast();
@@ -2325,7 +2329,7 @@ impl BuiltinTypedArray {
         let sort_compare =
             |x: &JsValue, y: &JsValue, context: &mut Context| -> JsResult<cmp::Ordering> {
                 // a. Return ? CompareTypedArrayElements(x, y, comparefn).
-                compare_typed_array_elements(x, y, compare_fn, context)
+                compare_typed_array_elements(x, y, compare_fn.as_ref(), context)
             };
 
         let ta = ta.upcast();

--- a/core/engine/src/builtins/typed_array/object.rs
+++ b/core/engine/src/builtins/typed_array/object.rs
@@ -6,7 +6,7 @@ use crate::{
     Context, JsNativeError, JsResult, JsString, JsValue,
     builtins::array_buffer::BufferObject,
     object::{
-        JsData, JsObject, JsObjectTyped,
+        JsData, JsObject,
         internal_methods::{
             InternalMethodContext, InternalObjectMethods, ORDINARY_INTERNAL_METHODS,
             ordinary_define_own_property, ordinary_delete, ordinary_get, ordinary_get_own_property,
@@ -193,10 +193,7 @@ impl TypedArray {
     /// Abstract operation [`ValidateTypedArray ( O, order )`][spec].
     ///
     /// [spec]: https://tc39.es/ecma262/sec-validatetypedarray
-    pub(crate) fn validate(
-        this: &JsValue,
-        order: Ordering,
-    ) -> JsResult<(JsObjectTyped<Self>, usize)> {
+    pub(crate) fn validate(this: &JsValue, order: Ordering) -> JsResult<(JsObject<Self>, usize)> {
         // 1. Perform ? RequireInternalSlot(O, [[TypedArrayName]]).
         let obj = this
             .as_object()

--- a/core/engine/src/builtins/typed_array/object.rs
+++ b/core/engine/src/builtins/typed_array/object.rs
@@ -6,7 +6,7 @@ use crate::{
     Context, JsNativeError, JsResult, JsString, JsValue,
     builtins::array_buffer::BufferObject,
     object::{
-        JsData, JsObject,
+        JsData, JsObject, JsObjectTyped,
         internal_methods::{
             InternalMethodContext, InternalObjectMethods, ORDINARY_INTERNAL_METHODS,
             ordinary_define_own_property, ordinary_delete, ordinary_get, ordinary_get_own_property,
@@ -193,7 +193,10 @@ impl TypedArray {
     /// Abstract operation [`ValidateTypedArray ( O, order )`][spec].
     ///
     /// [spec]: https://tc39.es/ecma262/sec-validatetypedarray
-    pub(crate) fn validate(this: &JsValue, order: Ordering) -> JsResult<(JsObject<Self>, usize)> {
+    pub(crate) fn validate(
+        this: &JsValue,
+        order: Ordering,
+    ) -> JsResult<(JsObjectTyped<Self>, usize)> {
         // 1. Perform ? RequireInternalSlot(O, [[TypedArrayName]]).
         let obj = this
             .as_object()

--- a/core/engine/src/builtins/typed_array/object.rs
+++ b/core/engine/src/builtins/typed_array/object.rs
@@ -568,7 +568,6 @@ pub(crate) fn typed_array_exotic_own_property_keys(
     obj: &JsObject,
     _context: &mut Context,
 ) -> JsResult<Vec<PropertyKey>> {
-    let obj = obj.borrow();
     let inner = obj
         .downcast_ref::<TypedArray>()
         .expect("TypedArray exotic method should only be callable from TypedArray objects");
@@ -591,12 +590,13 @@ pub(crate) fn typed_array_exotic_own_property_keys(
         }
         _ => Vec::new(),
     };
+    drop(inner);
 
     // 4. For each own property key P of O such that P is a String and P is not an integer index, in ascending chronological order of property creation, do
     //     a. Append P to keys.
     // 5. For each own property key P of O such that P is a Symbol, in ascending chronological order of property creation, do
     //     a. Append P to keys.
-    keys.extend(obj.properties.shape.keys());
+    keys.extend(obj.borrow().properties.shape.keys());
 
     // 6. Return keys.
     Ok(keys)

--- a/core/engine/src/builtins/weak/weak_ref.rs
+++ b/core/engine/src/builtins/weak/weak_ref.rs
@@ -108,8 +108,9 @@ impl WeakRef {
     pub(crate) fn deref(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let weakRef be the this value.
         // 2. Perform ? RequireInternalSlot(weakRef, [[WeakRefTarget]]).
-        let weak_ref = this
-            .as_object()
+        let object = this.as_object();
+        let weak_ref = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<WeakGc<ErasedVTableObject>>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message(

--- a/core/engine/src/builtins/weak_map/mod.rs
+++ b/core/engine/src/builtins/weak_map/mod.rs
@@ -127,8 +127,9 @@ impl WeakMap {
     ) -> JsResult<JsValue> {
         // 1. Let M be the this value.
         // 2. Perform ? RequireInternalSlot(M, [[WeakMapData]]).
-        let mut map = this
-            .as_object()
+        let object = this.as_object();
+        let mut map = object
+            .as_ref()
             .and_then(JsObject::downcast_mut::<NativeWeakMap>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("WeakMap.delete: called with non-object value")
@@ -164,8 +165,9 @@ impl WeakMap {
     ) -> JsResult<JsValue> {
         // 1. Let M be the this value.
         // 2. Perform ? RequireInternalSlot(M, [[WeakMapData]]).
-        let map = this
-            .as_object()
+        let object = this.as_object();
+        let map = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<NativeWeakMap>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("WeakMap.get: called with non-object value")
@@ -198,8 +200,9 @@ impl WeakMap {
     ) -> JsResult<JsValue> {
         // 1. Let M be the this value.
         // 2. Perform ? RequireInternalSlot(M, [[WeakMapData]]).
-        let map = this
-            .as_object()
+        let object = this.as_object();
+        let map = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<NativeWeakMap>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("WeakMap.has: called with non-object value")
@@ -232,8 +235,9 @@ impl WeakMap {
     ) -> JsResult<JsValue> {
         // 1. Let M be the this value.
         // 2. Perform ? RequireInternalSlot(M, [[WeakMapData]]).
-        let mut map = this
-            .as_object()
+        let object = this.as_object();
+        let mut map = object
+            .as_ref()
             .and_then(JsObject::downcast_mut::<NativeWeakMap>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("WeakMap.set: called with non-object value")

--- a/core/engine/src/builtins/weak_set/mod.rs
+++ b/core/engine/src/builtins/weak_set/mod.rs
@@ -141,8 +141,9 @@ impl WeakSet {
     ) -> JsResult<JsValue> {
         // 1. Let S be the this value.
         // 2. Perform ? RequireInternalSlot(S, [[WeakSetData]]).
-        let mut set = this
-            .as_object()
+        let object = this.as_object();
+        let mut set = object
+            .as_ref()
             .and_then(JsObject::downcast_mut::<NativeWeakSet>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("WeakSet.add: called with non-object value")
@@ -190,8 +191,9 @@ impl WeakSet {
     ) -> JsResult<JsValue> {
         // 1. Let S be the this value.
         // 2. Perform ? RequireInternalSlot(S, [[WeakSetData]]).
-        let mut set = this
-            .as_object()
+        let object = this.as_object();
+        let mut set = object
+            .as_ref()
             .and_then(JsObject::downcast_mut::<NativeWeakSet>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("WeakSet.delete: called with non-object value")
@@ -229,8 +231,9 @@ impl WeakSet {
     ) -> JsResult<JsValue> {
         // 1. Let S be the this value.
         // 2. Perform ? RequireInternalSlot(S, [[WeakSetData]]).
-        let set = this
-            .as_object()
+        let object = this.as_object();
+        let set = object
+            .as_ref()
             .and_then(JsObject::downcast_ref::<NativeWeakSet>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message("WeakSet.has: called with non-object value")

--- a/core/engine/src/context/intrinsics.rs
+++ b/core/engine/src/context/intrinsics.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 
 #[cfg(feature = "intl")]
-use crate::{builtins::intl::Intl, object::JsObjectTyped};
+use crate::builtins::intl::Intl;
 
 /// The intrinsic objects and constructors.
 ///
@@ -1095,7 +1095,7 @@ pub struct IntrinsicObjects {
 
     /// [`%Intl%`](https://tc39.es/ecma402/#intl-object)
     #[cfg(feature = "intl")]
-    intl: JsObjectTyped<Intl>,
+    intl: JsObject<Intl>,
 
     /// [`%SegmentsPrototype%`](https://tc39.es/ecma402/#sec-%segmentsprototype%-object)
     #[cfg(feature = "intl")]
@@ -1142,7 +1142,7 @@ impl IntrinsicObjects {
             #[cfg(feature = "annex-b")]
             unescape: JsFunction::empty_intrinsic_function(false),
             #[cfg(feature = "intl")]
-            intl: JsObjectTyped::new_unique(None, Intl::new()?),
+            intl: JsObject::new_unique(None, Intl::new()?),
             #[cfg(feature = "intl")]
             segments_prototype: JsObject::default(),
             #[cfg(feature = "temporal")]
@@ -1318,7 +1318,7 @@ impl IntrinsicObjects {
     #[must_use]
     #[cfg(feature = "intl")]
     #[inline]
-    pub fn intl(&self) -> JsObjectTyped<Intl> {
+    pub fn intl(&self) -> JsObject<Intl> {
         self.intl.clone()
     }
 

--- a/core/engine/src/context/intrinsics.rs
+++ b/core/engine/src/context/intrinsics.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 
 #[cfg(feature = "intl")]
-use crate::builtins::intl::Intl;
+use crate::{builtins::intl::Intl, object::JsObjectTyped};
 
 /// The intrinsic objects and constructors.
 ///
@@ -1095,7 +1095,7 @@ pub struct IntrinsicObjects {
 
     /// [`%Intl%`](https://tc39.es/ecma402/#intl-object)
     #[cfg(feature = "intl")]
-    intl: JsObject<Intl>,
+    intl: JsObjectTyped<Intl>,
 
     /// [`%SegmentsPrototype%`](https://tc39.es/ecma402/#sec-%segmentsprototype%-object)
     #[cfg(feature = "intl")]
@@ -1142,7 +1142,7 @@ impl IntrinsicObjects {
             #[cfg(feature = "annex-b")]
             unescape: JsFunction::empty_intrinsic_function(false),
             #[cfg(feature = "intl")]
-            intl: JsObject::new_unique(None, Intl::new()?),
+            intl: JsObjectTyped::new_unique(None, Intl::new()?),
             #[cfg(feature = "intl")]
             segments_prototype: JsObject::default(),
             #[cfg(feature = "temporal")]
@@ -1318,7 +1318,7 @@ impl IntrinsicObjects {
     #[must_use]
     #[cfg(feature = "intl")]
     #[inline]
-    pub fn intl(&self) -> JsObject<Intl> {
+    pub fn intl(&self) -> JsObjectTyped<Intl> {
         self.intl.clone()
     }
 

--- a/core/engine/src/interop/into_js_arguments.rs
+++ b/core/engine/src/interop/into_js_arguments.rs
@@ -236,7 +236,7 @@ impl<T: TryFromJs> Deref for JsThis<T> {
 /// [`JsThis`] capture instead.
 #[derive(Debug, Clone)]
 pub struct JsClass<T: NativeObject> {
-    inner: boa_engine::JsObjectTyped<T>,
+    inner: boa_engine::JsObject<T>,
 }
 
 impl<T: NativeObject> JsClass<T> {

--- a/core/engine/src/interop/into_js_arguments.rs
+++ b/core/engine/src/interop/into_js_arguments.rs
@@ -236,7 +236,7 @@ impl<T: TryFromJs> Deref for JsThis<T> {
 /// [`JsThis`] capture instead.
 #[derive(Debug, Clone)]
 pub struct JsClass<T: NativeObject> {
-    inner: boa_engine::JsObject<T>,
+    inner: boa_engine::JsObjectTyped<T>,
 }
 
 impl<T: NativeObject> JsClass<T> {

--- a/core/engine/src/lib.rs
+++ b/core/engine/src/lib.rs
@@ -124,7 +124,7 @@ pub mod prelude {
         interop::{IntoJsFunctionCopied, UnsafeIntoJsFunction},
         module::{IntoJsModule, Module},
         native_function::NativeFunction,
-        object::{JsData, JsObject, NativeObject},
+        object::{JsData, JsObject, JsObjectTyped, NativeObject},
         script::Script,
         string::{JsStr, JsString},
         symbol::JsSymbol,

--- a/core/engine/src/lib.rs
+++ b/core/engine/src/lib.rs
@@ -124,7 +124,7 @@ pub mod prelude {
         interop::{IntoJsFunctionCopied, UnsafeIntoJsFunction},
         module::{IntoJsModule, Module},
         native_function::NativeFunction,
-        object::{JsData, JsObject, JsObjectTyped, NativeObject},
+        object::{JsData, JsObject, NativeObject},
         script::Script,
         string::{JsStr, JsString},
         symbol::JsSymbol,

--- a/core/engine/src/object/builtins/jsarray.rs
+++ b/core/engine/src/object/builtins/jsarray.rs
@@ -115,7 +115,6 @@ impl JsArray {
     pub fn concat(&self, items: &[JsValue], context: &mut Context) -> JsResult<Self> {
         let object = Array::concat(&self.inner.clone().into(), items, context)?
             .as_object()
-            .cloned()
             .expect("Array.prototype.filter should always return object");
 
         Self::from_object(object)
@@ -240,7 +239,6 @@ impl JsArray {
             context,
         )?
         .as_object()
-        .cloned()
         .expect("Array.prototype.filter should always return object");
 
         Self::from_object(object)
@@ -260,7 +258,6 @@ impl JsArray {
             context,
         )?
         .as_object()
-        .cloned()
         .expect("Array.prototype.map should always return object");
 
         Self::from_object(object)
@@ -330,7 +327,6 @@ impl JsArray {
             context,
         )?
         .as_object()
-        .cloned()
         .expect("Array.prototype.slice should always return object");
 
         Self::from_object(object)
@@ -374,7 +370,6 @@ impl JsArray {
         Ok(Self {
             inner: array
                 .as_object()
-                .cloned()
                 .expect("`to_reversed` must always return an `Array` on success"),
         })
     }
@@ -395,7 +390,6 @@ impl JsArray {
         Ok(Self {
             inner: array
                 .as_object()
-                .cloned()
                 .expect("`to_sorted` must always return an `Array` on success"),
         })
     }
@@ -408,7 +402,6 @@ impl JsArray {
         Ok(Self {
             inner: array
                 .as_object()
-                .cloned()
                 .expect("`with` must always return an `Array` on success"),
         })
     }

--- a/core/engine/src/object/builtins/jsarraybuffer.rs
+++ b/core/engine/src/object/builtins/jsarraybuffer.rs
@@ -4,7 +4,7 @@ use crate::{
     builtins::array_buffer::ArrayBuffer,
     context::intrinsics::StandardConstructors,
     error::JsNativeError,
-    object::{JsObject, JsObjectTyped, Object, internal_methods::get_prototype_from_constructor},
+    object::{JsObject, Object, internal_methods::get_prototype_from_constructor},
     value::TryFromJs,
 };
 use boa_gc::{Finalize, GcRef, GcRefMut, Trace};
@@ -14,19 +14,19 @@ use std::ops::Deref;
 #[derive(Debug, Clone, Trace, Finalize)]
 #[boa_gc(unsafe_no_drop)]
 pub struct JsArrayBuffer {
-    inner: JsObjectTyped<ArrayBuffer>,
+    inner: JsObject<ArrayBuffer>,
 }
 
-impl From<JsArrayBuffer> for JsObjectTyped<ArrayBuffer> {
+impl From<JsArrayBuffer> for JsObject<ArrayBuffer> {
     #[inline]
     fn from(value: JsArrayBuffer) -> Self {
         value.inner
     }
 }
 
-impl From<JsObjectTyped<ArrayBuffer>> for JsArrayBuffer {
+impl From<JsObject<ArrayBuffer>> for JsArrayBuffer {
     #[inline]
-    fn from(value: JsObjectTyped<ArrayBuffer>) -> Self {
+    fn from(value: JsObject<ArrayBuffer>) -> Self {
         Self { inner: value }
     }
 }
@@ -117,7 +117,7 @@ impl JsArrayBuffer {
 
         // 3. Set obj.[[ArrayBufferData]] to block.
         // 4. Set obj.[[ArrayBufferByteLength]] to byteLength.
-        let obj = JsObjectTyped::new(
+        let obj = JsObject::new(
             context.root_shape(),
             prototype,
             ArrayBuffer::from_data(block, JsValue::undefined()),
@@ -303,7 +303,7 @@ impl From<JsArrayBuffer> for JsValue {
 }
 
 impl Deref for JsArrayBuffer {
-    type Target = JsObjectTyped<ArrayBuffer>;
+    type Target = JsObject<ArrayBuffer>;
 
     #[inline]
     fn deref(&self) -> &Self::Target {

--- a/core/engine/src/object/builtins/jsarraybuffer.rs
+++ b/core/engine/src/object/builtins/jsarraybuffer.rs
@@ -4,7 +4,7 @@ use crate::{
     builtins::array_buffer::ArrayBuffer,
     context::intrinsics::StandardConstructors,
     error::JsNativeError,
-    object::{JsObject, Object, internal_methods::get_prototype_from_constructor},
+    object::{JsObject, JsObjectTyped, Object, internal_methods::get_prototype_from_constructor},
     value::TryFromJs,
 };
 use boa_gc::{Finalize, GcRef, GcRefMut, Trace};
@@ -14,19 +14,19 @@ use std::ops::Deref;
 #[derive(Debug, Clone, Trace, Finalize)]
 #[boa_gc(unsafe_no_drop)]
 pub struct JsArrayBuffer {
-    inner: JsObject<ArrayBuffer>,
+    inner: JsObjectTyped<ArrayBuffer>,
 }
 
-impl From<JsArrayBuffer> for JsObject<ArrayBuffer> {
+impl From<JsArrayBuffer> for JsObjectTyped<ArrayBuffer> {
     #[inline]
     fn from(value: JsArrayBuffer) -> Self {
         value.inner
     }
 }
 
-impl From<JsObject<ArrayBuffer>> for JsArrayBuffer {
+impl From<JsObjectTyped<ArrayBuffer>> for JsArrayBuffer {
     #[inline]
-    fn from(value: JsObject<ArrayBuffer>) -> Self {
+    fn from(value: JsObjectTyped<ArrayBuffer>) -> Self {
         Self { inner: value }
     }
 }
@@ -117,7 +117,7 @@ impl JsArrayBuffer {
 
         // 3. Set obj.[[ArrayBufferData]] to block.
         // 4. Set obj.[[ArrayBufferByteLength]] to byteLength.
-        let obj = JsObject::new(
+        let obj = JsObjectTyped::new(
             context.root_shape(),
             prototype,
             ArrayBuffer::from_data(block, JsValue::undefined()),
@@ -303,7 +303,7 @@ impl From<JsArrayBuffer> for JsValue {
 }
 
 impl Deref for JsArrayBuffer {
-    type Target = JsObject<ArrayBuffer>;
+    type Target = JsObjectTyped<ArrayBuffer>;
 
     #[inline]
     fn deref(&self) -> &Self::Target {

--- a/core/engine/src/object/builtins/jsdataview.rs
+++ b/core/engine/src/object/builtins/jsdataview.rs
@@ -2,7 +2,7 @@
 use crate::{
     Context, JsNativeError, JsResult, JsValue,
     builtins::{DataView, array_buffer::BufferObject},
-    object::{JsArrayBuffer, JsObject},
+    object::{JsArrayBuffer, JsObject, JsObjectTyped},
     value::TryFromJs,
 };
 
@@ -31,19 +31,19 @@ use std::ops::Deref;
 #[derive(Debug, Clone, Trace, Finalize)]
 #[boa_gc(unsafe_no_drop)]
 pub struct JsDataView {
-    inner: JsObject<DataView>,
+    inner: JsObjectTyped<DataView>,
 }
 
-impl From<JsDataView> for JsObject<DataView> {
+impl From<JsDataView> for JsObjectTyped<DataView> {
     #[inline]
     fn from(value: JsDataView) -> Self {
         value.inner
     }
 }
 
-impl From<JsObject<DataView>> for JsDataView {
+impl From<JsObjectTyped<DataView>> for JsDataView {
     #[inline]
-    fn from(value: JsObject<DataView>) -> Self {
+    fn from(value: JsObjectTyped<DataView>) -> Self {
         Self { inner: value }
     }
 }
@@ -133,7 +133,7 @@ impl JsDataView {
                 .into());
         }
 
-        let obj = JsObject::new(
+        let obj = JsObjectTyped::new(
             context.root_shape(),
             prototype,
             DataView {
@@ -519,7 +519,7 @@ impl From<JsDataView> for JsValue {
 }
 
 impl Deref for JsDataView {
-    type Target = JsObject<DataView>;
+    type Target = JsObjectTyped<DataView>;
 
     #[inline]
     fn deref(&self) -> &Self::Target {

--- a/core/engine/src/object/builtins/jsdataview.rs
+++ b/core/engine/src/object/builtins/jsdataview.rs
@@ -2,7 +2,7 @@
 use crate::{
     Context, JsNativeError, JsResult, JsValue,
     builtins::{DataView, array_buffer::BufferObject},
-    object::{JsArrayBuffer, JsObject, JsObjectTyped},
+    object::{JsArrayBuffer, JsObject},
     value::TryFromJs,
 };
 
@@ -31,19 +31,19 @@ use std::ops::Deref;
 #[derive(Debug, Clone, Trace, Finalize)]
 #[boa_gc(unsafe_no_drop)]
 pub struct JsDataView {
-    inner: JsObjectTyped<DataView>,
+    inner: JsObject<DataView>,
 }
 
-impl From<JsDataView> for JsObjectTyped<DataView> {
+impl From<JsDataView> for JsObject<DataView> {
     #[inline]
     fn from(value: JsDataView) -> Self {
         value.inner
     }
 }
 
-impl From<JsObjectTyped<DataView>> for JsDataView {
+impl From<JsObject<DataView>> for JsDataView {
     #[inline]
-    fn from(value: JsObjectTyped<DataView>) -> Self {
+    fn from(value: JsObject<DataView>) -> Self {
         Self { inner: value }
     }
 }
@@ -133,7 +133,7 @@ impl JsDataView {
                 .into());
         }
 
-        let obj = JsObjectTyped::new(
+        let obj = JsObject::new(
             context.root_shape(),
             prototype,
             DataView {
@@ -519,7 +519,7 @@ impl From<JsDataView> for JsValue {
 }
 
 impl Deref for JsDataView {
-    type Target = JsObjectTyped<DataView>;
+    type Target = JsObject<DataView>;
 
     #[inline]
     fn deref(&self) -> &Self::Target {

--- a/core/engine/src/object/builtins/jspromise.rs
+++ b/core/engine/src/object/builtins/jspromise.rs
@@ -235,7 +235,7 @@ impl JsPromise {
     /// let promise = context.eval(Source::from_bytes(
     ///     "new Promise((resolve, reject) => resolve())",
     /// ))?;
-    /// let promise = promise.as_object().cloned().unwrap();
+    /// let promise = promise.as_object().unwrap();
     ///
     /// let promise = JsPromise::from_object(promise)?;
     ///

--- a/core/engine/src/object/builtins/jsproxy.rs
+++ b/core/engine/src/object/builtins/jsproxy.rs
@@ -37,7 +37,7 @@ impl JsProxy {
     /// `TypeError`.
     #[inline]
     pub fn from_object(object: JsObject) -> JsResult<Self> {
-        if object.borrow().is::<Proxy>() {
+        if object.is::<Proxy>() {
             Ok(Self { inner: object })
         } else {
             Err(JsNativeError::typ()

--- a/core/engine/src/object/builtins/jssharedarraybuffer.rs
+++ b/core/engine/src/object/builtins/jssharedarraybuffer.rs
@@ -1,10 +1,7 @@
 //! A Rust API wrapper for Boa's `SharedArrayBuffer` Builtin ECMAScript Object
 use crate::{
-    Context, JsResult, JsValue,
-    builtins::array_buffer::SharedArrayBuffer,
-    error::JsNativeError,
-    object::{JsObject, JsObjectTyped},
-    value::TryFromJs,
+    Context, JsResult, JsValue, builtins::array_buffer::SharedArrayBuffer, error::JsNativeError,
+    object::JsObject, value::TryFromJs,
 };
 use boa_gc::{Finalize, Trace};
 use std::{ops::Deref, sync::atomic::Ordering};
@@ -13,19 +10,19 @@ use std::{ops::Deref, sync::atomic::Ordering};
 #[derive(Debug, Clone, Trace, Finalize)]
 #[boa_gc(unsafe_no_drop)]
 pub struct JsSharedArrayBuffer {
-    inner: JsObjectTyped<SharedArrayBuffer>,
+    inner: JsObject<SharedArrayBuffer>,
 }
 
-impl From<JsSharedArrayBuffer> for JsObjectTyped<SharedArrayBuffer> {
+impl From<JsSharedArrayBuffer> for JsObject<SharedArrayBuffer> {
     #[inline]
     fn from(value: JsSharedArrayBuffer) -> Self {
         value.inner
     }
 }
 
-impl From<JsObjectTyped<SharedArrayBuffer>> for JsSharedArrayBuffer {
+impl From<JsObject<SharedArrayBuffer>> for JsSharedArrayBuffer {
     #[inline]
-    fn from(value: JsObjectTyped<SharedArrayBuffer>) -> Self {
+    fn from(value: JsObject<SharedArrayBuffer>) -> Self {
         JsSharedArrayBuffer { inner: value }
     }
 }
@@ -58,7 +55,7 @@ impl JsSharedArrayBuffer {
             .shared_array_buffer()
             .prototype();
 
-        let inner = JsObjectTyped::new(context.root_shape(), proto, buffer);
+        let inner = JsObject::new(context.root_shape(), proto, buffer);
 
         Self { inner }
     }
@@ -110,7 +107,7 @@ impl From<JsSharedArrayBuffer> for JsValue {
 }
 
 impl Deref for JsSharedArrayBuffer {
-    type Target = JsObjectTyped<SharedArrayBuffer>;
+    type Target = JsObject<SharedArrayBuffer>;
 
     #[inline]
     fn deref(&self) -> &Self::Target {

--- a/core/engine/src/object/builtins/jssharedarraybuffer.rs
+++ b/core/engine/src/object/builtins/jssharedarraybuffer.rs
@@ -88,7 +88,7 @@ impl JsSharedArrayBuffer {
     #[inline]
     #[must_use]
     pub fn inner(&self) -> SharedArrayBuffer {
-        self.borrow().data.clone()
+        self.borrow().data.as_ref().clone()
     }
 }
 

--- a/core/engine/src/object/builtins/jssharedarraybuffer.rs
+++ b/core/engine/src/object/builtins/jssharedarraybuffer.rs
@@ -1,7 +1,10 @@
 //! A Rust API wrapper for Boa's `SharedArrayBuffer` Builtin ECMAScript Object
 use crate::{
-    Context, JsResult, JsValue, builtins::array_buffer::SharedArrayBuffer, error::JsNativeError,
-    object::JsObject, value::TryFromJs,
+    Context, JsResult, JsValue,
+    builtins::array_buffer::SharedArrayBuffer,
+    error::JsNativeError,
+    object::{JsObject, JsObjectTyped},
+    value::TryFromJs,
 };
 use boa_gc::{Finalize, Trace};
 use std::{ops::Deref, sync::atomic::Ordering};
@@ -10,19 +13,19 @@ use std::{ops::Deref, sync::atomic::Ordering};
 #[derive(Debug, Clone, Trace, Finalize)]
 #[boa_gc(unsafe_no_drop)]
 pub struct JsSharedArrayBuffer {
-    inner: JsObject<SharedArrayBuffer>,
+    inner: JsObjectTyped<SharedArrayBuffer>,
 }
 
-impl From<JsSharedArrayBuffer> for JsObject<SharedArrayBuffer> {
+impl From<JsSharedArrayBuffer> for JsObjectTyped<SharedArrayBuffer> {
     #[inline]
     fn from(value: JsSharedArrayBuffer) -> Self {
         value.inner
     }
 }
 
-impl From<JsObject<SharedArrayBuffer>> for JsSharedArrayBuffer {
+impl From<JsObjectTyped<SharedArrayBuffer>> for JsSharedArrayBuffer {
     #[inline]
-    fn from(value: JsObject<SharedArrayBuffer>) -> Self {
+    fn from(value: JsObjectTyped<SharedArrayBuffer>) -> Self {
         JsSharedArrayBuffer { inner: value }
     }
 }
@@ -55,7 +58,7 @@ impl JsSharedArrayBuffer {
             .shared_array_buffer()
             .prototype();
 
-        let inner = JsObject::new(context.root_shape(), proto, buffer);
+        let inner = JsObjectTyped::new(context.root_shape(), proto, buffer);
 
         Self { inner }
     }
@@ -107,7 +110,7 @@ impl From<JsSharedArrayBuffer> for JsValue {
 }
 
 impl Deref for JsSharedArrayBuffer {
-    type Target = JsObject<SharedArrayBuffer>;
+    type Target = JsObjectTyped<SharedArrayBuffer>;
 
     #[inline]
     fn deref(&self) -> &Self::Target {

--- a/core/engine/src/object/builtins/jstypedarray.rs
+++ b/core/engine/src/object/builtins/jstypedarray.rs
@@ -1,8 +1,10 @@
 //! Rust API wrappers for the `TypedArray` Builtin ECMAScript Objects
 use crate::{
     Context, JsResult, JsString, JsValue,
-    builtins::typed_array::BuiltinTypedArray,
-    builtins::{BuiltInConstructor, typed_array::TypedArray},
+    builtins::{
+        BuiltInConstructor,
+        typed_array::{BuiltinTypedArray, TypedArray, TypedArrayKind},
+    },
     error::JsNativeError,
     object::{JsArrayBuffer, JsFunction, JsObject},
     value::{IntoOrUndefined, TryFromJs},
@@ -926,7 +928,7 @@ macro_rules! JsTypedArrayType {
     (
         $name:ident,
         $constructor_function:ident,
-        $checker_function:ident,
+        $kind:expr,
         $constructor_object:ident,
         $value_to_elem:ident,
         $element:ty
@@ -948,7 +950,12 @@ macro_rules! JsTypedArrayType {
             )]
             #[inline]
             pub fn from_object(object: JsObject) -> JsResult<Self> {
-                if object.borrow().$checker_function() {
+                let is_kind = if let Some(int) = object.downcast_ref::<TypedArray>() {
+                    int.kind() == $kind
+                } else {
+                    false
+                };
+                if is_kind {
                     Ok(Self {
                         inner: JsTypedArray {
                             inner: object.into(),
@@ -1082,7 +1089,7 @@ macro_rules! JsTypedArrayType {
 JsTypedArrayType!(
     JsUint8Array,
     Uint8Array,
-    is_typed_uint8_array,
+    TypedArrayKind::Uint8,
     typed_uint8_array,
     to_uint8,
     u8
@@ -1090,7 +1097,7 @@ JsTypedArrayType!(
 JsTypedArrayType!(
     JsInt8Array,
     Int8Array,
-    is_typed_int8_array,
+    TypedArrayKind::Int8,
     typed_int8_array,
     to_int8,
     i8
@@ -1098,7 +1105,7 @@ JsTypedArrayType!(
 JsTypedArrayType!(
     JsUint16Array,
     Uint16Array,
-    is_typed_uint16_array,
+    TypedArrayKind::Uint16,
     typed_uint16_array,
     to_uint16,
     u16
@@ -1106,7 +1113,7 @@ JsTypedArrayType!(
 JsTypedArrayType!(
     JsInt16Array,
     Int16Array,
-    is_typed_int16_array,
+    TypedArrayKind::Int16,
     typed_int16_array,
     to_int16,
     i16
@@ -1114,7 +1121,7 @@ JsTypedArrayType!(
 JsTypedArrayType!(
     JsUint32Array,
     Uint32Array,
-    is_typed_uint32_array,
+    TypedArrayKind::Uint32,
     typed_uint32_array,
     to_u32,
     u32
@@ -1122,7 +1129,7 @@ JsTypedArrayType!(
 JsTypedArrayType!(
     JsInt32Array,
     Int32Array,
-    is_typed_int32_array,
+    TypedArrayKind::Int32,
     typed_int32_array,
     to_i32,
     i32
@@ -1130,7 +1137,7 @@ JsTypedArrayType!(
 JsTypedArrayType!(
     JsFloat32Array,
     Float32Array,
-    is_typed_float32_array,
+    TypedArrayKind::Float32,
     typed_float32_array,
     to_f32,
     f32
@@ -1138,7 +1145,7 @@ JsTypedArrayType!(
 JsTypedArrayType!(
     JsFloat64Array,
     Float64Array,
-    is_typed_float64_array,
+    TypedArrayKind::Float64,
     typed_float64_array,
     to_number,
     f64

--- a/core/engine/src/object/builtins/jstypedarray.rs
+++ b/core/engine/src/object/builtins/jstypedarray.rs
@@ -184,7 +184,6 @@ impl JsTypedArray {
         Ok(Self {
             inner: object
                 .as_object()
-                .cloned()
                 .expect("`copyWithin` must always return a `TypedArray` on success"),
         })
     }
@@ -300,7 +299,6 @@ impl JsTypedArray {
         Ok(Self {
             inner: subarray
                 .as_object()
-                .cloned()
                 .expect("`subarray` must always return a `TypedArray` on success"),
         })
     }
@@ -337,7 +335,6 @@ impl JsTypedArray {
         Ok(Self {
             inner: object
                 .as_object()
-                .cloned()
                 .expect("`filter` must always return a `TypedArray` on success"),
         })
     }
@@ -359,7 +356,6 @@ impl JsTypedArray {
         Ok(Self {
             inner: object
                 .as_object()
-                .cloned()
                 .expect("`map` must always return a `TypedArray` on success"),
         })
     }
@@ -464,7 +460,6 @@ impl JsTypedArray {
         Ok(Self {
             inner: object
                 .as_object()
-                .cloned()
                 .expect("`slice` must always return a `TypedArray` on success"),
         })
     }
@@ -824,7 +819,6 @@ impl JsTypedArray {
         Ok(Self {
             inner: array
                 .as_object()
-                .cloned()
                 .expect("`to_reversed` must always return a `TypedArray` on success"),
         })
     }
@@ -845,7 +839,6 @@ impl JsTypedArray {
         Ok(Self {
             inner: array
                 .as_object()
-                .cloned()
                 .expect("`to_sorted` must always return a `TypedArray` on success"),
         })
     }
@@ -859,7 +852,6 @@ impl JsTypedArray {
         Ok(Self {
             inner: array
                 .as_object()
-                .cloned()
                 .expect("`with` must always return a `TypedArray` on success"),
         })
     }

--- a/core/engine/src/object/internal_methods/mod.rs
+++ b/core/engine/src/object/internal_methods/mod.rs
@@ -775,7 +775,7 @@ pub(crate) fn ordinary_set(
         // NOTE(HaledOdat): If the object and receiver are not the same then it's not inline cachable for now.
         context.slot().attributes.set(
             SlotAttributes::NOT_CACHABLE,
-            !JsObject::equals(obj, receiver),
+            !JsObject::equals(obj, &receiver),
         );
 
         // c. Let existingDescriptor be ? Receiver.[[GetOwnProperty]](P).

--- a/core/engine/src/object/internal_methods/string.rs
+++ b/core/engine/src/object/internal_methods/string.rs
@@ -86,8 +86,6 @@ pub(crate) fn string_exotic_own_property_keys(
     obj: &JsObject,
     _context: &mut Context,
 ) -> JsResult<Vec<PropertyKey>> {
-    let obj = obj.borrow();
-
     // 2. Let str be O.[[StringData]].
     // 3. Assert: Type(str) is String.
     let string = obj
@@ -108,6 +106,7 @@ pub(crate) fn string_exotic_own_property_keys(
     // and ! ToIntegerOrInfinity(P) ≥ len, in ascending numeric index order, do
     //      a. Add P as the last element of keys.
     let mut remaining_indices: Vec<_> = obj
+        .borrow()
         .properties
         .index_property_keys()
         .filter(|idx| (*idx as usize) >= len)
@@ -122,7 +121,7 @@ pub(crate) fn string_exotic_own_property_keys(
     // 8. For each own property key P of O such that Type(P) is Symbol, in ascending
     // chronological order of property creation, do
     //      a. Add P as the last element of keys.
-    keys.extend(obj.properties.shape.keys());
+    keys.extend(obj.borrow().properties.shape.keys());
 
     // 9. Return keys.
     Ok(keys)

--- a/core/engine/src/object/jsobject.rs
+++ b/core/engine/src/object/jsobject.rs
@@ -868,10 +868,10 @@ impl JsObject {
 }
 
 impl<T: NativeObject> JsObjectTyped<T> {
-    /// Creates a new `JsObject` from its root shape, prototype, and data.
+    /// Creates a new `JsObjectTyped` from its root shape, prototype, and data.
     ///
     /// Note that the returned object will not be erased to be convertible to a
-    /// `JsValue`. To erase the pointer, call [`JsObject::upcast`].
+    /// `JsValue`. To erase the pointer, call [`JsObjectTyped::upcast`].
     pub fn new<O: Into<Option<JsObject>>>(root_shape: &RootShape, prototype: O, data: T) -> Self
     where
         T: Sized,
@@ -893,10 +893,10 @@ impl<T: NativeObject> JsObjectTyped<T> {
         Self { inner }
     }
 
-    /// Creates a new `JsObject` from prototype, and data.
+    /// Creates a new `JsObjectTyped` from prototype, and data.
     ///
     /// Note that the returned object will not be erased to be convertible to a
-    /// `JsValue`. To erase the pointer, call [`JsObject::upcast`].
+    /// `JsValue`. To erase the pointer, call [`JsObjectTyped::upcast`].
     pub fn new_unique<O: Into<Option<JsObject>>>(prototype: O, data: T) -> Self
     where
         T: Sized,

--- a/core/engine/src/object/jsobject.rs
+++ b/core/engine/src/object/jsobject.rs
@@ -24,7 +24,7 @@ use crate::{
     property::{PropertyDescriptor, PropertyKey},
     value::PreferredType,
 };
-use boa_gc::{self, Finalize, Gc, GcBox, GcRefCell, Trace};
+use boa_gc::{self, Finalize, Gc, GcBox, GcErased, GcRefCell, Trace};
 use std::collections::HashSet;
 use std::{
     cell::RefCell,
@@ -57,11 +57,26 @@ impl JsData for ErasedObjectData {}
 /// Garbage collected `Object`.
 #[derive(Trace, Finalize)]
 #[boa_gc(unsafe_no_drop)]
-pub struct JsObject<T: NativeObject + ?Sized = ErasedObjectData> {
+pub struct JsObject {
+    inner: GcErased,
+}
+
+impl Clone for JsObject {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+/// Garbage collected typed `Object`.
+#[derive(Trace, Finalize)]
+#[boa_gc(unsafe_no_drop)]
+pub struct JsObjectTyped<T: NativeObject> {
     pub(crate) inner: Gc<VTableObject<T>>,
 }
 
-impl<T: NativeObject + ?Sized> Clone for JsObject<T> {
+impl<T: NativeObject> Clone for JsObjectTyped<T> {
     fn clone(&self) -> Self {
         Self {
             inner: self.inner.clone(),
@@ -77,8 +92,6 @@ impl<T: NativeObject + ?Sized> Clone for JsObject<T> {
 #[derive(Trace, Finalize)]
 pub(crate) struct VTableObject<T: NativeObject + ?Sized> {
     #[unsafe_ignore_trace]
-    type_id: core::any::TypeId,
-    #[unsafe_ignore_trace]
     vtable: &'static InternalObjectMethods,
     object: GcRefCell<Object<T>>,
 }
@@ -90,14 +103,38 @@ impl Default for JsObject {
 }
 
 impl JsObject {
-    pub(crate) fn from_raw(ptr: NonNull<GcBox<ErasedVTableObject>>) -> Self {
-        // SAFETY: The pointer is guaranteed to be valid because we just created it.
-        // `VTableObject<ErasedObjectData>` and `VTableObject<T>` have the same size and alignment.
-        unsafe {
-            JsObject {
-                inner: Gc::from_raw(ptr),
-            }
+    fn into_inner(self) -> Gc<ErasedVTableObject> {
+        // SAFETY: The `GcErased` is guaranteed to contain a `ErasedVTableObject`,
+        // since `JsObject` is constructed with `VTableObject<T>` which has the same size and alignment.
+        unsafe { self.inner.downcast_unchecked::<ErasedVTableObject>() }
+    }
+
+    fn inner_as_ref(&self) -> &Gc<ErasedVTableObject> {
+        // SAFETY: The `GcErased` is guaranteed to contain a `ErasedVTableObject`,
+        // since `JsObject` is constructed with `VTableObject<T>` which has the same size and alignment.
+        unsafe { self.inner.downcast_ref_unchecked::<ErasedVTableObject>() }
+    }
+
+    /// Creates a new `JsObject` from a raw pointer.
+    ///
+    /// # Safety
+    /// The caller must ensure that the pointer is valid and points to a `GcBox<ErasedVTableObject>`.
+    /// /// The pointer must not be null.
+    pub(crate) unsafe fn from_u64(value: u64) -> Self {
+        // SAFETY: The caller guaranteed the value to be a valid pointer to a `GcBox<ErasedVTableObject>`.
+        let ptr = unsafe {
+            Gc::from_raw(NonNull::new_unchecked(
+                value as *mut GcBox<ErasedVTableObject>,
+            ))
+        };
+
+        JsObject {
+            inner: GcErased::new(ptr),
         }
+    }
+
+    pub(crate) fn into_u64(self) -> u64 {
+        Gc::into_raw(self.into_inner()).as_ptr() as u64
     }
 
     /// Creates a new `JsObject` from its inner object and its vtable.
@@ -105,18 +142,13 @@ impl JsObject {
         object: Object<T>,
         vtable: &'static InternalObjectMethods,
     ) -> Self {
-        let ptr = Gc::into_raw(Gc::new(VTableObject {
-            type_id: core::any::TypeId::of::<T>(),
+        let gc = Gc::new(VTableObject {
             object: GcRefCell::new(object),
             vtable,
-        }));
+        });
 
-        // SAFETY: The pointer is guaranteed to be valid because we just created it.
-        // `VTableObject<ErasedObjectData>` and `VTableObject<T>` have the same size and alignment.
-        unsafe {
-            JsObject {
-                inner: Gc::from_raw(ptr.cast::<GcBox<ErasedVTableObject>>()),
-            }
+        JsObject {
+            inner: GcErased::new(gc),
         }
     }
 
@@ -159,8 +191,7 @@ impl JsObject {
         data: T,
     ) -> Self {
         let internal_methods = data.internal_methods();
-        let ptr = Gc::into_raw(Gc::new(VTableObject {
-            type_id: core::any::TypeId::of::<T>(),
+        let gc = Gc::new(VTableObject {
             object: GcRefCell::new(Object {
                 data: Box::new(data),
                 properties: PropertyMap::from_prototype_unique_shape(prototype.into()),
@@ -168,14 +199,10 @@ impl JsObject {
                 private_elements: ThinVec::new(),
             }),
             vtable: internal_methods,
-        }));
+        });
 
-        // SAFETY: The pointer is guaranteed to be valid because we just created it.
-        // `VTableObject<ErasedObjectData>` and `VTableObject<T>` have the same size and alignment.
-        unsafe {
-            JsObject {
-                inner: Gc::from_raw(ptr.cast::<GcBox<ErasedVTableObject>>()),
-            }
+        JsObject {
+            inner: GcErased::new(gc),
         }
     }
 
@@ -192,8 +219,7 @@ impl JsObject {
         data: T,
     ) -> Self {
         let internal_methods = data.internal_methods();
-        let ptr = Gc::into_raw(Gc::new(VTableObject {
-            type_id: core::any::TypeId::of::<T>(),
+        let gc = Gc::new(VTableObject {
             object: GcRefCell::new(Object {
                 data: Box::new(data),
                 properties: PropertyMap::from_prototype_with_shared_shape(
@@ -204,14 +230,10 @@ impl JsObject {
                 private_elements: ThinVec::new(),
             }),
             vtable: internal_methods,
-        }));
+        });
 
-        // SAFETY: The pointer is guaranteed to be valid because we just created it.
-        // `VTableObject<ErasedObjectData>` and `VTableObject<T>` have the same size and alignment.
-        unsafe {
-            JsObject {
-                inner: Gc::from_raw(ptr.cast::<GcBox<ErasedVTableObject>>()),
-            }
+        JsObject {
+            inner: GcErased::new(gc),
         }
     }
 
@@ -220,26 +242,11 @@ impl JsObject {
     /// # Panics
     ///
     /// Panics if the object is currently mutably borrowed.
-    pub fn downcast<T: NativeObject>(self) -> Result<JsObject<T>, Self> {
+    pub fn downcast<T: NativeObject>(self) -> Result<JsObjectTyped<T>, Self> {
         if self.is::<T>() {
-            let ptr: NonNull<GcBox<VTableObject<ErasedObjectData>>> = Gc::into_raw(self.inner);
-
-            // SAFETY: the rooted `Gc` ensures we can read the inner `GcBox` in a sound way.
-            #[cfg(debug_assertions)]
-            unsafe {
-                let erased = ptr.as_ref();
-
-                // Some sanity checks to ensure we're doing the correct cast.
-                assert_eq!(size_of_val(erased), size_of::<GcBox<VTableObject<T>>>());
-                assert_eq!(align_of_val(erased), align_of::<GcBox<VTableObject<T>>>());
-            }
-
-            let ptr: NonNull<GcBox<VTableObject<T>>> = ptr.cast();
-
-            // SAFETY: We checked that `self` is of type `T`, so we can safely cast the pointer.
-            let inner = unsafe { Gc::from_raw(ptr) };
-
-            Ok(JsObject { inner })
+            // SAFETY: We have verified that the object is of type `T`, so we can safely cast it.
+            let inner = unsafe { self.inner.downcast_unchecked::<VTableObject<T>>() };
+            Ok(JsObjectTyped { inner })
         } else {
             Err(self)
         }
@@ -251,18 +258,14 @@ impl JsObject {
     ///
     /// For this cast to be sound, `self` must contain an instance of `T` inside its inner data.
     #[must_use]
-    pub unsafe fn downcast_unchecked<T: NativeObject>(self) -> JsObject<T> {
-        let ptr: NonNull<GcBox<VTableObject<T>>> = Gc::into_raw(self.inner).cast();
-
+    pub unsafe fn downcast_unchecked<T: NativeObject>(self) -> JsObjectTyped<T> {
         // SAFETY: The caller guarantees `T` is the original inner data type of the underlying
         // object.
         // The pointer is guaranteed to be valid because we just created it.
         // `VTableObject<ErasedObjectData>` and `VTableObject<T>` have the same size and alignment.
-        unsafe {
-            JsObject {
-                inner: Gc::from_raw(ptr),
-            }
-        }
+        let gc = unsafe { self.inner.downcast_unchecked::<VTableObject<T>>() };
+
+        JsObjectTyped { inner: gc.clone() }
     }
 
     /// Downcasts a reference to the object,
@@ -314,7 +317,7 @@ impl JsObject {
     #[must_use]
     #[track_caller]
     pub fn is<T: NativeObject>(&self) -> bool {
-        self.inner.type_id == core::any::TypeId::of::<T>()
+        self.inner.is::<VTableObject<T>>()
     }
 
     /// Checks if it's an ordinary object.
@@ -686,74 +689,7 @@ Cannot both specify accessors and a value or writable attribute",
     }
 }
 
-impl<T: NativeObject + ?Sized> JsObject<T> {
-    /// Creates a new `JsObject` from its root shape, prototype, and data.
-    ///
-    /// Note that the returned object will not be erased to be convertible to a
-    /// `JsValue`. To erase the pointer, call [`JsObject::upcast`].
-    pub fn new<O: Into<Option<JsObject>>>(root_shape: &RootShape, prototype: O, data: T) -> Self
-    where
-        T: Sized,
-    {
-        let internal_methods = data.internal_methods();
-        let inner = Gc::new(VTableObject {
-            type_id: core::any::TypeId::of::<T>(),
-            object: GcRefCell::new(Object {
-                data: Box::new(data),
-                properties: PropertyMap::from_prototype_with_shared_shape(
-                    root_shape,
-                    prototype.into(),
-                ),
-                extensible: true,
-                private_elements: ThinVec::new(),
-            }),
-            vtable: internal_methods,
-        });
-
-        Self { inner }
-    }
-
-    /// Creates a new `JsObject` from prototype, and data.
-    ///
-    /// Note that the returned object will not be erased to be convertible to a
-    /// `JsValue`. To erase the pointer, call [`JsObject::upcast`].
-    pub fn new_unique<O: Into<Option<JsObject>>>(prototype: O, data: T) -> Self
-    where
-        T: Sized,
-    {
-        let internal_methods = data.internal_methods();
-        let inner = Gc::new(VTableObject {
-            type_id: core::any::TypeId::of::<T>(),
-            object: GcRefCell::new(Object {
-                data: Box::new(data),
-                properties: PropertyMap::from_prototype_unique_shape(prototype.into()),
-                extensible: true,
-                private_elements: ThinVec::new(),
-            }),
-            vtable: internal_methods,
-        });
-
-        Self { inner }
-    }
-
-    /// Upcasts this object's inner data from a specific type `T` to an erased type
-    /// `dyn NativeObject`.
-    #[must_use]
-    pub fn upcast(self) -> JsObject
-    where
-        T: Sized,
-    {
-        let ptr: NonNull<GcBox<ErasedVTableObject>> = Gc::into_raw(self.inner).cast();
-
-        // SAFETY: The pointer is guaranteed to be valid because we just created it.
-        // `VTableObject<ErasedObjectData>` and `VTableObject<T>` have the same size and alignment.
-        unsafe {
-            JsObject {
-                inner: Gc::from_raw(ptr),
-            }
-        }
-    }
-
+impl JsObject {
     /// Immutably borrows the `Object`.
     ///
     /// The borrow lasts until the returned `Ref` exits scope.
@@ -765,7 +701,7 @@ impl<T: NativeObject + ?Sized> JsObject<T> {
     #[inline]
     #[must_use]
     #[track_caller]
-    pub fn borrow(&self) -> Ref<'_, Object<T>> {
+    pub fn borrow(&self) -> Ref<'_, Object<ErasedObjectData>> {
         self.try_borrow().expect("Object already mutably borrowed")
     }
 
@@ -779,7 +715,7 @@ impl<T: NativeObject + ?Sized> JsObject<T> {
     #[inline]
     #[must_use]
     #[track_caller]
-    pub fn borrow_mut(&self) -> RefMut<'_, Object<T>, Object<T>> {
+    pub fn borrow_mut(&self) -> RefMut<'_, Object<ErasedObjectData>, Object<ErasedObjectData>> {
         self.try_borrow_mut().expect("Object already borrowed")
     }
 
@@ -790,8 +726,11 @@ impl<T: NativeObject + ?Sized> JsObject<T> {
     ///
     /// This is the non-panicking variant of [`borrow`](#method.borrow).
     #[inline]
-    pub fn try_borrow(&self) -> StdResult<Ref<'_, Object<T>>, BorrowError> {
-        self.inner.object.try_borrow().map_err(|_| BorrowError)
+    pub fn try_borrow(&self) -> StdResult<Ref<'_, Object<ErasedObjectData>>, BorrowError> {
+        self.inner_as_ref()
+            .object
+            .try_borrow()
+            .map_err(|_| BorrowError)
     }
 
     /// Mutably borrows the object, returning an error if the value is currently borrowed.
@@ -801,8 +740,11 @@ impl<T: NativeObject + ?Sized> JsObject<T> {
     ///
     /// This is the non-panicking variant of [`borrow_mut`](#method.borrow_mut).
     #[inline]
-    pub fn try_borrow_mut(&self) -> StdResult<RefMut<'_, Object<T>, Object<T>>, BorrowMutError> {
-        self.inner
+    pub fn try_borrow_mut(
+        &self,
+    ) -> StdResult<RefMut<'_, Object<ErasedObjectData>, Object<ErasedObjectData>>, BorrowMutError>
+    {
+        self.inner_as_ref()
             .object
             .try_borrow_mut()
             .map_err(|_| BorrowMutError)
@@ -883,7 +825,7 @@ impl<T: NativeObject + ?Sized> JsObject<T> {
         reason = "can only use `ptr::fn_addr_eq` on rustc 1.85"
     )]
     pub fn is_callable(&self) -> bool {
-        self.inner.vtable.__call__ != ORDINARY_INTERNAL_METHODS.__call__
+        self.inner_as_ref().vtable.__call__ != ORDINARY_INTERNAL_METHODS.__call__
     }
 
     /// It determines if Object is a function object with a `[[Construct]]` internal method.
@@ -899,15 +841,15 @@ impl<T: NativeObject + ?Sized> JsObject<T> {
         reason = "can only use `ptr::fn_addr_eq` on rustc 1.85"
     )]
     pub fn is_constructor(&self) -> bool {
-        self.inner.vtable.__construct__ != ORDINARY_INTERNAL_METHODS.__construct__
+        self.inner_as_ref().vtable.__construct__ != ORDINARY_INTERNAL_METHODS.__construct__
     }
 
     pub(crate) fn vtable(&self) -> &'static InternalObjectMethods {
-        self.inner.vtable
+        self.inner_as_ref().vtable
     }
 
-    pub(crate) const fn inner(&self) -> &Gc<VTableObject<T>> {
-        &self.inner
+    pub(crate) fn inner(&self) -> &Gc<VTableObject<ErasedObjectData>> {
+        self.inner_as_ref()
     }
 
     /// Create a new private name with this object as the unique identifier.
@@ -917,29 +859,92 @@ impl<T: NativeObject + ?Sized> JsObject<T> {
     }
 }
 
-impl<T: NativeObject + ?Sized> AsRef<GcRefCell<Object<T>>> for JsObject<T> {
-    #[inline]
-    fn as_ref(&self) -> &GcRefCell<Object<T>> {
-        &self.inner.object
-    }
-}
+impl<T: NativeObject> JsObjectTyped<T> {
+    /// Creates a new `JsObject` from its root shape, prototype, and data.
+    ///
+    /// Note that the returned object will not be erased to be convertible to a
+    /// `JsValue`. To erase the pointer, call [`JsObject::upcast`].
+    pub fn new<O: Into<Option<JsObject>>>(root_shape: &RootShape, prototype: O, data: T) -> Self
+    where
+        T: Sized,
+    {
+        let internal_methods = data.internal_methods();
+        let inner = Gc::new(VTableObject {
+            object: GcRefCell::new(Object {
+                data: Box::new(data),
+                properties: PropertyMap::from_prototype_with_shared_shape(
+                    root_shape,
+                    prototype.into(),
+                ),
+                extensible: true,
+                private_elements: ThinVec::new(),
+            }),
+            vtable: internal_methods,
+        });
 
-impl<T: NativeObject + ?Sized> From<Gc<VTableObject<T>>> for JsObject<T> {
-    #[inline]
-    fn from(inner: Gc<VTableObject<T>>) -> Self {
         Self { inner }
     }
+
+    /// Creates a new `JsObject` from prototype, and data.
+    ///
+    /// Note that the returned object will not be erased to be convertible to a
+    /// `JsValue`. To erase the pointer, call [`JsObject::upcast`].
+    pub fn new_unique<O: Into<Option<JsObject>>>(prototype: O, data: T) -> Self
+    where
+        T: Sized,
+    {
+        let internal_methods = data.internal_methods();
+        let inner = Gc::new(VTableObject {
+            object: GcRefCell::new(Object {
+                data: Box::new(data),
+                properties: PropertyMap::from_prototype_unique_shape(prototype.into()),
+                extensible: true,
+                private_elements: ThinVec::new(),
+            }),
+            vtable: internal_methods,
+        });
+
+        Self { inner }
+    }
+
+    /// Upcasts this object's inner data from a specific type `T` to an erased type
+    /// `dyn NativeObject`.
+    #[must_use]
+    pub fn upcast(self) -> JsObject
+    where
+        T: Sized,
+    {
+        JsObject {
+            inner: GcErased::new(self.inner),
+        }
+    }
 }
 
-impl<T: NativeObject + ?Sized> PartialEq for JsObject<T> {
+impl AsRef<GcRefCell<Object<ErasedObjectData>>> for JsObject {
+    #[inline]
+    fn as_ref(&self) -> &GcRefCell<Object<ErasedObjectData>> {
+        &self.inner_as_ref().object
+    }
+}
+
+impl From<Gc<VTableObject<ErasedObjectData>>> for JsObject {
+    #[inline]
+    fn from(inner: Gc<VTableObject<ErasedObjectData>>) -> Self {
+        Self {
+            inner: GcErased::new(inner),
+        }
+    }
+}
+
+impl PartialEq for JsObject {
     fn eq(&self, other: &Self) -> bool {
         Self::equals(self, other)
     }
 }
 
-impl<T: NativeObject + ?Sized> Eq for JsObject<T> {}
+impl Eq for JsObject {}
 
-impl<T: NativeObject + ?Sized> Hash for JsObject<T> {
+impl Hash for JsObject {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         std::ptr::hash(self.as_ref(), state);
     }
@@ -1053,7 +1058,7 @@ impl RecursionLimiter {
     }
 }
 
-impl<T: NativeObject + ?Sized> Debug for JsObject<T> {
+impl Debug for JsObject {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let limiter = RecursionLimiter::new(self.as_ref());
 
@@ -1088,5 +1093,157 @@ impl<T: NativeObject + ?Sized> Debug for JsObject<T> {
         } else {
             f.write_str("{ ... }")
         }
+    }
+}
+
+impl<T: NativeObject> JsObjectTyped<T> {
+    /// Immutably borrows the `Object`.
+    ///
+    /// The borrow lasts until the returned `Ref` exits scope.
+    /// Multiple immutable borrows can be taken out at the same time.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the object is currently mutably borrowed.
+    #[inline]
+    #[must_use]
+    #[track_caller]
+    pub fn borrow(&self) -> Ref<'_, Object<T>> {
+        self.try_borrow().expect("Object already mutably borrowed")
+    }
+
+    /// Mutably borrows the Object.
+    ///
+    /// The borrow lasts until the returned `RefMut` exits scope.
+    /// The object cannot be borrowed while this borrow is active.
+    ///
+    /// # Panics
+    /// Panics if the object is currently borrowed.
+    #[inline]
+    #[must_use]
+    #[track_caller]
+    pub fn borrow_mut(&self) -> RefMut<'_, Object<T>, Object<T>> {
+        self.try_borrow_mut().expect("Object already borrowed")
+    }
+
+    /// Immutably borrows the `Object`, returning an error if the value is currently mutably borrowed.
+    ///
+    /// The borrow lasts until the returned `GcCellRef` exits scope.
+    /// Multiple immutable borrows can be taken out at the same time.
+    ///
+    /// This is the non-panicking variant of [`borrow`](#method.borrow).
+    #[inline]
+    pub fn try_borrow(&self) -> StdResult<Ref<'_, Object<T>>, BorrowError> {
+        self.inner.object.try_borrow().map_err(|_| BorrowError)
+    }
+
+    /// Mutably borrows the object, returning an error if the value is currently borrowed.
+    ///
+    /// The borrow lasts until the returned `GcCellRefMut` exits scope.
+    /// The object be borrowed while this borrow is active.
+    ///
+    /// This is the non-panicking variant of [`borrow_mut`](#method.borrow_mut).
+    #[inline]
+    pub fn try_borrow_mut(&self) -> StdResult<RefMut<'_, Object<T>, Object<T>>, BorrowMutError> {
+        self.inner
+            .object
+            .try_borrow_mut()
+            .map_err(|_| BorrowMutError)
+    }
+
+    /// Checks if the garbage collected memory is the same.
+    #[must_use]
+    #[inline]
+    pub fn equals(lhs: &Self, rhs: &Self) -> bool {
+        Gc::ptr_eq(lhs.inner(), rhs.inner())
+    }
+
+    /// Get the prototype of the object.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the object is currently mutably borrowed.
+    #[inline]
+    #[must_use]
+    #[track_caller]
+    pub fn prototype(&self) -> JsPrototype {
+        self.borrow().prototype()
+    }
+
+    /// Set the prototype of the object.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the object is currently mutably borrowed
+    #[inline]
+    #[track_caller]
+    #[allow(clippy::must_use_candidate)]
+    pub fn set_prototype(&self, prototype: JsPrototype) -> bool {
+        self.borrow_mut().set_prototype(prototype)
+    }
+
+    /// Helper function for property insertion.
+    #[track_caller]
+    pub(crate) fn insert<K, P>(&self, key: K, property: P) -> bool
+    where
+        K: Into<PropertyKey>,
+        P: Into<PropertyDescriptor>,
+    {
+        self.borrow_mut().insert(key, property)
+    }
+
+    /// Inserts a field in the object `properties` without checking if it's writable.
+    ///
+    /// If a field was already in the object with the same name, than `true` is returned
+    /// with that field, otherwise `false` is returned.
+    pub fn insert_property<K, P>(&self, key: K, property: P) -> bool
+    where
+        K: Into<PropertyKey>,
+        P: Into<PropertyDescriptor>,
+    {
+        self.insert(key.into(), property)
+    }
+
+    /// It determines if Object is a callable function with a `[[Call]]` internal method.
+    ///
+    /// More information:
+    /// - [ECMAScript reference][spec]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-iscallable
+    #[inline]
+    #[must_use]
+    #[expect(
+        unpredictable_function_pointer_comparisons,
+        reason = "can only use `ptr::fn_addr_eq` on rustc 1.85"
+    )]
+    pub fn is_callable(&self) -> bool {
+        self.inner.vtable.__call__ != ORDINARY_INTERNAL_METHODS.__call__
+    }
+
+    /// It determines if Object is a function object with a `[[Construct]]` internal method.
+    ///
+    /// More information:
+    /// - [ECMAScript reference][spec]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-isconstructor
+    #[inline]
+    #[must_use]
+    #[expect(
+        unpredictable_function_pointer_comparisons,
+        reason = "can only use `ptr::fn_addr_eq` on rustc 1.85"
+    )]
+    pub fn is_constructor(&self) -> bool {
+        self.inner.vtable.__construct__ != ORDINARY_INTERNAL_METHODS.__construct__
+    }
+
+    const fn inner(&self) -> &Gc<VTableObject<T>> {
+        &self.inner
+    }
+}
+
+impl<T: NativeObject> Debug for JsObjectTyped<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let object = self.clone().upcast();
+        f.write_fmt(format_args!("{object:?}"))
     }
 }

--- a/core/engine/src/object/mod.rs
+++ b/core/engine/src/object/mod.rs
@@ -10,14 +10,7 @@ use thin_vec::ThinVec;
 use self::{internal_methods::ORDINARY_INTERNAL_METHODS, shape::Shape};
 use crate::{
     Context, JsString, JsSymbol, JsValue,
-    builtins::{
-        OrdinaryObject,
-        function::{
-            ConstructorKind,
-            arguments::{MappedArguments, UnmappedArguments},
-        },
-        typed_array::{TypedArray, TypedArrayKind},
-    },
+    builtins::{OrdinaryObject, function::ConstructorKind},
     context::intrinsics::StandardConstructor,
     js_string,
     native_function::{NativeFunction, NativeFunctionObject},
@@ -180,7 +173,7 @@ pub struct Object<T: ?Sized> {
     /// The `[[PrivateElements]]` internal slot.
     private_elements: ThinVec<(PrivateName, PrivateElement)>,
     /// The inner object data
-    pub(crate) data: T,
+    pub(crate) data: Box<T>,
 }
 
 impl<T: Default> Default for Object<T> {
@@ -189,7 +182,7 @@ impl<T: Default> Default for Object<T> {
             properties: PropertyMap::default(),
             extensible: true,
             private_elements: ThinVec::new(),
-            data: T::default(),
+            data: Box::default(),
         }
     }
 }
@@ -330,120 +323,6 @@ impl<T: ?Sized> Object<T> {
         }
 
         self.private_elements.push((name, element));
-    }
-}
-
-impl Object<dyn NativeObject> {
-    /// Return `true` if it is a native object and the native type is `T`.
-    #[must_use]
-    pub fn is<T: NativeObject>(&self) -> bool {
-        self.data.is::<T>()
-    }
-
-    /// Downcast a reference to the object,
-    /// if the object is type native object type `T`.
-    #[must_use]
-    pub fn downcast_ref<T: NativeObject>(&self) -> Option<&T> {
-        self.data.downcast_ref::<T>()
-    }
-
-    /// Downcast a mutable reference to the object,
-    /// if the object is type native object type `T`.
-    pub fn downcast_mut<T: NativeObject>(&mut self) -> Option<&mut T> {
-        self.data.downcast_mut::<T>()
-    }
-
-    /// Checks if this object is an `Arguments` object.
-    pub(crate) fn is_arguments(&self) -> bool {
-        self.is::<UnmappedArguments>() || self.is::<MappedArguments>()
-    }
-
-    /// Checks if it a `Uint8Array` object.
-    #[inline]
-    #[must_use]
-    pub fn is_typed_uint8_array(&self) -> bool {
-        if let Some(int) = self.downcast_ref::<TypedArray>() {
-            matches!(int.kind(), TypedArrayKind::Uint8)
-        } else {
-            false
-        }
-    }
-
-    /// Checks if it a `Int8Array` object.
-    #[inline]
-    #[must_use]
-    pub fn is_typed_int8_array(&self) -> bool {
-        if let Some(int) = self.downcast_ref::<TypedArray>() {
-            matches!(int.kind(), TypedArrayKind::Int8)
-        } else {
-            false
-        }
-    }
-
-    /// Checks if it a `Uint16Array` object.
-    #[inline]
-    #[must_use]
-    pub fn is_typed_uint16_array(&self) -> bool {
-        if let Some(int) = self.downcast_ref::<TypedArray>() {
-            matches!(int.kind(), TypedArrayKind::Uint16)
-        } else {
-            false
-        }
-    }
-
-    /// Checks if it a `Int16Array` object.
-    #[inline]
-    #[must_use]
-    pub fn is_typed_int16_array(&self) -> bool {
-        if let Some(int) = self.downcast_ref::<TypedArray>() {
-            matches!(int.kind(), TypedArrayKind::Int16)
-        } else {
-            false
-        }
-    }
-
-    /// Checks if it a `Uint32Array` object.
-    #[inline]
-    #[must_use]
-    pub fn is_typed_uint32_array(&self) -> bool {
-        if let Some(int) = self.downcast_ref::<TypedArray>() {
-            matches!(int.kind(), TypedArrayKind::Uint32)
-        } else {
-            false
-        }
-    }
-
-    /// Checks if it a `Int32Array` object.
-    #[inline]
-    #[must_use]
-    pub fn is_typed_int32_array(&self) -> bool {
-        if let Some(int) = self.downcast_ref::<TypedArray>() {
-            matches!(int.kind(), TypedArrayKind::Int32)
-        } else {
-            false
-        }
-    }
-
-    /// Checks if it a `Float32Array` object.
-    #[inline]
-    #[must_use]
-    pub fn is_typed_float32_array(&self) -> bool {
-        if let Some(int) = self.downcast_ref::<TypedArray>() {
-            matches!(int.kind(), TypedArrayKind::Float32)
-        } else {
-            false
-        }
-    }
-
-    /// Checks if it a `Float64Array` object.
-    #[inline]
-    #[must_use]
-    pub fn is_typed_float64_array(&self) -> bool {
-        if let Some(int) = self.downcast_ref::<TypedArray>() {
-            matches!(int.kind(), TypedArrayKind::Float64)
-        } else {
-            false
-        }
     }
 }
 
@@ -743,13 +622,13 @@ impl<'ctx> ConstructorBuilder<'ctx> {
             context,
             function,
             constructor_object: Object {
-                data: OrdinaryObject,
+                data: Box::new(OrdinaryObject),
                 properties: PropertyMap::default(),
                 extensible: true,
                 private_elements: ThinVec::new(),
             },
             prototype: Object {
-                data: OrdinaryObject,
+                data: Box::new(OrdinaryObject),
                 properties: PropertyMap::default(),
                 extensible: true,
                 private_elements: ThinVec::new(),
@@ -1008,16 +887,18 @@ impl<'ctx> ConstructorBuilder<'ctx> {
         };
 
         let constructor = {
+            let data = NativeFunctionObject {
+                f: self.function,
+                name: self.name.clone(),
+                constructor: self.kind,
+                realm: Some(self.context.realm().clone()),
+            };
+            let internal_methods = data.internal_methods();
             let mut constructor = Object {
                 properties: self.constructor_object.properties,
                 extensible: self.constructor_object.extensible,
                 private_elements: self.constructor_object.private_elements,
-                data: NativeFunctionObject {
-                    f: self.function,
-                    name: self.name.clone(),
-                    constructor: self.kind,
-                    realm: Some(self.context.realm().clone()),
-                },
+                data: Box::new(data),
             };
 
             constructor.insert(StaticJsStrings::LENGTH, length);
@@ -1046,7 +927,6 @@ impl<'ctx> ConstructorBuilder<'ctx> {
                 );
             }
 
-            let internal_methods = constructor.data.internal_methods();
             JsObject::from_object_and_vtable(constructor, internal_methods)
         };
 

--- a/core/engine/src/object/operations.rs
+++ b/core/engine/src/object/operations.rs
@@ -1095,7 +1095,7 @@ impl JsObject {
             ClassFieldDefinition::Public(field_name, _, function_name) => {
                 if let Some(function_name) = function_name {
                     set_function_name(
-                        init_value
+                        &init_value
                             .as_object()
                             .expect("init value must be a function object"),
                         function_name,
@@ -1354,7 +1354,7 @@ impl JsValue {
             return object.instance_of(&bound_function.target_function().clone().into(), context);
         }
 
-        let Some(mut object) = object.as_object().cloned() else {
+        let Some(mut object) = object.as_object() else {
             // 3. If Type(O) is not Object, return false.
             return Ok(false);
         };
@@ -1378,7 +1378,7 @@ impl JsValue {
             };
 
             // c. If SameValue(P, O) is true, return true.
-            if JsObject::equals(&object, prototype) {
+            if JsObject::equals(&object, &prototype) {
                 return Ok(true);
             }
         }

--- a/core/engine/src/object/operations.rs
+++ b/core/engine/src/object/operations.rs
@@ -791,8 +791,7 @@ impl JsObject {
         }
 
         // 3. If argument is a Proxy exotic object, then
-        let object = self.borrow();
-        if let Some(proxy) = object.downcast_ref::<Proxy>() {
+        if let Some(proxy) = self.downcast_ref::<Proxy>() {
             // a. If argument.[[ProxyHandler]] is null, throw a TypeError exception.
             // b. Let target be argument.[[ProxyTarget]].
             let (target, _) = proxy.try_data()?;
@@ -809,24 +808,21 @@ impl JsObject {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-getfunctionrealm
     pub(crate) fn get_function_realm(&self, context: &mut Context) -> JsResult<Realm> {
-        let constructor = self.borrow();
-        if let Some(fun) = constructor.downcast_ref::<OrdinaryFunction>() {
+        if let Some(fun) = self.downcast_ref::<OrdinaryFunction>() {
             return Ok(fun.realm().clone());
         }
 
-        if let Some(f) = constructor.downcast_ref::<NativeFunctionObject>() {
+        if let Some(f) = self.downcast_ref::<NativeFunctionObject>() {
             return Ok(f.realm.clone().unwrap_or_else(|| context.realm().clone()));
         }
 
-        if let Some(bound) = constructor.downcast_ref::<BoundFunction>() {
+        if let Some(bound) = self.downcast_ref::<BoundFunction>() {
             let fun = bound.target_function().clone();
-            drop(constructor);
             return fun.get_function_realm(context);
         }
 
-        if let Some(proxy) = constructor.downcast_ref::<Proxy>() {
+        if let Some(proxy) = self.downcast_ref::<Proxy>() {
             let (fun, _) = proxy.try_data()?;
-            drop(constructor);
             return fun.get_function_realm(context);
         }
 

--- a/core/engine/src/object/shape/shared_shape/template.rs
+++ b/core/engine/src/object/shape/shared_shape/template.rs
@@ -110,7 +110,7 @@ impl ObjectTemplate {
         let internal_methods = data.internal_methods();
 
         let mut object = Object {
-            data,
+            data: Box::new(data),
             extensible: true,
             properties: PropertyMap::new(self.shape.clone().into(), IndexedProperties::default()),
             private_elements: ThinVec::new(),
@@ -133,7 +133,7 @@ impl ObjectTemplate {
     ) -> JsObject {
         let internal_methods = data.internal_methods();
         let mut object = Object {
-            data,
+            data: Box::new(data),
             extensible: true,
             properties: PropertyMap::new(self.shape.clone().into(), indexed_properties),
             private_elements: ThinVec::new(),

--- a/core/engine/src/object/shape/unique_shape.rs
+++ b/core/engine/src/object/shape/unique_shape.rs
@@ -59,7 +59,7 @@ impl UniqueShape {
     }
 
     /// Get the property table of the [`UniqueShape`].
-    pub(crate) fn property_table(&self) -> &RefCell<PropertyTableInner> {
+    fn property_table(&self) -> &RefCell<PropertyTableInner> {
         &self.inner.property_table
     }
 

--- a/core/engine/src/value/conversions/serde_json.rs
+++ b/core/engine/src/value/conversions/serde_json.rs
@@ -133,7 +133,7 @@ impl JsValue {
                 .with_message("cannot convert bigint to JSON")
                 .into()),
             JsVariant::Object(obj) => {
-                if seen_objects.contains(obj) {
+                if seen_objects.contains(&obj) {
                     return Err(JsNativeError::typ()
                         .with_message("cyclic object value")
                         .into());
@@ -165,7 +165,7 @@ impl JsValue {
                     }
                     // Passing the object rather than its clone that was inserted to the set should be fine
                     // as they hash to the same value and therefore HashSet can still remove the clone
-                    seen_objects.remove(obj);
+                    seen_objects.remove(&obj);
                     Ok(Some(Value::Array(arr)))
                 } else {
                     let mut map = Map::new();
@@ -193,7 +193,7 @@ impl JsValue {
                             map.insert(key, value);
                         }
                     }
-                    seen_objects.remove(obj);
+                    seen_objects.remove(&obj);
                     Ok(Some(Value::Object(map)))
                 }
             }

--- a/core/engine/src/value/display.rs
+++ b/core/engine/src/value/display.rs
@@ -104,20 +104,20 @@ pub(crate) fn log_string_from(x: &JsValue, print_internals: bool, print_children
         JsVariant::Object(v) => {
             // Can use the private "type" field of an Object to match on
             // which type of Object it represents for special printing
-            let v_bor = v.borrow();
-            if let Some(s) = v_bor.downcast_ref::<JsString>() {
+            if let Some(s) = v.downcast_ref::<JsString>() {
                 format!("String {{ \"{}\" }}", s.to_std_string_escaped())
-            } else if let Some(b) = v_bor.downcast_ref::<bool>() {
+            } else if let Some(b) = v.downcast_ref::<bool>() {
                 format!("Boolean {{ {b} }}")
-            } else if let Some(r) = v_bor.downcast_ref::<f64>() {
+            } else if let Some(r) = v.downcast_ref::<f64>() {
                 if r.is_sign_negative() && *r == 0.0 {
                     "Number { -0 }".to_string()
                 } else {
                     let mut buffer = ryu_js::Buffer::new();
                     format!("Number {{ {} }}", buffer.format(*r))
                 }
-            } else if v_bor.is::<Array>() {
-                let len = v_bor
+            } else if v.is::<Array>() {
+                let len = v
+                    .borrow()
                     .properties()
                     .get(&js_string!("length").into())
                     .expect("array object must have 'length' property")
@@ -138,7 +138,8 @@ pub(crate) fn log_string_from(x: &JsValue, print_internals: bool, print_children
                             // which are part of the Array
 
                             // FIXME: handle accessor descriptors
-                            if let Some(value) = v_bor
+                            if let Some(value) = v
+                                .borrow()
                                 .properties()
                                 .get(&i.into())
                                 .and_then(|x| x.value().cloned())
@@ -155,7 +156,7 @@ pub(crate) fn log_string_from(x: &JsValue, print_internals: bool, print_children
                 } else {
                     format!("Array({len})")
                 }
-            } else if let Some(map) = v_bor.downcast_ref::<OrderedMap<JsValue>>() {
+            } else if let Some(map) = v.downcast_ref::<OrderedMap<JsValue>>() {
                 let size = map.len();
                 if size == 0 {
                     return String::from("Map(0)");
@@ -175,7 +176,7 @@ pub(crate) fn log_string_from(x: &JsValue, print_internals: bool, print_children
                 } else {
                     format!("Map({size})")
                 }
-            } else if let Some(set) = v_bor.downcast_ref::<OrderedSet>() {
+            } else if let Some(set) = v.downcast_ref::<OrderedSet>() {
                 let size = set.len();
 
                 if size == 0 {
@@ -192,8 +193,7 @@ pub(crate) fn log_string_from(x: &JsValue, print_internals: bool, print_children
                 } else {
                     format!("Set({size})")
                 }
-            } else if v_bor.is::<Error>() {
-                drop(v_bor);
+            } else if v.is::<Error>() {
                 let name: Cow<'static, str> = v
                     .get_property(&js_string!("name").into())
                     .as_ref()
@@ -260,7 +260,7 @@ pub(crate) fn log_string_from(x: &JsValue, print_internals: bool, print_children
                     }
                 }
                 result
-            } else if let Some(promise) = v_bor.downcast_ref::<Promise>() {
+            } else if let Some(promise) = v.downcast_ref::<Promise>() {
                 format!(
                     "Promise {{ {} }}",
                     match promise.state() {

--- a/core/engine/src/value/equality.rs
+++ b/core/engine/src/value/equality.rs
@@ -12,7 +12,7 @@ impl JsValue {
     ) -> JsResult<bool> {
         match (self.as_object(), other.as_object()) {
             (None, None) => Ok(self.strict_equals(other)),
-            (Some(x), Some(y)) => JsObject::deep_strict_equals_inner(x, y, encounters, context),
+            (Some(x), Some(y)) => JsObject::deep_strict_equals_inner(&x, &y, encounters, context),
             _ => Ok(false),
         }
     }
@@ -225,7 +225,7 @@ impl JsValue {
             }
             (JsVariant::String(x), JsVariant::String(y)) => x == y,
             (JsVariant::Boolean(x), JsVariant::Boolean(y)) => x == y,
-            (JsVariant::Object(x), JsVariant::Object(y)) => JsObject::equals(x, y),
+            (JsVariant::Object(x), JsVariant::Object(y)) => JsObject::equals(&x, &y),
             (JsVariant::Symbol(x), JsVariant::Symbol(y)) => x == y,
             _ => false,
         }

--- a/core/engine/src/value/inner/legacy.rs
+++ b/core/engine/src/value/inner/legacy.rs
@@ -32,7 +32,7 @@ impl Finalize for EnumBasedValue {
 unsafe impl Trace for EnumBasedValue {
     custom_trace! {this, mark, {
         if let Some(o) = this.as_object() {
-            mark(o);
+            mark(&o);
         }
     }}
 }
@@ -208,9 +208,9 @@ impl EnumBasedValue {
     /// Returns the value as a boxed `[JsObject]`.
     #[must_use]
     #[inline]
-    pub(crate) const fn as_object(&self) -> Option<&JsObject> {
+    pub(crate) fn as_object(&self) -> Option<JsObject> {
         match self {
-            Self::Object(value) => Some(value),
+            Self::Object(value) => Some(value.clone()),
             _ => None,
         }
     }
@@ -238,7 +238,7 @@ impl EnumBasedValue {
     /// Returns the `[JsVariant]` of this inner value.
     #[must_use]
     #[inline]
-    pub(crate) const fn as_variant(&self) -> JsVariant<'_> {
+    pub(crate) fn as_variant(&self) -> JsVariant<'_> {
         match self {
             Self::Undefined => JsVariant::Undefined,
             Self::Null => JsVariant::Null,
@@ -246,7 +246,7 @@ impl EnumBasedValue {
             Self::Integer32(v) => JsVariant::Integer32(*v),
             Self::Float64(v) => JsVariant::Float64(*v),
             Self::BigInt(v) => JsVariant::BigInt(v),
-            Self::Object(v) => JsVariant::Object(v),
+            Self::Object(v) => JsVariant::Object(v.clone()),
             Self::Symbol(v) => JsVariant::Symbol(v),
             Self::String(v) => JsVariant::String(v),
         }

--- a/core/engine/src/value/inner/nan_boxed.rs
+++ b/core/engine/src/value/inner/nan_boxed.rs
@@ -123,8 +123,11 @@ const_assert!(align_of::<*mut ()>() >= 4);
 /// All bit magic is done here.
 mod bits {
     use boa_engine::{JsBigInt, JsObject, JsSymbol};
+    use boa_gc::GcBox;
     use boa_string::JsString;
     use std::ptr::NonNull;
+
+    use crate::object::ErasedVTableObject;
 
     /// The mask for the bits that indicate if the value is a NaN-value.
     const MASK_NAN: u64 = 0x7FF0_0000_0000_0000;
@@ -295,8 +298,8 @@ mod bits {
     /// The box is forgotten after this operation. It must be dropped separately,
     /// by calling `[Self::drop_pointer]`.
     #[inline(always)]
-    pub(super) unsafe fn tag_object(value: Box<JsObject>) -> u64 {
-        let value = Box::into_raw(value) as u64;
+    pub(super) unsafe fn tag_object(value: JsObject) -> u64 {
+        let value = boa_gc::Gc::into_raw(value.inner).as_ptr() as u64;
         let value_masked: u64 = value & MASK_POINTER_VALUE;
 
         // Assert alignment and location of the pointer.
@@ -309,6 +312,20 @@ mod bits {
 
         // Simply cast for bits.
         value_masked | MASK_OBJECT
+    }
+
+    /// Returns an owned `JsObject` from a tagged value.
+    ///
+    /// # Safety
+    /// * The pointer must be a valid pointer to a `GcBox<ErasedVTableObject>`.
+    #[allow(clippy::unnecessary_box_returns)]
+    pub(super) unsafe fn untag_object_owned(value: u64) -> JsObject {
+        // This is safe since we already checked the pointer is not null as this point.
+        unsafe {
+            JsObject::from_raw(NonNull::new_unchecked(
+                (value & MASK_POINTER_VALUE) as *mut GcBox<ErasedVTableObject>,
+            ))
+        }
     }
 
     /// Returns a tagged u64 of a boxed `[JsSymbol]`.
@@ -428,7 +445,7 @@ impl Finalize for NanBoxedValue {
 unsafe impl Trace for NanBoxedValue {
     custom_trace! {this, mark, {
         if let Some(o) = this.as_object() {
-            mark(o);
+            mark(&o);
         }
     }}
 }
@@ -506,7 +523,7 @@ impl NanBoxedValue {
     #[must_use]
     #[inline(always)]
     pub(crate) fn object(value: JsObject) -> Self {
-        Self::from_inner_unchecked(unsafe { bits::tag_object(Box::new(value)) })
+        Self::from_inner_unchecked(unsafe { bits::tag_object(value) })
     }
 
     /// Returns a `InnerValue` from a boxed `[JsSymbol]`.
@@ -633,9 +650,12 @@ impl NanBoxedValue {
     /// Returns the value as a boxed `[JsObject]`.
     #[must_use]
     #[inline(always)]
-    pub(crate) const fn as_object(&self) -> Option<&JsObject> {
+    pub(crate) fn as_object(&self) -> Option<JsObject> {
         if self.is_object() {
-            Some(unsafe { bits::untag_pointer::<'_, JsObject>(self.0) })
+            let obj = unsafe { bits::untag_object_owned(self.0) };
+            let o = obj.clone();
+            core::mem::forget(obj); // Prevent double drop.
+            Some(o)
         } else {
             None
         }
@@ -666,9 +686,14 @@ impl NanBoxedValue {
     /// Returns the `[JsVariant]` of this inner value.
     #[must_use]
     #[inline(always)]
-    pub(crate) const fn as_variant(&self) -> JsVariant<'_> {
+    pub(crate) fn as_variant(&self) -> JsVariant<'_> {
         match self.0 & bits::MASK_KIND {
-            bits::MASK_OBJECT => JsVariant::Object(unsafe { bits::untag_pointer(self.0) }),
+            bits::MASK_OBJECT => {
+                let obj = unsafe { bits::untag_object_owned(self.0) };
+                let o = obj.clone();
+                core::mem::forget(obj); // Prevent double drop.
+                JsVariant::Object(o)
+            }
             bits::MASK_STRING => JsVariant::String(unsafe { bits::untag_pointer(self.0) }),
             bits::MASK_SYMBOL => JsVariant::Symbol(unsafe { bits::untag_pointer(self.0) }),
             bits::MASK_BIGINT => JsVariant::BigInt(unsafe { bits::untag_pointer(self.0) }),
@@ -687,7 +712,7 @@ impl Drop for NanBoxedValue {
     #[inline(always)]
     fn drop(&mut self) {
         match self.0 & bits::MASK_KIND {
-            bits::MASK_OBJECT => drop(unsafe { bits::untag_pointer_owned::<JsObject>(self.0) }),
+            bits::MASK_OBJECT => drop(unsafe { bits::untag_object_owned(self.0) }),
             bits::MASK_STRING => drop(unsafe { bits::untag_pointer_owned::<JsString>(self.0) }),
             bits::MASK_SYMBOL => drop(unsafe { bits::untag_pointer_owned::<JsSymbol>(self.0) }),
             bits::MASK_BIGINT => drop(unsafe { bits::untag_pointer_owned::<JsBigInt>(self.0) }),
@@ -779,8 +804,8 @@ macro_rules! assert_type {
     ($value: ident is object($scalar: ident)) => {
         assert_type!(@@is $value, 0, 0, 0, 0, 0, 0, 0, 1, 0);
         assert_type!(@@as $value, 0, 0, 0, 0, 0, 0, 0, 1, 0);
-        assert_eq!(Some(&$scalar), $value.as_object());
-        assert_eq!($value.as_variant(), JsVariant::Object(&$scalar));
+        assert_eq!(Some(&$scalar), $value.as_object().as_ref());
+        assert_eq!($value.as_variant(), JsVariant::Object($scalar));
     };
     ($value: ident is symbol($scalar: ident)) => {
         assert_type!(@@is $value, 0, 0, 0, 0, 0, 0, 0, 0, 1);

--- a/core/engine/src/value/type.rs
+++ b/core/engine/src/value/type.rs
@@ -37,7 +37,7 @@ impl JsValue {
     ///
     /// Check [`JsValue::type_of`] if you need to call the `typeof` operator.
     #[must_use]
-    pub const fn get_type(&self) -> Type {
+    pub fn get_type(&self) -> Type {
         match self.variant() {
             JsVariant::Float64(_) | JsVariant::Integer32(_) => Type::Number,
             JsVariant::String(_) => Type::String,

--- a/core/engine/src/value/variant.rs
+++ b/core/engine/src/value/variant.rs
@@ -24,7 +24,7 @@ pub enum JsVariant<'a> {
     /// `BigInt` - holds any arbitrary large signed integer.
     BigInt(&'a JsBigInt),
     /// `Object` - An object, such as `Math`, represented by a binary tree of string keys to Javascript values.
-    Object(&'a JsObject),
+    Object(JsObject),
     /// `Symbol` - A Symbol Primitive type.
     Symbol(&'a JsSymbol),
 }

--- a/core/engine/src/vm/mod.rs
+++ b/core/engine/src/vm/mod.rs
@@ -256,21 +256,18 @@ impl Stack {
             .stack
             .get(frame.promise_capability_promise_register_index())
             .expect("stack must have a promise capability")
-            .as_object()
-            .cloned()?;
+            .as_object()?;
         let resolve = self
             .stack
             .get(frame.promise_capability_resolve_register_index())
             .expect("stack must have a resolve function")
             .as_object()
-            .cloned()
             .and_then(JsFunction::from_object)?;
         let reject = self
             .stack
             .get(frame.promise_capability_reject_register_index())
             .expect("stack must have a reject function")
             .as_object()
-            .cloned()
             .and_then(JsFunction::from_object)?;
 
         Some(PromiseCapability {
@@ -296,7 +293,6 @@ impl Stack {
             .get(frame.async_generator_object_register_index())
             .expect("stack must have an async generator object")
             .as_object()
-            .cloned()
     }
 
     /// Push a value on the stack.

--- a/core/engine/src/vm/opcode/call/mod.rs
+++ b/core/engine/src/vm/opcode/call/mod.rs
@@ -40,7 +40,7 @@ impl CallEval {
         // 6. If ref is a Reference Record, IsPropertyReference(ref) is false, and ref.[[ReferencedName]] is "eval", then
         //     a. If SameValue(func, %eval%) is true, then
         let eval = context.intrinsics().objects().eval();
-        if JsObject::equals(object, &eval) {
+        if JsObject::equals(&object, &eval) {
             let arguments = context
                 .vm
                 .stack
@@ -110,7 +110,7 @@ impl CallEvalSpread {
 
         let func = context.vm.stack.calling_convention_get_function(0);
 
-        let Some(object) = func.as_object().cloned() else {
+        let Some(object) = func.as_object() else {
             return Err(JsNativeError::typ()
                 .with_message("not a callable function")
                 .into());

--- a/core/engine/src/vm/opcode/define/class/getter.rs
+++ b/core/engine/src/vm/opcode/define/class/getter.rs
@@ -34,7 +34,7 @@ impl DefineClassStaticGetterByName {
             let function_object = function
                 .as_object()
                 .expect("method must be function object");
-            set_function_name(function_object, &key, Some(js_str!("get")), context);
+            set_function_name(&function_object, &key, Some(js_str!("get")), context);
             function_object
                 .downcast_mut::<OrdinaryFunction>()
                 .expect("method must be function object")
@@ -91,7 +91,7 @@ impl DefineClassGetterByName {
             let function_object = function
                 .as_object()
                 .expect("method must be function object");
-            set_function_name(function_object, &key, Some(js_str!("get")), context);
+            set_function_name(&function_object, &key, Some(js_str!("get")), context);
             function_object
                 .downcast_mut::<OrdinaryFunction>()
                 .expect("method must be function object")
@@ -146,7 +146,7 @@ impl DefineClassStaticGetterByValue {
             let function_object = function
                 .as_object()
                 .expect("method must be function object");
-            set_function_name(function_object, &key, Some(js_str!("get")), context);
+            set_function_name(&function_object, &key, Some(js_str!("get")), context);
             function_object
                 .downcast_mut::<OrdinaryFunction>()
                 .expect("method must be function object")
@@ -202,7 +202,7 @@ impl DefineClassGetterByValue {
             let function_object = function
                 .as_object()
                 .expect("method must be function object");
-            set_function_name(function_object, &key, Some(js_str!("get")), context);
+            set_function_name(&function_object, &key, Some(js_str!("get")), context);
             function_object
                 .downcast_mut::<OrdinaryFunction>()
                 .expect("method must be function object")

--- a/core/engine/src/vm/opcode/define/class/method.rs
+++ b/core/engine/src/vm/opcode/define/class/method.rs
@@ -32,7 +32,7 @@ impl DefineClassStaticMethodByName {
             let function_object = function
                 .as_object()
                 .expect("method must be function object");
-            set_function_name(function_object, &key, None, context);
+            set_function_name(&function_object, &key, None, context);
             function_object
                 .downcast_mut::<OrdinaryFunction>()
                 .expect("method must be function object")
@@ -85,7 +85,7 @@ impl DefineClassMethodByName {
             let function_object = function
                 .as_object()
                 .expect("method must be function object");
-            set_function_name(function_object, &key, None, context);
+            set_function_name(&function_object, &key, None, context);
             function_object
                 .downcast_mut::<OrdinaryFunction>()
                 .expect("method must be function object")
@@ -136,7 +136,7 @@ impl DefineClassStaticMethodByValue {
             let function_object = function
                 .as_object()
                 .expect("method must be function object");
-            set_function_name(function_object, &key, None, context);
+            set_function_name(&function_object, &key, None, context);
             function_object
                 .downcast_mut::<OrdinaryFunction>()
                 .expect("method must be function object")
@@ -187,7 +187,7 @@ impl DefineClassMethodByValue {
             let function_object = function
                 .as_object()
                 .expect("method must be function object");
-            set_function_name(function_object, &key, None, context);
+            set_function_name(&function_object, &key, None, context);
             function_object
                 .downcast_mut::<OrdinaryFunction>()
                 .expect("method must be function object")

--- a/core/engine/src/vm/opcode/define/class/setter.rs
+++ b/core/engine/src/vm/opcode/define/class/setter.rs
@@ -34,7 +34,7 @@ impl DefineClassStaticSetterByName {
             let function_object = function
                 .as_object()
                 .expect("method must be function object");
-            set_function_name(function_object, &key, Some(js_str!("set")), context);
+            set_function_name(&function_object, &key, Some(js_str!("set")), context);
             function_object
                 .downcast_mut::<OrdinaryFunction>()
                 .expect("method must be function object")
@@ -92,7 +92,7 @@ impl DefineClassSetterByName {
             let function_object = function
                 .as_object()
                 .expect("method must be function object");
-            set_function_name(function_object, &key, Some(js_str!("set")), context);
+            set_function_name(&function_object, &key, Some(js_str!("set")), context);
             function_object
                 .downcast_mut::<OrdinaryFunction>()
                 .expect("method must be function object")
@@ -149,7 +149,7 @@ impl DefineClassStaticSetterByValue {
             let function_object = function
                 .as_object()
                 .expect("method must be function object");
-            set_function_name(function_object, &key, Some(js_str!("set")), context);
+            set_function_name(&function_object, &key, Some(js_str!("set")), context);
             function_object
                 .downcast_mut::<OrdinaryFunction>()
                 .expect("method must be function object")
@@ -206,7 +206,7 @@ impl DefineClassSetterByValue {
             let function_object = function
                 .as_object()
                 .expect("method must be function object");
-            set_function_name(function_object, &key, Some(js_str!("set")), context);
+            set_function_name(&function_object, &key, Some(js_str!("set")), context);
             function_object
                 .downcast_mut::<OrdinaryFunction>()
                 .expect("method must be function object")

--- a/core/engine/src/vm/opcode/environment/mod.rs
+++ b/core/engine/src/vm/opcode/environment/mod.rs
@@ -95,8 +95,8 @@ impl Super {
                 .downcast_ref::<OrdinaryFunction>()
                 .expect("must be function object")
                 .get_home_object()
-                .or(this.as_object())
                 .cloned()
+                .or(this.as_object())
         };
 
         let value = home_object

--- a/core/engine/src/vm/opcode/generator/mod.rs
+++ b/core/engine/src/vm/opcode/generator/mod.rs
@@ -42,16 +42,13 @@ impl Generator {
             .get(PROTOTYPE, context)
             .expect("generator must have a prototype property")
             .as_object()
-            .map_or_else(
-                || {
-                    if r#async {
-                        context.intrinsics().objects().async_generator()
-                    } else {
-                        context.intrinsics().objects().generator()
-                    }
-                },
-                Clone::clone,
-            );
+            .unwrap_or_else(|| {
+                if r#async {
+                    context.intrinsics().objects().async_generator()
+                } else {
+                    context.intrinsics().objects().generator()
+                }
+            });
 
         let generator = if r#async {
             JsObject::from_proto_and_data_with_shared_shape(

--- a/core/engine/src/vm/opcode/set/property.rs
+++ b/core/engine/src/vm/opcode/set/property.rs
@@ -384,7 +384,7 @@ impl SetFunctionName {
         };
 
         set_function_name(
-            function.as_object().expect("function is not an object"),
+            &function.as_object().expect("function is not an object"),
             &name,
             prefix,
             context,

--- a/core/gc/src/cell.rs
+++ b/core/gc/src/cell.rs
@@ -255,6 +255,29 @@ pub struct GcRef<'a, T: ?Sized + 'static> {
 }
 
 impl<'a, T: ?Sized> GcRef<'a, T> {
+    /// Casts to a `GcRef` of another type.
+    ///
+    /// # Safety
+    /// * The caller must ensure that `T` can be safeley cast to `U`.
+    #[must_use]
+    pub unsafe fn cast<U>(self) -> GcRef<'a, U> {
+        let value = ptr::from_ref(self.value);
+
+        // SAFETY: This is safe as `GcCellRef` is already borrowed, so the value is rooted.
+        // The caller must ensure that `T` can be safeley cast to `U`.
+        let value = unsafe { &*(value.cast::<U>()) };
+        let cell = GcRef {
+            flags: self.flags,
+            value,
+        };
+
+        // We have to tell the compiler not to call the destructor of GcCellRef,
+        // because it will update the borrow flags.
+        core::mem::forget(self);
+
+        cell
+    }
+
     /// Copies a `GcCellRef`.
     ///
     /// The `GcCell` is already immutably borrowed, so this cannot fail.
@@ -391,6 +414,30 @@ pub struct GcRefMut<'a, T: ?Sized + 'static, U: ?Sized = T> {
 }
 
 impl<'a, T: ?Sized, U: ?Sized> GcRefMut<'a, T, U> {
+    /// Casts to a `GcRefMut` of another type.
+    ///
+    /// # Safety
+    /// * The caller must ensure that `U` can be safeley cast to `V`.
+    #[must_use]
+    pub unsafe fn cast<V>(self) -> GcRefMut<'a, T, V> {
+        let value = ptr::from_mut::<U>(self.value);
+
+        // SAFETY: This is safe as `GcCellRefMut` is already borrowed, so the value is rooted.
+        // The caller must ensure that `U` can be safeley cast to `V`.
+        let value = unsafe { &mut *(value.cast::<V>()) };
+
+        let cell = GcRefMut {
+            gc_cell: self.gc_cell,
+            value,
+        };
+
+        // We have to tell the compiler not to call the destructor of GcCellRef,
+        // because it will update the borrow flags.
+        std::mem::forget(self);
+
+        cell
+    }
+
     /// Tries to make a new `GcCellRefMut` for a component of the borrowed data, returning `None`
     /// if the mapping function returns `None`.
     ///

--- a/core/gc/src/pointers/gc.rs
+++ b/core/gc/src/pointers/gc.rs
@@ -282,10 +282,6 @@ impl<T: Trace + ?Sized> Gc<T> {
             inner_ptr,
             marker: PhantomData,
         }
-
-        // SAFETY: Casting a Gc<T> to a Gc<U> of any type is safe, as long as you don’t actually access it as a U.
-        //         The correct functions for T will still be called during tracing, finalization, and dropping.
-        // unsafe { (*(&raw const *this).cast::<Gc<U>>()).clone() }
     }
 
     /// Returns reference to the inner value of type `T`.

--- a/core/interop/tests/embedded.rs
+++ b/core/interop/tests/embedded.rs
@@ -45,7 +45,6 @@ fn load_module_and_test(module_loader: &Rc<EmbeddedModuleLoader>) {
                 .get(js_string!("bar"), &mut context)
                 .unwrap()
                 .as_callable()
-                .cloned()
                 .unwrap();
             let value = bar.call(&JsValue::undefined(), &[], &mut context).unwrap();
             assert_eq!(

--- a/core/macros/src/class.rs
+++ b/core/macros/src/class.rs
@@ -58,12 +58,14 @@ impl Function {
         // `&mut self`
         let downcast = if receiver.mutability.is_some() {
             quote! {
-                let self_ = &mut *this.as_downcast_mut::< #class_ty >()
+                let object = this.as_object();
+                let self_ = &mut *object.as_ref().and_then(|o| o.downcast_mut::< #class_ty >())
                     .ok_or( boa_engine::js_error!( #err ))?;
             }
         } else {
             quote! {
-                let self_ = &*this.as_downcast_ref::< #class_ty >()
+                let object = this.as_object();
+                let self_ = &*object.as_ref().and_then(|o| o.downcast_ref::< #class_ty >())
                     .ok_or( boa_engine::js_error!( #err ))?;
             }
         };

--- a/examples/src/bin/closures.rs
+++ b/examples/src/bin/closures.rs
@@ -172,7 +172,6 @@ fn main() -> Result<(), JsError> {
     let result = context.eval(Source::from_bytes("enumerate()"))?;
     let object = result
         .as_object()
-        .cloned()
         .ok_or_else(|| JsNativeError::typ().with_message("not an array!"))?;
     let array = JsArray::from_object(object)?;
 
@@ -183,7 +182,6 @@ fn main() -> Result<(), JsError> {
     let result = context.eval(Source::from_bytes("enumerate()"))?;
     let object = result
         .as_object()
-        .cloned()
         .ok_or_else(|| JsNativeError::typ().with_message("not an array!"))?;
     let array = JsArray::from_object(object)?;
 

--- a/examples/src/bin/modules.rs
+++ b/examples/src/bin/modules.rs
@@ -114,7 +114,6 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mix = namespace
         .get(js_string!("mix"), context)?
         .as_callable()
-        .cloned()
         .ok_or_else(|| JsNativeError::typ().with_message("mix export wasn't a function!"))?;
     let result = mix.call(&JsValue::undefined(), &[5.into(), 10.into()], context)?;
 

--- a/examples/src/bin/smol_event_loop.rs
+++ b/examples/src/bin/smol_event_loop.rs
@@ -173,7 +173,7 @@ fn delay(
 // Example interval function. We cannot use a function returning async in this case since it would
 // borrow the context for too long, but using a `NativeAsyncJob` we can!
 fn interval(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-    let Some(function) = args.get_or_undefined(0).as_callable().cloned() else {
+    let Some(function) = args.get_or_undefined(0).as_callable() else {
         return Err(JsNativeError::typ()
             .with_message("arg must be a callable")
             .into());

--- a/examples/src/bin/synthetic.rs
+++ b/examples/src/bin/synthetic.rs
@@ -89,7 +89,6 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mix = namespace
         .get(js_string!("mix"), context)?
         .as_callable()
-        .cloned()
         .ok_or_else(|| JsNativeError::typ().with_message("mix export wasn't a function!"))?;
     let result = mix.call(&JsValue::undefined(), &[5.into(), 10.into()], context)?;
 

--- a/examples/src/bin/tokio_event_loop.rs
+++ b/examples/src/bin/tokio_event_loop.rs
@@ -181,7 +181,7 @@ fn delay(
 // Example interval function. We cannot use a function returning async in this case since it would
 // borrow the context for too long, but using a `NativeAsyncJob` we can!
 fn interval(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-    let Some(function) = args.get_or_undefined(0).as_callable().cloned() else {
+    let Some(function) = args.get_or_undefined(0).as_callable() else {
         return Err(JsNativeError::typ()
             .with_message("arg must be a callable")
             .into());

--- a/tests/tester/src/exec/js262.rs
+++ b/tests/tester/src/exec/js262.rs
@@ -135,15 +135,11 @@ fn detach_array_buffer(_: &JsValue, args: &[JsValue], _: &mut Context) -> JsResu
         JsNativeError::typ().with_message("The provided object was not an ArrayBuffer")
     }
 
-    let array_buffer = args
+    // 1. Assert: IsSharedArrayBuffer(arrayBuffer) is false.
+    let mut array_buffer = args
         .first()
         .and_then(JsValue::as_object)
-        .ok_or_else(type_err)?;
-    let mut array_buffer = array_buffer.borrow_mut();
-
-    // 1. Assert: IsSharedArrayBuffer(arrayBuffer) is false.
-    let array_buffer = array_buffer
-        .downcast_mut::<ArrayBuffer>()
+        .and_then(|o| o.downcast_mut::<ArrayBuffer>())
         .ok_or_else(type_err)?;
 
     // 2. If key is not present, set key to undefined.

--- a/tests/tester/src/exec/js262.rs
+++ b/tests/tester/src/exec/js262.rs
@@ -136,9 +136,9 @@ fn detach_array_buffer(_: &JsValue, args: &[JsValue], _: &mut Context) -> JsResu
     }
 
     // 1. Assert: IsSharedArrayBuffer(arrayBuffer) is false.
-    let mut array_buffer = args
-        .first()
-        .and_then(JsValue::as_object)
+    let object = args.first().and_then(JsValue::as_object);
+    let mut array_buffer = object
+        .as_ref()
         .and_then(|o| o.downcast_mut::<ArrayBuffer>())
         .ok_or_else(type_err)?;
 


### PR DESCRIPTION
This is currently a draft, since I think there are some important design decisions that need to be discussed.If you look at this, best is to review the changes commit by commit.

This PR contains two changes that can be best viewed separately.

1. [Refactor `JsObject` to always be a size 8 thin pointer (`Gc<T: Sized>`).](https://github.com/boa-dev/boa/commit/89c136ab2b0cbbbfdc7467a5b0f2c2c4ea72928b)
2. [Building on 1., remove the `Box` from the nan-boxed `JsObject` value.](https://github.com/boa-dev/boa/commit/8aa6d2af956a1ead9610c7e80c287d93ca9e0ba0)


## Motivation

I think the ideal representation for `JsObject` and `JsValue` should be a `no Drop` + `Copy` size 8 value. Currently we have a lot of drop and clone code in our runtime, caused by our ref-counting GC, as well as a lot of `Box` allocations from our current nan-box creation / clones. Hopefully we can get rid of the `Drop` and `Clone` requirements for `Gc` in the future. Then we could also move all other pointer types (`JsString`, `JsSymbol` and `JsBigInt`) to be `Gc` values, to enable `JsValue` to be `Copy`.

## Refactor `JsObject` to always be a size 8 thin pointer (`Gc<T: Sized>`)

Currently our `JsObject` type can be either typed (e.g. `JsObject<u64>`) or erased (e.g. `JsObject` == `JsObject<dyn NativeObject>)`. While there is only a `Gc` field on `JsObject`, the erased variant is a size 16 fat pointer, to store the Rust DST vtable for `dyn NativeObject`. The goal of this change is to make `JsObject` always a transparent size 8 thin pointer (`Gc`) to enable storing it directly as a nan-boxed value.

Here are the requirements for `JsObject` that I tried to keep:

* `JsObject` needs to be a size 8 thin pointer.
* Typed and erased variants should be one struct (erased being the default).
  * Possible alternative: `JsObject` could be a non generic struct and `JsObject::downcast` could return a typed struct. The positive of this approach would be, that access to the data T of the object can be controlled better, which would probably make everything safer. One drawback, that I currently see, is, that functions that should work on `JsObject<T>` would have to be either specific to one variant, or need to be implemented twice. I have not tried this approach, but I think in theory it should be possible.
* Any type that implements `NativeObject` should be able to be used as `T` for `JsObject` without any other user interactions (e.g. registering the type, manual unsafe vtable implementation, ...)

This lead me to the current design in this PR. Instead of erasing the object into a `dyn NativeObject`, the `TypeId` is stored in the object itself and used to check during casts. The default `T` is erased into a size 0 struct. I don't really like this approach, since one could access the erased struct. It might also be that some of this is inherently unsafe. Any ideas are welcome.


## Using the `JsObject` `Gc` pointer as the value for nan boxing.

At first this seems straight forward. But since there is no additional `Box` around the real value, it seems to me, that returning a reference to the `JsObject` from a nan boxed `JsValue` is impossible.
This alters the `JsValue::as_object` API to return a `Option<JsObject>` instead of `Option<&JsObject>`, which cascades out into some breaking changes in our `JsValue` APIs and some arguably less ergonomic usage patterns.
I think we should break the APIs, since when we move all pointer types and `JsValue` to being `Copy`, we basically don't want to work with references to those types anyway and always take them as values. This would of course mean a lot of breaking changes in our APIs, but I think it would be the logical thing to do.

## Benchmarks

The current changes obviously don't change anything related to the GC, but removing the additional `Box` for nan-boxed `JsObject`s seems to already make a difference. Local benchmark results:

Before

```
RESULT Richards 221
RESULT DeltaBlue 218
RESULT Crypto 208
RESULT RayTrace 485
RESULT EarleyBoyer 591
RESULT RegExp 104
RESULT Splay 829
RESULT NavierStokes 485
SCORE 324
```

After

```
RESULT Richards 276
RESULT DeltaBlue 281
RESULT Crypto 226
RESULT RayTrace 587
RESULT EarleyBoyer 721
RESULT RegExp 110
RESULT Splay 1039
RESULT NavierStokes 513
SCORE 380
```
