### PR TITLE
Fix panics on staging TypedArray.slice tests

### DIFF
--- a/core/engine/src/builtins/array_buffer/mod.rs
+++ b/core/engine/src/builtins/array_buffer/mod.rs
@@ -177,6 +177,7 @@ impl BufferObject {
 
     /// Returns `true` if the buffer objects point to the same buffer.
     #[inline]
+    #[track_caller]
     pub(crate) fn equals(lhs: &Self, rhs: &Self) -> bool {
         match (lhs, rhs) {
             (BufferObject::Buffer(lhs), BufferObject::Buffer(rhs)) => JsObject::equals(lhs, rhs),

--- a/core/engine/src/builtins/array_buffer/utils.rs
+++ b/core/engine/src/builtins/array_buffer/utils.rs
@@ -209,6 +209,7 @@ impl SliceRefMut<'_> {
     }
 
     /// Gets a subslice of this `SliceRefMut`.
+    #[expect(unused, reason = "could still be useful in the future")]
     pub(crate) fn subslice<I>(&self, index: I) -> SliceRef<'_>
     where
         I: SliceIndex<[u8], Output = [u8]> + SliceIndex<[AtomicU8], Output = [AtomicU8]>,

--- a/core/engine/src/builtins/typed_array/builtin.rs
+++ b/core/engine/src/builtins/typed_array/builtin.rs
@@ -2048,8 +2048,8 @@ impl BuiltinTypedArray {
 
         // a. Set taRecord to MakeTypedArrayWithBufferWitnessRecord(O, seq-cst).
         // b. If IsTypedArrayOutOfBounds(taRecord) is true, throw a TypeError exception.
-        let mut src_buf_borrow = src_borrow.data.viewed_array_buffer().as_buffer_mut();
-        let Some(mut src_buf) = src_buf_borrow
+        let src_buf_borrow = src_borrow.data.viewed_array_buffer().as_buffer();
+        let Some(src_buf) = src_buf_borrow
             .bytes(Ordering::SeqCst)
             .filter(|s| !src_borrow.data.is_out_of_bounds(s.len()))
         else {
@@ -2058,8 +2058,10 @@ impl BuiltinTypedArray {
                 .into());
         };
 
+        let src_buf_len = src_buf.len();
+
         // c. Set endIndex to min(endIndex, TypedArrayLength(taRecord)).
-        let end_index = min(end_index, src_borrow.data.array_length(src_buf.len()));
+        let end_index = min(end_index, src_borrow.data.array_length(src_buf_len));
 
         // d. Set countBytes to max(endIndex - startIndex, 0).
         let count = end_index.saturating_sub(start_index) as usize;
@@ -2128,6 +2130,12 @@ impl BuiltinTypedArray {
                 target_borrow.data.viewed_array_buffer(),
             ) {
                 // cannot borrow the target mutably (overlapping bytes), but we can move the data instead.
+                drop(src_buf_borrow);
+
+                let mut src_buf_borrow = src_borrow.data.viewed_array_buffer().as_buffer_mut();
+                let mut src_buf = src_buf_borrow
+                    .bytes_with_len(src_buf_len)
+                    .expect("already checked that the buffer is not detached");
 
                 #[cfg(debug_assertions)]
                 {


### PR DESCRIPTION
Follow up from #4288.

Fixes the two panics that occurred after bumping the Test262 commit hash.