### PR TITLE
Bump Test262 hash commit and cleanup test features

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,6 @@
 [target.wasm32-unknown-unknown]
 rustflags = '--cfg getrandom_backend="wasm_js"'
+
+# TODO: track https://github.com/rust-lang/rust/issues/141626 for a resolution
+[target.x86_64-pc-windows-msvc]
+linker = "rust-lld"

--- a/test262_config.toml
+++ b/test262_config.toml
@@ -1,4 +1,4 @@
-commit = "8296db887368bbffa3379f995a1e628ddbe8421f"
+commit = "a073f479f80b336256b7fc4e04700c827293e2fe"
 
 [ignored]
 # Not implemented yet:
@@ -13,6 +13,13 @@ features = [
     "Intl.DisplayNames",
     "Intl.RelativeTimeFormat",
     "Intl-enumeration",
+    "import-attributes",
+    "json-modules",
+    "Intl.DurationFormat",
+    "regexp-duplicate-named-groups",
+    "RegExp.escape",
+    "iterator-helpers",
+    "Float16Array",
 
     ### Pending proposals
 
@@ -22,47 +29,32 @@ features = [
     # https://github.com/tc39/proposal-regexp-legacy-features
     "legacy-regexp",
 
-    # Import Attributes
-    # https://github.com/tc39/proposal-import-attributes/
-    "import-attributes",
-
-    # https://github.com/tc39/proposal-import-attributes
-    "import-assertions",
-
     # https://github.com/tc39/proposal-defer-import-eval
     "import-defer",
 
     # https://github.com/tc39/proposal-iterator-sequencing
     "iterator-sequencing",
 
-    # https://github.com/tc39/proposal-json-modules
-    "json-modules",
-
     # https://github.com/tc39/proposal-realms
     "ShadowRealm",
-
-    # https://github.com/tc39/proposal-intl-duration-format
-    "Intl.DurationFormat",
 
     # https://github.com/tc39/proposal-decorators
     "decorators",
 
-    # https://github.com/tc39/proposal-duplicate-named-capturing-groups
-    "regexp-duplicate-named-groups",
-
     # https://github.com/tc39/proposal-json-parse-with-source
     "json-parse-with-source",
-
-    # RegExp.escape
-    # https://github.com/tc39/proposal-regex-escaping
-    "RegExp.escape",
-
-    # https://github.com/tc39/proposal-iterator-helpers
-    "iterator-helpers",
 
     # Uint8Array Base64
     # https://github.com/tc39/proposal-arraybuffer-base64
     "uint8array-base64",
+
+    # Time Zone Canonicalization
+    # https://github.com/tc39/proposal-canonical-tz
+    "canonical-tz",
+
+    # Upsert
+    # https://github.com/tc39/proposal-upsert
+    "upsert",
 
     ### Non-standard
     "caller",

--- a/tests/tester/src/edition.rs
+++ b/tests/tester/src/edition.rs
@@ -13,10 +13,6 @@ use crate::read::{MetaData, TestFlag};
 static FEATURE_EDITION: phf::Map<&'static str, SpecEdition> = phf::phf_map! {
     // Proposed language features
 
-    // Error.isError
-    // https://github.com/tc39/proposal-is-error
-    "Error.isError" => SpecEdition::ESNext,
-
     // Intl.Locale Info
     // https://github.com/tc39/proposal-intl-locale-info
     "Intl.Locale-info"  => SpecEdition::ESNext,
@@ -25,37 +21,25 @@ static FEATURE_EDITION: phf::Map<&'static str, SpecEdition> = phf::phf_map! {
     // https://github.com/tc39/proposal-cleanup-some
     "FinalizationRegistry.prototype.cleanupSome" => SpecEdition::ESNext,
 
-    // Intl.NumberFormat V3
-    // https://github.com/tc39/proposal-intl-numberformat-v3
-    "Intl.NumberFormat-v3" => SpecEdition::ESNext,
-
     // Legacy RegExp features
     // https://github.com/tc39/proposal-regexp-legacy-features
     "legacy-regexp"  => SpecEdition::ESNext,
-
-    // Import Attributes
-    // https://github.com/tc39/proposal-import-attributes/
-    "import-attributes" => SpecEdition::ESNext,
 
     // Import Defer
     // https://tc39.es/proposal-defer-import-eval
     "import-defer" => SpecEdition::ESNext,
 
-    // Import Assertions
-    // https://github.com/tc39/proposal-import-assertions/
-    "import-assertions"  => SpecEdition::ESNext,
-
     // Iterator sequencing
     // https://github.com/tc39/proposal-iterator-sequencing
     "iterator-sequencing" => SpecEdition::ESNext,
 
-    // JSON modules
-    // https://github.com/tc39/proposal-json-modules
-    "json-modules"  => SpecEdition::ESNext,
+    // Time Zone Canonicalization
+    // https://github.com/tc39/proposal-canonical-tz
+    "canonical-tz" => SpecEdition::ESNext,
 
-    // ArrayBuffer transfer
-    // https://github.com/tc39/proposal-arraybuffer-transfer
-    "arraybuffer-transfer" => SpecEdition::ESNext,
+    // Upsert
+    // https://github.com/tc39/proposal-upsert
+    "upsert" => SpecEdition::ESNext,
 
     // Temporal
     // https://github.com/tc39/proposal-temporal
@@ -65,17 +49,9 @@ static FEATURE_EDITION: phf::Map<&'static str, SpecEdition> = phf::phf_map! {
     // https://github.com/tc39/proposal-realms
     "ShadowRealm" => SpecEdition::ESNext,
 
-    // Intl.DurationFormat
-    // https://github.com/tc39/proposal-intl-duration-format
-    "Intl.DurationFormat" => SpecEdition::ESNext,
-
     // Decorators
     // https://github.com/tc39/proposal-decorators
     "decorators" => SpecEdition::ESNext,
-
-    // Duplicate named capturing groups
-    // https://github.com/tc39/proposal-duplicate-named-capturing-groups
-    "regexp-duplicate-named-groups" => SpecEdition::ESNext,
 
     // Array.fromAsync
     // https://github.com/tc39/proposal-array-from-async
@@ -85,29 +61,13 @@ static FEATURE_EDITION: phf::Map<&'static str, SpecEdition> = phf::phf_map! {
     // https://github.com/tc39/proposal-json-parse-with-source
     "json-parse-with-source" => SpecEdition::ESNext,
 
-    // RegExp.escape
-    // https://github.com/tc39/proposal-regex-escaping
-    "RegExp.escape" => SpecEdition::ESNext,
-
     // Regular expression modifiers
     // https://github.com/tc39/proposal-regexp-modifiers
     "regexp-modifiers" => SpecEdition::ESNext,
 
-    // Iterator Helpers
-    // https://github.com/tc39/proposal-iterator-helpers
-    "iterator-helpers" => SpecEdition::ESNext,
-
-    // Promise.try
-    // https://github.com/tc39/proposal-promise-try
-    "promise-try" => SpecEdition::ESNext,
-
     // Explicit Resource Management
     // https://github.com/tc39/proposal-explicit-resource-management
     "explicit-resource-management" => SpecEdition::ESNext,
-
-    // Float16Array + Math.f16round
-    // https://github.com/tc39/proposal-float16array
-    "Float16Array" => SpecEdition::ESNext,
 
     // Math.sumPrecise
     // https://github.com/tc39/proposal-math-sum
@@ -126,6 +86,48 @@ static FEATURE_EDITION: phf::Map<&'static str, SpecEdition> = phf::phf_map! {
     // Atomics.pause
     // https://github.com/tc39/proposal-atomics-microwait
     "Atomics.pause" => SpecEdition::ESNext,
+
+    // ===== Next ES version =====
+
+    // Error.isError
+    // https://github.com/tc39/proposal-is-error
+    "Error.isError" => SpecEdition::ESNext,
+
+    // Import Attributes
+    // https://github.com/tc39/proposal-import-attributes/
+    "import-attributes" => SpecEdition::ESNext,
+
+    // JSON modules
+    // https://github.com/tc39/proposal-json-modules
+    "json-modules"  => SpecEdition::ESNext,
+
+    // ArrayBuffer transfer
+    // https://github.com/tc39/proposal-arraybuffer-transfer
+    "arraybuffer-transfer" => SpecEdition::ESNext,
+
+    // Intl.DurationFormat
+    // https://github.com/tc39/proposal-intl-duration-format
+    "Intl.DurationFormat" => SpecEdition::ESNext,
+
+    // Duplicate named capturing groups
+    // https://github.com/tc39/proposal-duplicate-named-capturing-groups
+    "regexp-duplicate-named-groups" => SpecEdition::ESNext,
+
+    // RegExp.escape
+    // https://github.com/tc39/proposal-regex-escaping
+    "RegExp.escape" => SpecEdition::ESNext,
+
+    // Iterator Helpers
+    // https://github.com/tc39/proposal-iterator-helpers
+    "iterator-helpers" => SpecEdition::ESNext,
+
+    // Promise.try
+    // https://github.com/tc39/proposal-promise-try
+    "promise-try" => SpecEdition::ESNext,
+
+    // Float16Array + Math.f16round
+    // https://github.com/tc39/proposal-float16array
+    "Float16Array" => SpecEdition::ESNext,
 
     // Standard language features
     "AggregateError" => SpecEdition::ES12,
@@ -200,6 +202,7 @@ static FEATURE_EDITION: phf::Map<&'static str, SpecEdition> = phf::phf_map! {
     "Intl.ListFormat" => SpecEdition::ES12,
     "Intl.Locale" => SpecEdition::ES12,
     "Intl.NumberFormat-unified" => SpecEdition::ES11,
+    "Intl.NumberFormat-v3" => SpecEdition::ES14,
     "Intl.RelativeTimeFormat" => SpecEdition::ES11,
     "Intl.Segmenter" => SpecEdition::ES13,
     "json-superset" => SpecEdition::ES10,


### PR DESCRIPTION
Another day, another Test262 bump.

Had to cleanup a couple of feature names, because some of them were included into ES2025, and two new ones were added.
