### PR TITLE
Implement backtrace information for errors

### DIFF
--- a/core/engine/src/builtins/builder.rs
+++ b/core/engine/src/builtins/builder.rs
@@ -470,6 +470,7 @@ impl BuiltInCallable<'_> {
         let object = self.realm.intrinsics().templates().function().create(
             NativeFunctionObject {
                 f: NativeFunction::from_fn_ptr(self.function),
+                name: self.name.clone(),
                 constructor: None,
                 realm: Some(self.realm.clone()),
             },

--- a/core/engine/src/builtins/error/aggregate.rs
+++ b/core/engine/src/builtins/error/aggregate.rs
@@ -21,7 +21,7 @@ use crate::{
     string::StaticJsStrings,
 };
 
-use super::Error;
+use super::{Error, ErrorKind};
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct AggregateError;
@@ -88,7 +88,7 @@ impl BuiltInConstructor for AggregateError {
         let o = JsObject::from_proto_and_data_with_shared_shape(
             context.root_shape(),
             prototype,
-            Error::Aggregate,
+            Error::with_caller_position(ErrorKind::Aggregate, context),
         );
 
         // 3. If message is not undefined, then

--- a/core/engine/src/builtins/error/eval.rs
+++ b/core/engine/src/builtins/error/eval.rs
@@ -22,7 +22,7 @@ use crate::{
     string::StaticJsStrings,
 };
 
-use super::Error;
+use super::{Error, ErrorKind};
 
 /// JavaScript `EvalError` implementation.
 #[derive(Debug, Clone, Copy)]
@@ -83,7 +83,7 @@ impl BuiltInConstructor for EvalError {
         let o = JsObject::from_proto_and_data_with_shared_shape(
             context.root_shape(),
             prototype,
-            Error::Eval,
+            Error::with_caller_position(ErrorKind::Eval, context),
         );
 
         // 3. If message is not undefined, then

--- a/core/engine/src/builtins/error/range.rs
+++ b/core/engine/src/builtins/error/range.rs
@@ -20,7 +20,7 @@ use crate::{
     string::StaticJsStrings,
 };
 
-use super::Error;
+use super::{Error, ErrorKind};
 
 /// JavaScript `RangeError` implementation.
 #[derive(Debug, Clone, Copy)]
@@ -81,7 +81,7 @@ impl BuiltInConstructor for RangeError {
         let o = JsObject::from_proto_and_data_with_shared_shape(
             context.root_shape(),
             prototype,
-            Error::Range,
+            Error::with_caller_position(ErrorKind::Range, context),
         );
 
         // 3. If message is not undefined, then

--- a/core/engine/src/builtins/error/reference.rs
+++ b/core/engine/src/builtins/error/reference.rs
@@ -20,7 +20,7 @@ use crate::{
     string::StaticJsStrings,
 };
 
-use super::Error;
+use super::{Error, ErrorKind};
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct ReferenceError;
@@ -83,7 +83,7 @@ impl BuiltInConstructor for ReferenceError {
         let o = JsObject::from_proto_and_data_with_shared_shape(
             context.root_shape(),
             prototype,
-            Error::Reference,
+            Error::with_caller_position(ErrorKind::Reference, context),
         );
 
         // 3. If message is not undefined, then

--- a/core/engine/src/builtins/error/syntax.rs
+++ b/core/engine/src/builtins/error/syntax.rs
@@ -22,7 +22,7 @@ use crate::{
     string::StaticJsStrings,
 };
 
-use super::Error;
+use super::{Error, ErrorKind};
 
 /// JavaScript `SyntaxError` implementation.
 #[derive(Debug, Clone, Copy)]
@@ -86,7 +86,7 @@ impl BuiltInConstructor for SyntaxError {
         let o = JsObject::from_proto_and_data_with_shared_shape(
             context.root_shape(),
             prototype,
-            Error::Syntax,
+            Error::with_caller_position(ErrorKind::Syntax, context),
         );
 
         // 3. If message is not undefined, then

--- a/core/engine/src/builtins/error/type.rs
+++ b/core/engine/src/builtins/error/type.rs
@@ -28,7 +28,7 @@ use crate::{
     string::StaticJsStrings,
 };
 
-use super::Error;
+use super::{Error, ErrorKind};
 
 /// JavaScript `TypeError` implementation.
 #[derive(Debug, Clone, Copy)]
@@ -89,7 +89,7 @@ impl BuiltInConstructor for TypeError {
         let o = JsObject::from_proto_and_data_with_shared_shape(
             context.root_shape(),
             prototype,
-            Error::Type,
+            Error::with_caller_position(ErrorKind::Type, context),
         );
 
         // 3. If message is not undefined, then
@@ -133,6 +133,7 @@ impl IntrinsicObject for ThrowTypeError {
                     )
                     .into())
             }),
+            name: js_string!(),
             constructor: None,
             realm: Some(realm.clone()),
         };

--- a/core/engine/src/builtins/error/uri.rs
+++ b/core/engine/src/builtins/error/uri.rs
@@ -21,7 +21,7 @@ use crate::{
     string::StaticJsStrings,
 };
 
-use super::Error;
+use super::{Error, ErrorKind};
 
 /// JavaScript `URIError` implementation.
 #[derive(Debug, Clone, Copy)]
@@ -82,7 +82,7 @@ impl BuiltInConstructor for UriError {
         let o = JsObject::from_proto_and_data_with_shared_shape(
             context.root_shape(),
             prototype,
-            Error::Uri,
+            Error::with_caller_position(ErrorKind::Uri, context),
         );
 
         // 3. If message is not undefined, then

--- a/core/engine/src/builtins/eval/mod.rs
+++ b/core/engine/src/builtins/eval/mod.rs
@@ -21,7 +21,7 @@ use crate::{
     realm::Realm,
     spanned_source_text::SourceText,
     string::StaticJsStrings,
-    vm::{CallFrame, CallFrameFlags, Constant},
+    vm::{CallFrame, CallFrameFlags, Constant, source_info::SourcePath},
 };
 use boa_ast::{
     operations::{ContainsSymbol, contains, contains_arguments},
@@ -123,7 +123,9 @@ impl Eval {
         //     c. If script Contains ScriptBody is false, return undefined.
         //     d. Let body be the ScriptBody of script.
         let x = x.to_vec();
-        let mut parser = Parser::new(Source::from_utf16(&x));
+        let source = Source::from_utf16(&x);
+
+        let mut parser = Parser::new(source);
         parser.set_identifier(context.next_parser_identifier());
         if strict {
             parser.set_strict();
@@ -263,7 +265,7 @@ impl Eval {
         let spanned_source_text = SpannedSourceText::new_source_only(source_text);
 
         let mut compiler = ByteCompiler::new(
-            js_string!("<main>"),
+            js_string!("<eval>"),
             body.strict(),
             false,
             variable_scope.clone(),
@@ -273,6 +275,8 @@ impl Eval {
             context.interner_mut(),
             in_with,
             spanned_source_text,
+            // TODO: Could give more information from previous shadow stack.
+            SourcePath::Eval,
         );
 
         compiler.current_open_environments_count += 1;

--- a/core/engine/src/builtins/function/mod.rs
+++ b/core/engine/src/builtins/function/mod.rs
@@ -880,7 +880,7 @@ impl BuiltInFunctionObject {
             .ok_or_else(|| JsNativeError::typ().with_message("not a function"))?;
 
         let code = function.codeblock();
-        if let Some(code_points) = code.source_text_spanned.to_code_points() {
+        if let Some(code_points) = code.source_info().text_spanned().to_code_points() {
             return Ok(JsString::from(code_points).into());
         }
 

--- a/core/engine/src/builtins/mod.rs
+++ b/core/engine/src/builtins/mod.rs
@@ -37,6 +37,7 @@ pub mod weak_set;
 mod builder;
 
 use builder::BuiltInBuilder;
+use error::Error;
 
 #[cfg(feature = "annex-b")]
 pub mod escape;
@@ -59,8 +60,7 @@ pub(crate) use self::{
     dataview::DataView,
     date::Date,
     error::{
-        AggregateError, Error, EvalError, RangeError, ReferenceError, SyntaxError, TypeError,
-        UriError,
+        AggregateError, EvalError, RangeError, ReferenceError, SyntaxError, TypeError, UriError,
     },
     eval::Eval,
     function::BuiltInFunctionObject,

--- a/core/engine/src/bytecompiler/class.rs
+++ b/core/engine/src/bytecompiler/class.rs
@@ -105,6 +105,7 @@ impl ByteCompiler<'_> {
             self.interner,
             self.in_with,
             spanned_source_text,
+            self.source_path.clone(),
         );
 
         compiler.code_block_flags |= CodeBlockFlags::IS_CLASS_CONSTRUCTOR;
@@ -127,7 +128,9 @@ impl ByteCompiler<'_> {
                 expr.scopes(),
             );
 
+            compiler.push_source_position(expr.span().start());
             compiler.compile_statement_list(expr.body().statement_list(), false, false);
+            compiler.pop_source_position();
 
             compiler.bytecode.emit_push_undefined(value.variable());
         } else if class.super_ref.is_some() {
@@ -412,6 +415,7 @@ impl ByteCompiler<'_> {
                         self.interner,
                         self.in_with,
                         self.spanned_source_text.clone_only_source(),
+                        self.source_path.clone(),
                     );
 
                     // Function environment
@@ -462,6 +466,7 @@ impl ByteCompiler<'_> {
                         self.interner,
                         self.in_with,
                         self.spanned_source_text.clone_only_source(),
+                        self.source_path.clone(),
                     );
                     field_compiler.code_block_flags |= CodeBlockFlags::HAS_FUNCTION_SCOPE;
                     let _ = field_compiler.push_scope(field.scope());
@@ -513,6 +518,7 @@ impl ByteCompiler<'_> {
                         self.interner,
                         self.in_with,
                         self.spanned_source_text.clone_only_source(),
+                        self.source_path.clone(),
                     );
                     field_compiler.code_block_flags |= CodeBlockFlags::HAS_FUNCTION_SCOPE;
                     let _ = field_compiler.push_scope(field.scope());
@@ -556,6 +562,7 @@ impl ByteCompiler<'_> {
                         self.interner,
                         self.in_with,
                         self.spanned_source_text.clone_only_source(),
+                        self.source_path.clone(),
                     );
                     field_compiler.code_block_flags |= CodeBlockFlags::HAS_FUNCTION_SCOPE;
                     let _ = field_compiler.push_scope(field.scope());
@@ -598,6 +605,7 @@ impl ByteCompiler<'_> {
                         self.interner,
                         self.in_with,
                         self.spanned_source_text.clone_only_source(),
+                        self.source_path.clone(),
                     );
                     compiler.code_block_flags |= CodeBlockFlags::HAS_FUNCTION_SCOPE;
                     let _ = compiler.push_scope(block.scopes().function_scope());
@@ -611,11 +619,13 @@ impl ByteCompiler<'_> {
                         block.scopes(),
                     );
 
+                    compiler.push_source_position(block.statements().span().start());
                     compiler.compile_statement_list(
                         block.statements().statement_list(),
                         false,
                         false,
                     );
+                    compiler.pop_source_position();
 
                     let code = Gc::new(compiler.finish());
                     static_elements.push(StaticElement::StaticBlock(code));

--- a/core/engine/src/bytecompiler/declarations.rs
+++ b/core/engine/src/bytecompiler/declarations.rs
@@ -537,6 +537,7 @@ impl ByteCompiler<'_> {
                 .r#async(r#async)
                 .strict(self.strict())
                 .in_with(self.in_with)
+                .source_path(self.source_path.clone())
                 .compile(
                     parameters,
                     body,

--- a/core/engine/src/bytecompiler/expression/assign.rs
+++ b/core/engine/src/bytecompiler/expression/assign.rs
@@ -1,5 +1,7 @@
 use crate::{
-    bytecompiler::{Access, BindingAccessOpcode, ByteCompiler, Label, Register, ToJsString},
+    bytecompiler::{
+        Access, BindingAccessOpcode, ByteCompiler, Label, Register, SourcePositionGuard, ToJsString,
+    },
     vm::opcode::BindingOpcode,
 };
 use boa_ast::{
@@ -13,18 +15,19 @@ use boa_ast::{
 
 impl ByteCompiler<'_> {
     pub(crate) fn compile_assign(&mut self, assign: &Assign, dst: &Register) {
-        self.push_source_position(assign.span().start());
+        let mut compiler = SourcePositionGuard::new(self, assign.span().start());
+
         if assign.op() == AssignOp::Assign {
             match Access::from_assign_target(assign.lhs()) {
                 Ok(access) => {
-                    self.access_set(access, |compiler| {
+                    compiler.access_set(access, |compiler| {
                         compiler.compile_expr(assign.rhs(), dst);
                         dst
                     });
                 }
                 Err(pattern) => {
-                    self.compile_expr(assign.rhs(), dst);
-                    self.compile_declaration_pattern(pattern, BindingOpcode::SetName, dst);
+                    compiler.compile_expr(assign.rhs(), dst);
+                    compiler.compile_declaration_pattern(pattern, BindingOpcode::SetName, dst);
                 }
             }
         } else {
@@ -132,38 +135,44 @@ impl ByteCompiler<'_> {
 
             match access {
                 Access::Variable { name } => {
-                    let name = name.to_js_string(self.interner());
+                    let name = name.to_js_string(compiler.interner());
 
-                    let binding = self.lexical_scope.get_identifier_reference(name.clone());
+                    let binding = compiler
+                        .lexical_scope
+                        .get_identifier_reference(name.clone());
                     let is_lexical = binding.is_lexical();
-                    let index = self.get_binding(&binding);
+                    let index = compiler.get_binding(&binding);
 
                     if is_lexical {
-                        self.emit_binding_access(BindingAccessOpcode::GetName, &index, dst);
+                        compiler.emit_binding_access(BindingAccessOpcode::GetName, &index, dst);
                     } else {
-                        self.emit_binding_access(
+                        compiler.emit_binding_access(
                             BindingAccessOpcode::GetNameAndLocator,
                             &index,
                             dst,
                         );
                     }
 
-                    early_exit = emit(self, dst, assign.rhs(), assign.op());
+                    early_exit = emit(&mut compiler, dst, assign.rhs(), assign.op());
 
                     if is_lexical {
-                        match self.lexical_scope.set_mutable_binding(name.clone()) {
+                        match compiler.lexical_scope.set_mutable_binding(name.clone()) {
                             Ok(binding) => {
-                                let index = self.insert_binding(binding);
-                                self.emit_binding_access(BindingAccessOpcode::SetName, &index, dst);
+                                let index = compiler.insert_binding(binding);
+                                compiler.emit_binding_access(
+                                    BindingAccessOpcode::SetName,
+                                    &index,
+                                    dst,
+                                );
                             }
                             Err(BindingLocatorError::MutateImmutable) => {
-                                let index = self.get_or_insert_string(name);
-                                self.bytecode.emit_throw_mutate_immutable(index.into());
+                                let index = compiler.get_or_insert_string(name);
+                                compiler.bytecode.emit_throw_mutate_immutable(index.into());
                             }
                             Err(BindingLocatorError::Silent) => {}
                         }
                     } else {
-                        self.emit_binding_access(
+                        compiler.emit_binding_access(
                             BindingAccessOpcode::SetNameByLocator,
                             &index,
                             dst,
@@ -173,110 +182,110 @@ impl ByteCompiler<'_> {
                 Access::Property { access } => match access {
                     PropertyAccess::Simple(access) => match access.field() {
                         PropertyAccessField::Const(name) => {
-                            let object = self.register_allocator.alloc();
-                            self.compile_expr(access.target(), &object);
+                            let object = compiler.register_allocator.alloc();
+                            compiler.compile_expr(access.target(), &object);
 
-                            self.emit_get_property_by_name(dst, &object, &object, name.sym());
+                            compiler.emit_get_property_by_name(dst, &object, &object, name.sym());
 
-                            early_exit = emit(self, dst, assign.rhs(), assign.op());
+                            early_exit = emit(&mut compiler, dst, assign.rhs(), assign.op());
 
-                            self.emit_set_property_by_name(dst, &object, &object, name.sym());
+                            compiler.emit_set_property_by_name(dst, &object, &object, name.sym());
 
-                            self.register_allocator.dealloc(object);
+                            compiler.register_allocator.dealloc(object);
                         }
                         PropertyAccessField::Expr(expr) => {
-                            let object = self.register_allocator.alloc();
-                            self.compile_expr(access.target(), &object);
+                            let object = compiler.register_allocator.alloc();
+                            compiler.compile_expr(access.target(), &object);
 
-                            let key = self.register_allocator.alloc();
-                            self.compile_expr(expr, &key);
+                            let key = compiler.register_allocator.alloc();
+                            compiler.compile_expr(expr, &key);
 
-                            self.bytecode.emit_get_property_by_value_push(
+                            compiler.bytecode.emit_get_property_by_value_push(
                                 dst.variable(),
                                 key.variable(),
                                 object.variable(),
                                 object.variable(),
                             );
 
-                            early_exit = emit(self, dst, assign.rhs(), assign.op());
+                            early_exit = emit(&mut compiler, dst, assign.rhs(), assign.op());
 
-                            self.bytecode.emit_set_property_by_value(
+                            compiler.bytecode.emit_set_property_by_value(
                                 dst.variable(),
                                 key.variable(),
                                 object.variable(),
                                 object.variable(),
                             );
 
-                            self.register_allocator.dealloc(key);
-                            self.register_allocator.dealloc(object);
+                            compiler.register_allocator.dealloc(key);
+                            compiler.register_allocator.dealloc(object);
                         }
                     },
                     PropertyAccess::Private(access) => {
-                        let index = self.get_or_insert_private_name(access.field());
+                        let index = compiler.get_or_insert_private_name(access.field());
 
-                        let object = self.register_allocator.alloc();
-                        self.compile_expr(access.target(), &object);
+                        let object = compiler.register_allocator.alloc();
+                        compiler.compile_expr(access.target(), &object);
 
-                        self.bytecode.emit_get_private_field(
+                        compiler.bytecode.emit_get_private_field(
                             dst.variable(),
                             object.variable(),
                             index.into(),
                         );
 
-                        early_exit = emit(self, dst, assign.rhs(), assign.op());
+                        early_exit = emit(&mut compiler, dst, assign.rhs(), assign.op());
 
-                        self.bytecode.emit_set_private_field(
+                        compiler.bytecode.emit_set_private_field(
                             dst.variable(),
                             object.variable(),
                             index.into(),
                         );
 
-                        self.register_allocator.dealloc(object);
+                        compiler.register_allocator.dealloc(object);
                     }
                     PropertyAccess::Super(access) => match access.field() {
                         PropertyAccessField::Const(name) => {
-                            let object = self.register_allocator.alloc();
-                            let receiver = self.register_allocator.alloc();
-                            self.bytecode.emit_super(object.variable());
-                            self.bytecode.emit_this(receiver.variable());
+                            let object = compiler.register_allocator.alloc();
+                            let receiver = compiler.register_allocator.alloc();
+                            compiler.bytecode.emit_super(object.variable());
+                            compiler.bytecode.emit_this(receiver.variable());
 
-                            self.emit_get_property_by_name(dst, &receiver, &object, name.sym());
+                            compiler.emit_get_property_by_name(dst, &receiver, &object, name.sym());
 
-                            early_exit = emit(self, dst, assign.rhs(), assign.op());
+                            early_exit = emit(&mut compiler, dst, assign.rhs(), assign.op());
 
-                            self.emit_set_property_by_name(dst, &receiver, &object, name.sym());
+                            compiler.emit_set_property_by_name(dst, &receiver, &object, name.sym());
 
-                            self.register_allocator.dealloc(receiver);
-                            self.register_allocator.dealloc(object);
+                            compiler.register_allocator.dealloc(receiver);
+                            compiler.register_allocator.dealloc(object);
                         }
                         PropertyAccessField::Expr(expr) => {
-                            let object = self.register_allocator.alloc();
-                            let receiver = self.register_allocator.alloc();
-                            self.bytecode.emit_super(object.variable());
-                            self.bytecode.emit_this(receiver.variable());
+                            let object = compiler.register_allocator.alloc();
+                            let receiver = compiler.register_allocator.alloc();
+                            compiler.bytecode.emit_super(object.variable());
+                            compiler.bytecode.emit_this(receiver.variable());
 
-                            let key = self.register_allocator.alloc();
-                            self.compile_expr(expr, &key);
+                            let key = compiler.register_allocator.alloc();
+                            compiler.compile_expr(expr, &key);
 
-                            self.bytecode.emit_get_property_by_value_push(
+                            compiler.bytecode.emit_get_property_by_value_push(
                                 dst.variable(),
                                 key.variable(),
                                 receiver.variable(),
                                 object.variable(),
                             );
 
-                            early_exit = emit(self, dst, assign.rhs(), assign.op());
+                            early_exit = emit(&mut compiler, dst, assign.rhs(), assign.op());
 
-                            self.bytecode.emit_set_property_by_value(
+                            compiler.bytecode.emit_set_property_by_value(
                                 dst.variable(),
                                 key.variable(),
                                 receiver.variable(),
                                 object.variable(),
                             );
 
-                            self.register_allocator.dealloc(key);
-                            self.register_allocator.dealloc(receiver);
-                            self.register_allocator.dealloc(object);
+                            compiler.register_allocator.dealloc(key);
+                            compiler.register_allocator.dealloc(receiver);
+                            compiler.register_allocator.dealloc(object);
                         }
                     },
                 },
@@ -284,11 +293,10 @@ impl ByteCompiler<'_> {
             }
 
             if let Some(early_exit) = early_exit {
-                let skip = self.jump();
-                self.patch_jump(early_exit);
-                self.patch_jump(skip);
+                let skip = compiler.jump();
+                compiler.patch_jump(early_exit);
+                compiler.patch_jump(skip);
             }
         }
-        self.pop_source_position();
     }
 }

--- a/core/engine/src/bytecompiler/expression/assign.rs
+++ b/core/engine/src/bytecompiler/expression/assign.rs
@@ -13,6 +13,7 @@ use boa_ast::{
 
 impl ByteCompiler<'_> {
     pub(crate) fn compile_assign(&mut self, assign: &Assign, dst: &Register) {
+        self.push_source_position(assign.span().start());
         if assign.op() == AssignOp::Assign {
             match Access::from_assign_target(assign.lhs()) {
                 Ok(access) => {
@@ -288,5 +289,6 @@ impl ByteCompiler<'_> {
                 self.patch_jump(skip);
             }
         }
+        self.pop_source_position();
     }
 }

--- a/core/engine/src/bytecompiler/expression/unary.rs
+++ b/core/engine/src/bytecompiler/expression/unary.rs
@@ -8,12 +8,14 @@ impl ByteCompiler<'_> {
     pub(crate) fn compile_unary(&mut self, unary: &Unary, dst: &Register) {
         match unary.op() {
             UnaryOp::Delete => {
+                self.push_source_position(unary.span().start());
                 if let Some(access) = Access::from_expression(unary.target()) {
                     self.access_delete(access, dst);
                 } else {
                     self.compile_expr(unary.target(), dst);
                     self.bytecode.emit_push_true(dst.variable());
                 }
+                self.pop_source_position();
             }
             UnaryOp::Minus => {
                 self.compile_expr(unary.target(), dst);

--- a/core/engine/src/bytecompiler/expression/update.rs
+++ b/core/engine/src/bytecompiler/expression/update.rs
@@ -1,4 +1,6 @@
-use crate::bytecompiler::{Access, BindingAccessOpcode, ByteCompiler, Register, ToJsString};
+use crate::bytecompiler::{
+    Access, BindingAccessOpcode, ByteCompiler, Register, SourcePositionGuard, ToJsString,
+};
 use boa_ast::{
     expression::{
         access::{PropertyAccess, PropertyAccessField},
@@ -9,7 +11,7 @@ use boa_ast::{
 
 impl ByteCompiler<'_> {
     pub(crate) fn compile_update(&mut self, update: &Update, dst: &Register) {
-        self.push_source_position(update.span().start());
+        let mut compiler = SourcePositionGuard::new(self, update.span().start());
         let increment = matches!(
             update.op(),
             UpdateOp::IncrementPost | UpdateOp::IncrementPre
@@ -21,88 +23,111 @@ impl ByteCompiler<'_> {
 
         match Access::from_update_target(update.target()) {
             Access::Variable { name } => {
-                let name = name.to_js_string(self.interner());
-                let binding = self.lexical_scope.get_identifier_reference(name.clone());
+                let name = name.to_js_string(compiler.interner());
+                let binding = compiler
+                    .lexical_scope
+                    .get_identifier_reference(name.clone());
                 let is_lexical = binding.is_lexical();
-                let index = self.get_binding(&binding);
+                let index = compiler.get_binding(&binding);
 
                 if is_lexical {
-                    self.emit_binding_access(BindingAccessOpcode::GetName, &index, dst);
+                    compiler.emit_binding_access(BindingAccessOpcode::GetName, &index, dst);
                 } else {
-                    self.emit_binding_access(BindingAccessOpcode::GetNameAndLocator, &index, dst);
+                    compiler.emit_binding_access(
+                        BindingAccessOpcode::GetNameAndLocator,
+                        &index,
+                        dst,
+                    );
                 }
 
-                let value = self.register_allocator.alloc();
+                let value = compiler.register_allocator.alloc();
                 if increment {
-                    self.bytecode.emit_inc(value.variable(), dst.variable());
+                    compiler.bytecode.emit_inc(value.variable(), dst.variable());
                 } else {
-                    self.bytecode.emit_dec(value.variable(), dst.variable());
+                    compiler.bytecode.emit_dec(value.variable(), dst.variable());
                 }
 
                 if is_lexical {
-                    match self.lexical_scope.set_mutable_binding(name.clone()) {
+                    match compiler.lexical_scope.set_mutable_binding(name.clone()) {
                         Ok(binding) => {
-                            let index = self.insert_binding(binding);
-                            self.emit_binding_access(BindingAccessOpcode::SetName, &index, &value);
+                            let index = compiler.insert_binding(binding);
+                            compiler.emit_binding_access(
+                                BindingAccessOpcode::SetName,
+                                &index,
+                                &value,
+                            );
                         }
                         Err(BindingLocatorError::MutateImmutable) => {
-                            let index = self.get_or_insert_string(name);
-                            self.bytecode.emit_throw_mutate_immutable(index.into());
+                            let index = compiler.get_or_insert_string(name);
+                            compiler.bytecode.emit_throw_mutate_immutable(index.into());
                         }
                         Err(BindingLocatorError::Silent) => {}
                     }
                 } else {
-                    self.emit_binding_access(BindingAccessOpcode::SetNameByLocator, &index, &value);
+                    compiler.emit_binding_access(
+                        BindingAccessOpcode::SetNameByLocator,
+                        &index,
+                        &value,
+                    );
                 }
                 if !post {
-                    self.bytecode.emit_move(dst.variable(), value.variable());
+                    compiler
+                        .bytecode
+                        .emit_move(dst.variable(), value.variable());
                 }
 
-                self.register_allocator.dealloc(value);
+                compiler.register_allocator.dealloc(value);
             }
             Access::Property { access } => match access {
                 PropertyAccess::Simple(access) => {
-                    let object = self.register_allocator.alloc();
-                    self.compile_expr(access.target(), &object);
+                    let object = compiler.register_allocator.alloc();
+                    compiler.compile_expr(access.target(), &object);
 
                     match access.field() {
                         PropertyAccessField::Const(ident) => {
-                            self.emit_get_property_by_name(dst, &object, &object, ident.sym());
-                            let value = self.register_allocator.alloc();
+                            compiler.emit_get_property_by_name(dst, &object, &object, ident.sym());
+                            let value = compiler.register_allocator.alloc();
                             if increment {
-                                self.bytecode.emit_inc(value.variable(), dst.variable());
+                                compiler.bytecode.emit_inc(value.variable(), dst.variable());
                             } else {
-                                self.bytecode.emit_dec(value.variable(), dst.variable());
+                                compiler.bytecode.emit_dec(value.variable(), dst.variable());
                             }
 
-                            self.emit_set_property_by_name(&value, &object, &object, ident.sym());
+                            compiler.emit_set_property_by_name(
+                                &value,
+                                &object,
+                                &object,
+                                ident.sym(),
+                            );
 
                             if !post {
-                                self.bytecode.emit_move(dst.variable(), value.variable());
+                                compiler
+                                    .bytecode
+                                    .emit_move(dst.variable(), value.variable());
                             }
 
-                            self.register_allocator.dealloc(object);
-                            self.register_allocator.dealloc(value);
+                            compiler.register_allocator.dealloc(object);
+                            compiler.register_allocator.dealloc(value);
                         }
                         PropertyAccessField::Expr(expr) => {
-                            let key = self.register_allocator.alloc();
-                            self.compile_expr(expr, &key);
+                            let key = compiler.register_allocator.alloc();
+                            compiler.compile_expr(expr, &key);
 
-                            self.bytecode.emit_get_property_by_value_push(
+                            compiler.bytecode.emit_get_property_by_value_push(
                                 dst.variable(),
                                 key.variable(),
                                 object.variable(),
                                 object.variable(),
                             );
 
-                            let value = self.register_allocator.alloc();
+                            let value = compiler.register_allocator.alloc();
                             if increment {
-                                self.bytecode.emit_inc(value.variable(), dst.variable());
+                                compiler.bytecode.emit_inc(value.variable(), dst.variable());
                             } else {
-                                self.bytecode.emit_dec(value.variable(), dst.variable());
+                                compiler.bytecode.emit_dec(value.variable(), dst.variable());
                             }
 
-                            self.bytecode.emit_set_property_by_value(
+                            compiler.bytecode.emit_set_property_by_value(
                                 value.variable(),
                                 key.variable(),
                                 object.variable(),
@@ -110,106 +135,111 @@ impl ByteCompiler<'_> {
                             );
 
                             if !post {
-                                self.bytecode.emit_move(dst.variable(), value.variable());
+                                compiler
+                                    .bytecode
+                                    .emit_move(dst.variable(), value.variable());
                             }
 
-                            self.register_allocator.dealloc(key);
-                            self.register_allocator.dealloc(object);
-                            self.register_allocator.dealloc(value);
+                            compiler.register_allocator.dealloc(key);
+                            compiler.register_allocator.dealloc(object);
+                            compiler.register_allocator.dealloc(value);
                         }
                     }
                 }
                 PropertyAccess::Private(access) => {
-                    let index = self.get_or_insert_private_name(access.field());
+                    let index = compiler.get_or_insert_private_name(access.field());
 
-                    let object = self.register_allocator.alloc();
-                    self.compile_expr(access.target(), &object);
+                    let object = compiler.register_allocator.alloc();
+                    compiler.compile_expr(access.target(), &object);
 
-                    self.bytecode.emit_get_private_field(
+                    compiler.bytecode.emit_get_private_field(
                         dst.variable(),
                         object.variable(),
                         index.into(),
                     );
 
-                    let value = self.register_allocator.alloc();
+                    let value = compiler.register_allocator.alloc();
                     if increment {
-                        self.bytecode.emit_inc(value.variable(), dst.variable());
+                        compiler.bytecode.emit_inc(value.variable(), dst.variable());
                     } else {
-                        self.bytecode.emit_dec(value.variable(), dst.variable());
+                        compiler.bytecode.emit_dec(value.variable(), dst.variable());
                     }
-                    self.bytecode.emit_set_private_field(
+                    compiler.bytecode.emit_set_private_field(
                         value.variable(),
                         object.variable(),
                         index.into(),
                     );
 
                     if !post {
-                        self.bytecode.emit_move(dst.variable(), value.variable());
+                        compiler
+                            .bytecode
+                            .emit_move(dst.variable(), value.variable());
                     }
 
-                    self.register_allocator.dealloc(value);
-                    self.register_allocator.dealloc(object);
+                    compiler.register_allocator.dealloc(value);
+                    compiler.register_allocator.dealloc(object);
                 }
                 PropertyAccess::Super(access) => match access.field() {
                     PropertyAccessField::Const(ident) => {
-                        let object = self.register_allocator.alloc();
-                        let receiver = self.register_allocator.alloc();
-                        self.bytecode.emit_super(object.variable());
-                        self.bytecode.emit_this(receiver.variable());
+                        let object = compiler.register_allocator.alloc();
+                        let receiver = compiler.register_allocator.alloc();
+                        compiler.bytecode.emit_super(object.variable());
+                        compiler.bytecode.emit_this(receiver.variable());
 
-                        self.emit_get_property_by_name(dst, &receiver, &object, ident.sym());
+                        compiler.emit_get_property_by_name(dst, &receiver, &object, ident.sym());
 
-                        let value = self.register_allocator.alloc();
+                        let value = compiler.register_allocator.alloc();
                         if increment {
-                            self.bytecode.emit_inc(value.variable(), dst.variable());
+                            compiler.bytecode.emit_inc(value.variable(), dst.variable());
                         } else {
-                            self.bytecode.emit_dec(value.variable(), dst.variable());
+                            compiler.bytecode.emit_dec(value.variable(), dst.variable());
                         }
 
-                        self.emit_set_property_by_name(&value, &receiver, &object, ident.sym());
+                        compiler.emit_set_property_by_name(&value, &receiver, &object, ident.sym());
                         if !post {
-                            self.bytecode.emit_move(dst.variable(), value.variable());
+                            compiler
+                                .bytecode
+                                .emit_move(dst.variable(), value.variable());
                         }
 
-                        self.register_allocator.dealloc(receiver);
-                        self.register_allocator.dealloc(object);
-                        self.register_allocator.dealloc(value);
+                        compiler.register_allocator.dealloc(receiver);
+                        compiler.register_allocator.dealloc(object);
+                        compiler.register_allocator.dealloc(value);
                     }
                     PropertyAccessField::Expr(expr) => {
-                        let object = self.register_allocator.alloc();
-                        let receiver = self.register_allocator.alloc();
-                        self.bytecode.emit_super(object.variable());
-                        self.bytecode.emit_this(receiver.variable());
+                        let object = compiler.register_allocator.alloc();
+                        let receiver = compiler.register_allocator.alloc();
+                        compiler.bytecode.emit_super(object.variable());
+                        compiler.bytecode.emit_this(receiver.variable());
 
-                        let key = self.register_allocator.alloc();
-                        self.compile_expr(expr, &key);
+                        let key = compiler.register_allocator.alloc();
+                        compiler.compile_expr(expr, &key);
 
-                        self.bytecode.emit_get_property_by_value(
+                        compiler.bytecode.emit_get_property_by_value(
                             dst.variable(),
                             key.variable(),
                             receiver.variable(),
                             object.variable(),
                         );
                         if increment {
-                            self.bytecode.emit_inc(dst.variable(), dst.variable());
+                            compiler.bytecode.emit_inc(dst.variable(), dst.variable());
                         } else {
-                            self.bytecode.emit_dec(dst.variable(), dst.variable());
+                            compiler.bytecode.emit_dec(dst.variable(), dst.variable());
                         }
-                        self.bytecode.emit_set_property_by_value(
+                        compiler.bytecode.emit_set_property_by_value(
                             dst.variable(),
                             key.variable(),
                             receiver.variable(),
                             object.variable(),
                         );
 
-                        self.register_allocator.dealloc(receiver);
-                        self.register_allocator.dealloc(object);
-                        self.register_allocator.dealloc(key);
+                        compiler.register_allocator.dealloc(receiver);
+                        compiler.register_allocator.dealloc(object);
+                        compiler.register_allocator.dealloc(key);
                     }
                 },
             },
             Access::This => unreachable!(),
         }
-        self.pop_source_position();
     }
 }

--- a/core/engine/src/bytecompiler/expression/update.rs
+++ b/core/engine/src/bytecompiler/expression/update.rs
@@ -9,6 +9,7 @@ use boa_ast::{
 
 impl ByteCompiler<'_> {
     pub(crate) fn compile_update(&mut self, update: &Update, dst: &Register) {
+        self.push_source_position(update.span().start());
         let increment = matches!(
             update.op(),
             UpdateOp::IncrementPost | UpdateOp::IncrementPre
@@ -209,5 +210,6 @@ impl ByteCompiler<'_> {
             },
             Access::This => unreachable!(),
         }
+        self.pop_source_position();
     }
 }

--- a/core/engine/src/bytecompiler/function.rs
+++ b/core/engine/src/bytecompiler/function.rs
@@ -12,6 +12,8 @@ use boa_ast::{
 use boa_gc::Gc;
 use boa_interner::Interner;
 
+use super::SourcePositionGuard;
+
 /// `FunctionCompiler` is used to compile AST functions to bytecode.
 #[derive(Debug, Clone)]
 #[allow(clippy::struct_excessive_bools)]
@@ -221,9 +223,10 @@ impl FunctionCompiler {
             }
         }
 
-        compiler.push_source_position(body.span().start());
-        compiler.compile_statement_list(body.statement_list(), false, false);
-        compiler.pop_source_position();
+        {
+            let mut compiler = SourcePositionGuard::new(&mut compiler, body.span().start());
+            compiler.compile_statement_list(body.statement_list(), false, false);
+        }
 
         compiler.params = parameters.clone();
         compiler.parameter_scope = scopes.parameter_scope();

--- a/core/engine/src/bytecompiler/mod.rs
+++ b/core/engine/src/bytecompiler/mod.rs
@@ -12,7 +12,11 @@ mod register;
 mod statement;
 mod utils;
 
-use std::cell::Cell;
+use std::{
+    borrow::{Borrow, BorrowMut},
+    cell::Cell,
+    ops::{Deref, DerefMut},
+};
 
 use crate::{
     JsBigInt, JsStr, JsString, SourceText, SpannedSourceText,
@@ -405,6 +409,43 @@ pub(crate) enum BindingAccessOpcode {
     DeleteName,
     GetLocator,
     DefVar,
+}
+
+/// Manages the source position scope, push on creation, pop on drop.
+pub(crate) struct SourcePositionGuard<'a, 'b> {
+    compiler: &'a mut ByteCompiler<'b>,
+}
+impl<'a, 'b> SourcePositionGuard<'a, 'b> {
+    pub(crate) fn new(compiler: &'a mut ByteCompiler<'b>, position: Position) -> Self {
+        compiler.push_source_position(position);
+        Self { compiler }
+    }
+}
+impl Drop for SourcePositionGuard<'_, '_> {
+    fn drop(&mut self) {
+        self.pop_source_position();
+    }
+}
+impl<'a> Deref for SourcePositionGuard<'_, 'a> {
+    type Target = ByteCompiler<'a>;
+    fn deref(&self) -> &Self::Target {
+        self.compiler
+    }
+}
+impl DerefMut for SourcePositionGuard<'_, '_> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.compiler
+    }
+}
+impl<'a> Borrow<ByteCompiler<'a>> for SourcePositionGuard<'_, 'a> {
+    fn borrow(&self) -> &ByteCompiler<'a> {
+        self.compiler
+    }
+}
+impl<'a> BorrowMut<ByteCompiler<'a>> for SourcePositionGuard<'_, 'a> {
+    fn borrow_mut(&mut self) -> &mut ByteCompiler<'a> {
+        self.compiler
+    }
 }
 
 /// The [`ByteCompiler`] is used to compile ECMAScript AST from [`boa_ast`] to bytecode.
@@ -1057,71 +1098,74 @@ impl<'ctx> ByteCompiler<'ctx> {
                 let index = self.get_binding(&binding);
                 self.emit_binding_access(BindingAccessOpcode::GetName, &index, dst);
             }
-            Access::Property { access } => {
-                match access {
-                    PropertyAccess::Simple(access) => {
-                        self.push_source_position(access.field().span().start());
-                        let object = self.register_allocator.alloc();
-                        self.compile_expr(access.target(), &object);
+            Access::Property { access } => match access {
+                PropertyAccess::Simple(access) => {
+                    let mut compiler =
+                        SourcePositionGuard::new(self, access.field().span().start());
 
-                        match access.field() {
-                            PropertyAccessField::Const(ident) => {
-                                self.emit_get_property_by_name(dst, &object, &object, ident.sym());
-                            }
-                            PropertyAccessField::Expr(expr) => {
-                                let key = self.register_allocator.alloc();
-                                self.compile_expr(expr, &key);
-                                self.bytecode.emit_get_property_by_value(
-                                    dst.variable(),
-                                    key.variable(),
-                                    object.variable(),
-                                    object.variable(),
-                                );
-                                self.register_allocator.dealloc(key);
-                            }
+                    let object = compiler.register_allocator.alloc();
+                    compiler.compile_expr(access.target(), &object);
+
+                    match access.field() {
+                        PropertyAccessField::Const(ident) => {
+                            compiler.emit_get_property_by_name(dst, &object, &object, ident.sym());
                         }
-                        self.register_allocator.dealloc(object);
-                    }
-                    PropertyAccess::Private(access) => {
-                        self.push_source_position(access.field().span().start());
-                        let index = self.get_or_insert_private_name(access.field());
-                        let object = self.register_allocator.alloc();
-                        self.compile_expr(access.target(), &object);
-                        self.bytecode.emit_get_private_field(
-                            dst.variable(),
-                            object.variable(),
-                            index.into(),
-                        );
-                        self.register_allocator.dealloc(object);
-                    }
-                    PropertyAccess::Super(access) => {
-                        self.push_source_position(access.field().span().start());
-                        let value = self.register_allocator.alloc();
-                        let receiver = self.register_allocator.alloc();
-                        self.bytecode.emit_super(value.variable());
-                        self.bytecode.emit_this(receiver.variable());
-                        match access.field() {
-                            PropertyAccessField::Const(ident) => {
-                                self.emit_get_property_by_name(dst, &receiver, &value, ident.sym());
-                            }
-                            PropertyAccessField::Expr(expr) => {
-                                let key = self.register_allocator.alloc();
-                                self.compile_expr(expr, &key);
-                                self.bytecode.emit_get_property_by_value(
-                                    dst.variable(),
-                                    key.variable(),
-                                    receiver.variable(),
-                                    value.variable(),
-                                );
-                                self.register_allocator.dealloc(key);
-                            }
+                        PropertyAccessField::Expr(expr) => {
+                            let key = compiler.register_allocator.alloc();
+                            compiler.compile_expr(expr, &key);
+                            compiler.bytecode.emit_get_property_by_value(
+                                dst.variable(),
+                                key.variable(),
+                                object.variable(),
+                                object.variable(),
+                            );
+                            compiler.register_allocator.dealloc(key);
                         }
-                        self.register_allocator.dealloc(receiver);
-                        self.register_allocator.dealloc(value);
                     }
+                    compiler.register_allocator.dealloc(object);
                 }
-                self.pop_source_position();
-            }
+                PropertyAccess::Private(access) => {
+                    let mut compiler =
+                        SourcePositionGuard::new(self, access.field().span().start());
+
+                    let index = compiler.get_or_insert_private_name(access.field());
+                    let object = compiler.register_allocator.alloc();
+                    compiler.compile_expr(access.target(), &object);
+                    compiler.bytecode.emit_get_private_field(
+                        dst.variable(),
+                        object.variable(),
+                        index.into(),
+                    );
+                    compiler.register_allocator.dealloc(object);
+                }
+                PropertyAccess::Super(access) => {
+                    let mut compiler =
+                        SourcePositionGuard::new(self, access.field().span().start());
+
+                    let value = compiler.register_allocator.alloc();
+                    let receiver = compiler.register_allocator.alloc();
+                    compiler.bytecode.emit_super(value.variable());
+                    compiler.bytecode.emit_this(receiver.variable());
+                    match access.field() {
+                        PropertyAccessField::Const(ident) => {
+                            compiler.emit_get_property_by_name(dst, &receiver, &value, ident.sym());
+                        }
+                        PropertyAccessField::Expr(expr) => {
+                            let key = compiler.register_allocator.alloc();
+                            compiler.compile_expr(expr, &key);
+                            compiler.bytecode.emit_get_property_by_value(
+                                dst.variable(),
+                                key.variable(),
+                                receiver.variable(),
+                                value.variable(),
+                            );
+                            compiler.register_allocator.dealloc(key);
+                        }
+                    }
+                    compiler.register_allocator.dealloc(receiver);
+                    compiler.register_allocator.dealloc(value);
+                }
+            },
             Access::This => {
                 self.bytecode.emit_this(dst.variable());
             }
@@ -1957,7 +2001,7 @@ impl<'ctx> ByteCompiler<'ctx> {
             }
         }
 
-        self.push_source_position(call.span().start());
+        let mut compiler = SourcePositionGuard::new(self, call.span().start());
 
         let contains_spread = call
             .args()
@@ -1965,56 +2009,63 @@ impl<'ctx> ByteCompiler<'ctx> {
             .any(|arg| matches!(arg, Expression::Spread(_)));
 
         if contains_spread {
-            let array = self.register_allocator.alloc();
-            let value = self.register_allocator.alloc();
+            let array = compiler.register_allocator.alloc();
+            let value = compiler.register_allocator.alloc();
 
-            self.bytecode.emit_push_new_array(array.variable());
+            compiler.bytecode.emit_push_new_array(array.variable());
 
             for arg in call.args() {
-                self.compile_expr(arg, &value);
+                compiler.compile_expr(arg, &value);
                 if let Expression::Spread(_) = arg {
-                    self.bytecode.emit_get_iterator(value.variable());
-                    self.bytecode.emit_push_iterator_to_array(array.variable());
+                    compiler.bytecode.emit_get_iterator(value.variable());
+                    compiler
+                        .bytecode
+                        .emit_push_iterator_to_array(array.variable());
                 } else {
-                    self.bytecode
+                    compiler
+                        .bytecode
                         .emit_push_value_to_array(value.variable(), array.variable());
                 }
             }
 
-            self.push_from_register(&array);
+            compiler.push_from_register(&array);
 
-            self.register_allocator.dealloc(array);
-            self.register_allocator.dealloc(value);
+            compiler.register_allocator.dealloc(array);
+            compiler.register_allocator.dealloc(value);
         } else {
             for arg in call.args() {
-                let value = self.register_allocator.alloc();
-                self.compile_expr(arg, &value);
-                self.push_from_register(&value);
-                self.register_allocator.dealloc(value);
+                let value = compiler.register_allocator.alloc();
+                compiler.compile_expr(arg, &value);
+                compiler.push_from_register(&value);
+                compiler.register_allocator.dealloc(value);
             }
         }
 
         match kind {
             CallKind::CallEval => {
-                let scope_index = self.constants.len() as u32;
-                self.constants
-                    .push(Constant::Scope(self.lexical_scope.clone()));
+                let scope_index = compiler.constants.len() as u32;
+                let lexical_scope = compiler.lexical_scope.clone();
+                compiler.constants.push(Constant::Scope(lexical_scope));
                 if contains_spread {
-                    self.bytecode.emit_call_eval_spread(scope_index.into());
+                    compiler.bytecode.emit_call_eval_spread(scope_index.into());
                 } else {
-                    self.bytecode
+                    compiler
+                        .bytecode
                         .emit_call_eval((call.args().len() as u32).into(), scope_index.into());
                 }
             }
-            CallKind::Call if contains_spread => self.bytecode.emit_call_spread(),
+            CallKind::Call if contains_spread => compiler.bytecode.emit_call_spread(),
             CallKind::Call => {
-                self.bytecode.emit_call((call.args().len() as u32).into());
+                compiler
+                    .bytecode
+                    .emit_call((call.args().len() as u32).into());
             }
-            CallKind::New if contains_spread => self.bytecode.emit_new_spread(),
-            CallKind::New => self.bytecode.emit_new((call.args().len() as u32).into()),
+            CallKind::New if contains_spread => compiler.bytecode.emit_new_spread(),
+            CallKind::New => compiler
+                .bytecode
+                .emit_new((call.args().len() as u32).into()),
         }
-        self.pop_source_position();
-        self.pop_into_register(dst);
+        compiler.pop_into_register(dst);
     }
 
     /// Finish compiling code with the [`ByteCompiler`] and return the generated [`CodeBlock`].

--- a/core/engine/src/bytecompiler/statement/mod.rs
+++ b/core/engine/src/bytecompiler/statement/mod.rs
@@ -1,4 +1,7 @@
-use super::jump_control::{JumpRecord, JumpRecordAction, JumpRecordKind};
+use super::{
+    SourcePositionGuard,
+    jump_control::{JumpRecord, JumpRecordAction, JumpRecordKind},
+};
 use crate::bytecompiler::ByteCompiler;
 use boa_ast::Statement;
 
@@ -58,14 +61,12 @@ impl ByteCompiler<'_> {
                 self.compile_break(*node, use_expr);
             }
             Statement::Throw(throw) => {
-                self.push_source_position(throw.target().span().start());
+                let mut compiler = SourcePositionGuard::new(self, throw.target().span().start());
 
-                let error = self.register_allocator.alloc();
-                self.compile_expr(throw.target(), &error);
-                self.bytecode.emit_throw(error.variable());
-                self.register_allocator.dealloc(error);
-
-                self.pop_source_position();
+                let error = compiler.register_allocator.alloc();
+                compiler.compile_expr(throw.target(), &error);
+                compiler.bytecode.emit_throw(error.variable());
+                compiler.register_allocator.dealloc(error);
             }
             Statement::Switch(switch) => {
                 self.compile_switch(switch, use_expr);

--- a/core/engine/src/bytecompiler/statement/mod.rs
+++ b/core/engine/src/bytecompiler/statement/mod.rs
@@ -58,10 +58,14 @@ impl ByteCompiler<'_> {
                 self.compile_break(*node, use_expr);
             }
             Statement::Throw(throw) => {
+                self.push_source_position(throw.target().span().start());
+
                 let error = self.register_allocator.alloc();
                 self.compile_expr(throw.target(), &error);
                 self.bytecode.emit_throw(error.variable());
                 self.register_allocator.dealloc(error);
+
+                self.pop_source_position();
             }
             Statement::Switch(switch) => {
                 self.compile_switch(switch, use_expr);

--- a/core/engine/src/context/hooks.rs
+++ b/core/engine/src/context/hooks.rs
@@ -45,9 +45,11 @@ use time::{OffsetDateTime, UtcOffset};
 ///
 /// let context = &mut ContextBuilder::new().host_hooks(Rc::new(Hooks)).build().unwrap();
 /// let result = context.eval(Source::from_bytes(r#"eval("let a = 5")"#));
-/// assert_eq!(
-///     result.unwrap_err().to_string(),
-///     "TypeError: eval calls not available"
+/// assert!(
+///     result
+///         .unwrap_err()
+///         .to_string()
+///         .starts_with("TypeError: eval calls not available")
 /// );
 /// ```
 ///

--- a/core/engine/src/module/mod.rs
+++ b/core/engine/src/module/mod.rs
@@ -170,7 +170,7 @@ impl Module {
             parser.parse_module_with_source(realm.scope(), context.interner_mut())?;
 
         let source_text = SourceText::new(source);
-        let src = SourceTextModule::new(module, context.interner(), source_text);
+        let src = SourceTextModule::new(module, context.interner(), source_text, path.clone());
 
         Ok(Self {
             inner: Gc::new(ModuleRepr {

--- a/core/engine/src/module/source.rs
+++ b/core/engine/src/module/source.rs
@@ -1,4 +1,4 @@
-use std::{cell::Cell, collections::HashSet, hash::BuildHasherDefault, rc::Rc};
+use std::{cell::Cell, collections::HashSet, hash::BuildHasherDefault, path::PathBuf, rc::Rc};
 
 use boa_ast::{
     declaration::{
@@ -235,6 +235,7 @@ struct ModuleCode {
     requested_modules: IndexSet<JsString, BuildHasherDefault<FxHasher>>,
     source: boa_ast::Module,
     source_text: SourceText,
+    path: Option<PathBuf>,
     import_entries: Vec<ImportEntry>,
     local_export_entries: Vec<LocalExportEntry>,
     indirect_export_entries: Vec<IndirectExportEntry>,
@@ -247,7 +248,12 @@ impl SourceTextModule {
     /// Contains part of the abstract operation [`ParseModule`][parse].
     ///
     /// [parse]: https://tc39.es/ecma262/#sec-parsemodule
-    pub(super) fn new(code: boa_ast::Module, interner: &Interner, source_text: SourceText) -> Self {
+    pub(super) fn new(
+        code: boa_ast::Module,
+        interner: &Interner,
+        source_text: SourceText,
+        path: Option<PathBuf>,
+    ) -> Self {
         // 3. Let requestedModules be the ModuleRequests of body.
         let requested_modules = code
             .items()
@@ -339,6 +345,7 @@ impl SourceTextModule {
             code: ModuleCode {
                 source: code,
                 source_text,
+                path,
                 requested_modules,
                 has_tla,
                 import_entries,
@@ -1457,6 +1464,7 @@ impl SourceTextModule {
             context.interner_mut(),
             false,
             spanned_source_text,
+            self.code.path.clone().into(),
         );
 
         compiler.async_handler = Some(compiler.push_handler());

--- a/core/engine/src/module/synthetic.rs
+++ b/core/engine/src/module/synthetic.rs
@@ -11,7 +11,7 @@ use crate::{
     environments::{DeclarativeEnvironment, EnvironmentStack},
     js_string,
     object::JsPromise,
-    vm::{ActiveRunnable, CallFrame, CodeBlock},
+    vm::{ActiveRunnable, CallFrame, CodeBlock, source_info::SourcePath},
 };
 
 trait TraceableCallback: Trace {
@@ -309,7 +309,7 @@ impl SyntheticModule {
         // TODO: A bit of a hack to be able to pass the currently active runnable without an
         // available codeblock to execute.
         let compiler = ByteCompiler::new(
-            js_string!("<main>"),
+            js_string!("<synthetic>"),
             true,
             false,
             module_scope.clone(),
@@ -320,6 +320,7 @@ impl SyntheticModule {
             false,
             // A synthetic module does not contain `SourceText`
             SpannedSourceText::new_empty(),
+            SourcePath::None,
         );
 
         // 4. For each String exportName in module.[[ExportNames]], do

--- a/core/engine/src/object/builtins/jsfunction.rs
+++ b/core/engine/src/object/builtins/jsfunction.rs
@@ -1,4 +1,5 @@
 //! A Rust API wrapper for Boa's `Function` Builtin ECMAScript Object
+use crate::js_string;
 use crate::{
     Context, JsNativeError, JsResult, JsValue, NativeFunction, TryIntoJsResult,
     builtins::function::ConstructorKind, native_function::NativeFunctionObject, object::JsObject,
@@ -130,6 +131,7 @@ impl JsFunction {
                 None,
                 NativeFunctionObject {
                     f: NativeFunction::from_fn_ptr(|_, _, _| Ok(JsValue::undefined())),
+                    name: js_string!(),
                     constructor: constructor.then_some(ConstructorKind::Base),
                     realm: None,
                 },

--- a/core/engine/src/object/mod.rs
+++ b/core/engine/src/object/mod.rs
@@ -562,6 +562,7 @@ impl<'realm> FunctionObjectBuilder<'realm> {
         let object = self.realm.intrinsics().templates().function().create(
             NativeFunctionObject {
                 f: self.function,
+                name: self.name.clone(),
                 constructor: self.constructor,
                 realm: Some(self.realm.clone()),
             },
@@ -1013,6 +1014,7 @@ impl<'ctx> ConstructorBuilder<'ctx> {
                 private_elements: self.constructor_object.private_elements,
                 data: NativeFunctionObject {
                     f: self.function,
+                    name: self.name.clone(),
                     constructor: self.kind,
                     realm: Some(self.context.realm().clone()),
                 },

--- a/core/engine/src/script.rs
+++ b/core/engine/src/script.rs
@@ -142,6 +142,7 @@ impl Script {
             context.interner_mut(),
             false,
             spanned_source_text,
+            self.path().map(Path::to_owned).into(),
         );
 
         #[cfg(feature = "annex-b")]

--- a/core/engine/src/spanned_source_text.rs
+++ b/core/engine/src/spanned_source_text.rs
@@ -12,7 +12,7 @@ impl Inner {
     }
 }
 
-#[derive(Trace, Finalize, Clone)]
+#[derive(Default, Trace, Finalize, Clone)]
 pub(crate) struct SourceText {
     #[unsafe_ignore_trace]
     source_text: Option<Rc<Inner>>,
@@ -41,12 +41,12 @@ impl SourceText {
 }
 
 /// Contains pointer to source code and span of the object.
-#[derive(Trace, Finalize, Clone)]
+#[derive(Default, Clone)]
 pub struct SpannedSourceText {
     source_text: SourceText,
-    #[unsafe_ignore_trace]
     span: Option<LinearSpan>,
 }
+
 impl SpannedSourceText {
     pub(crate) fn new(source_text: SourceText, span: Option<LinearSpan>) -> Self {
         Self { source_text, span }

--- a/core/engine/src/vm/code_block.rs
+++ b/core/engine/src/vm/code_block.rs
@@ -19,6 +19,7 @@ use thin_vec::ThinVec;
 use super::{
     InlineCache,
     opcode::{ByteCode, Instruction, InstructionIterator},
+    source_info::{SourceInfo, SourceMap, SourcePath},
 };
 
 bitflags! {
@@ -113,10 +114,6 @@ pub(crate) enum Constant {
 /// attributes of the function.
 #[derive(Clone, Debug, Trace, Finalize)]
 pub struct CodeBlock {
-    /// Name of this function
-    #[unsafe_ignore_trace]
-    pub(crate) name: JsString,
-
     #[unsafe_ignore_trace]
     pub(crate) flags: Cell<CodeBlockFlags>,
 
@@ -151,8 +148,8 @@ pub struct CodeBlock {
     /// inline caching
     pub(crate) ic: Box<[InlineCache]>,
 
-    /// source text of the code block
-    pub(crate) source_text_spanned: SpannedSourceText,
+    /// Bytecode to source code mapping.
+    pub(crate) source_info: SourceInfo,
 }
 
 /// ---- `CodeBlock` public API ----
@@ -166,7 +163,6 @@ impl CodeBlock {
             bytecode: ByteCode::default(),
             constants: ThinVec::default(),
             bindings: Box::default(),
-            name,
             flags: Cell::new(flags),
             length,
             register_count: 0,
@@ -175,14 +171,18 @@ impl CodeBlock {
             parameter_length: 0,
             handlers: ThinVec::default(),
             ic: Box::default(),
-            source_text_spanned: SpannedSourceText::new_empty(),
+            source_info: SourceInfo::new(
+                SourceMap::new(Box::default(), SourcePath::None),
+                name,
+                SpannedSourceText::new_empty(),
+            ),
         }
     }
 
     /// Retrieves the name associated with this code block.
     #[must_use]
-    pub const fn name(&self) -> &JsString {
-        &self.name
+    pub fn name(&self) -> &JsString {
+        self.source_info.function_name()
     }
 
     /// Check if the function is traced.
@@ -316,6 +316,10 @@ impl CodeBlock {
         }
 
         panic!("expected scope constant at index {index}")
+    }
+
+    pub(crate) fn source_info(&self) -> &SourceInfo {
+        &self.source_info
     }
 }
 
@@ -993,6 +997,35 @@ impl Display for CodeBlock {
                     handler.handler(),
                     handler.environment_count,
                 )?;
+            }
+        }
+        f.write_str("Source Map:")?;
+        if self.source_info().map().entries().is_empty() {
+            f.write_str(" <empty>\n")?;
+        } else {
+            f.write_char('\n')?;
+
+            let bytecode_len = self.bytecode.bytecode.len() as u32;
+            for (i, handler) in self.source_info().map().entries().windows(2).enumerate() {
+                let current = handler[0];
+                let next = handler.get(1);
+
+                write!(
+                    f,
+                    "    {i:04}: {:?}: ",
+                    current.pc..next.map_or(bytecode_len, |entry| entry.pc),
+                )?;
+
+                if let Some(position) = current.position {
+                    writeln!(
+                        f,
+                        "({}, {})",
+                        position.line_number(),
+                        position.column_number()
+                    )?;
+                } else {
+                    f.write_str("unknown")?;
+                }
             }
         }
         Ok(())

--- a/core/engine/src/vm/opcode/await/mod.rs
+++ b/core/engine/src/vm/opcode/await/mod.rs
@@ -203,7 +203,7 @@ impl CompletePromiseCapability {
         let Some(promise_capability) = context.vm.stack.get_promise_capability(&context.vm.frame)
         else {
             return if context.vm.pending_exception.is_some() {
-                context.handle_thow()
+                context.handle_throw()
             } else {
                 ControlFlow::Continue(())
             };

--- a/core/engine/src/vm/opcode/control_flow/return.rs
+++ b/core/engine/src/vm/opcode/control_flow/return.rs
@@ -57,7 +57,7 @@ impl CheckReturn {
                     .with_realm(realm)
                     .into(),
             );
-            return context.handle_thow();
+            return context.handle_throw();
         } else {
             let frame = context.vm.frame();
             if frame.has_this_value_cached() {
@@ -69,7 +69,7 @@ impl CheckReturn {
                     Err(err) => {
                         let err = err.inject_realm(realm);
                         context.vm.pending_exception = Some(err);
-                        return context.handle_thow();
+                        return context.handle_throw();
                     }
                     Ok(Some(this)) => this,
                     Ok(None) => context.realm().global_this().clone().into(),

--- a/core/engine/src/vm/opcode/control_flow/throw.rs
+++ b/core/engine/src/vm/opcode/control_flow/throw.rs
@@ -31,7 +31,7 @@ impl Throw {
             return ControlFlow::Continue(());
         }
 
-        context.handle_thow()
+        context.handle_throw()
     }
 }
 
@@ -66,7 +66,7 @@ impl ReThrow {
             return context.handle_return();
         }
 
-        context.handle_thow()
+        context.handle_throw()
     }
 }
 

--- a/core/engine/src/vm/runtime_limits.rs
+++ b/core/engine/src/vm/runtime_limits.rs
@@ -7,6 +7,9 @@ pub struct RuntimeLimits {
     /// Max loop iterations before an error is thrown.
     loop_iteration: u64,
 
+    /// Max backtrace count in exception.
+    backtrace_limit: usize,
+
     /// Max function recursion limit
     resursion: usize,
 }
@@ -17,6 +20,7 @@ impl Default for RuntimeLimits {
         Self {
             loop_iteration: u64::MAX,
             resursion: 512,
+            backtrace_limit: 50,
             stack_size: 1024 * 10,
         }
     }
@@ -48,6 +52,21 @@ impl RuntimeLimits {
     #[inline]
     pub fn disable_loop_iteration_limit(&mut self) {
         self.loop_iteration = u64::MAX;
+    }
+
+    /// Get max backtrace limit for an exception.
+    ///
+    /// Default is 50.
+    #[inline]
+    #[must_use]
+    pub const fn backtrace_limit(&self) -> usize {
+        self.backtrace_limit
+    }
+
+    /// Set max backtrace limit for an exception.
+    #[inline]
+    pub fn set_backtrace_limit(&mut self, value: usize) {
+        self.backtrace_limit = value;
     }
 
     /// Get max stack size.

--- a/core/engine/src/vm/shadow_stack.rs
+++ b/core/engine/src/vm/shadow_stack.rs
@@ -1,0 +1,79 @@
+use boa_gc::{Finalize, Trace};
+use boa_string::JsString;
+use thin_vec::ThinVec;
+
+use super::source_info::SourceInfo;
+
+#[derive(Debug, Default, Clone, Trace, Finalize)]
+pub(crate) struct Backtrace {
+    // SAFETY: Nothing in `ShadowEntry` requires trace, so this is safe.
+    #[unsafe_ignore_trace]
+    stack: ThinVec<ShadowEntry>,
+}
+
+impl Backtrace {
+    pub(crate) fn iter(&self) -> impl DoubleEndedIterator<Item = &ShadowEntry> {
+        self.stack.iter()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum ShadowEntry {
+    Native { function_name: JsString },
+    Bytecode { pc: u32, source_info: SourceInfo },
+}
+
+#[derive(Debug, Default, Clone)]
+pub(crate) struct ShadowStack {
+    stack: ThinVec<ShadowEntry>,
+}
+
+impl ShadowStack {
+    pub(crate) fn push_native(&mut self, last_pc: u32, function_name: JsString) {
+        // NOTE: pc points to the next opcode, so we offset by -1 to put it within range.
+        let last_pc = last_pc.saturating_sub(1);
+
+        if let Some(ShadowEntry::Bytecode { pc, .. }) = self.stack.last_mut() {
+            *pc = last_pc;
+        }
+        self.stack.push(ShadowEntry::Native { function_name });
+    }
+
+    pub(crate) fn push_bytecode(&mut self, last_pc: u32, source_info: SourceInfo) {
+        // NOTE: pc points to the next opcode, so we offset by -1 to put it within range.
+        let last_pc = last_pc.saturating_sub(1);
+
+        if let Some(ShadowEntry::Bytecode { pc, .. }) = self.stack.last_mut() {
+            *pc = last_pc;
+        }
+        self.stack
+            .push(ShadowEntry::Bytecode { pc: 0, source_info });
+    }
+
+    pub(crate) fn pop(&mut self) -> Option<ShadowEntry> {
+        self.stack.pop()
+    }
+
+    pub(crate) fn take(&self, n: usize, last_pc: u32) -> Backtrace {
+        let mut stack = self
+            .stack
+            .iter()
+            .rev()
+            .take(n)
+            .rev()
+            .cloned()
+            .collect::<ThinVec<_>>();
+
+        if let Some(ShadowEntry::Bytecode { pc, .. }) = stack.last_mut() {
+            // NOTE: pc points to the next opcode, so we offset by -1 to put it within range.
+            *pc = last_pc.saturating_sub(1);
+        }
+        Backtrace { stack }
+    }
+
+    pub(crate) fn caller_position(&self) -> Option<ShadowEntry> {
+        // NOTE: We push the function that is currently execution, so the second last is the caller.
+        let index = self.stack.len().checked_sub(2)?;
+        self.stack.get(index).cloned()
+    }
+}

--- a/core/engine/src/vm/source_info/builder/mod.rs
+++ b/core/engine/src/vm/source_info/builder/mod.rs
@@ -1,0 +1,120 @@
+use std::{cmp::Ordering, ops::Range};
+
+use boa_ast::Position;
+use itertools::Itertools;
+
+use crate::vm::source_info::Entry;
+
+#[cfg(test)]
+mod tests;
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+struct EntryRange {
+    start: u32,
+    end: u32,
+    position: Option<Position>,
+}
+
+impl EntryRange {
+    fn range(&self) -> Range<u32> {
+        self.start..self.end
+    }
+
+    fn is_empty(&self) -> bool {
+        self.range().is_empty()
+    }
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct SourceMapBuilder {
+    entries: Vec<EntryRange>,
+    stack: Vec<u32>,
+}
+
+impl SourceMapBuilder {
+    pub(crate) fn build(self, final_pc: u32) -> Box<[Entry]> {
+        assert!(self.stack.is_empty(), "forgot to pop source scope");
+        let end_entry = self
+            .entries
+            .last()
+            .copied()
+            .map(|entry| EntryRange {
+                start: entry.end,
+                end: final_pc,
+                position: None,
+            })
+            .unwrap_or_default();
+
+        self.entries
+            .into_iter()
+            .chain(std::iter::once(end_entry))
+            .filter(|entry| !entry.is_empty())
+            .dedup_by(|a, b| a.position == b.position)
+            .map(|entry| Entry {
+                pc: entry.start,
+                position: entry.position,
+            })
+            .collect::<Box<[_]>>()
+    }
+
+    pub(crate) fn push_source_position(&mut self, start_pc: u32, position: Option<Position>) {
+        let index = self.entries.len() as u32;
+        self.entries.push(EntryRange {
+            start: start_pc,
+            end: u32::MAX,
+            position,
+        });
+        self.stack.push(index);
+    }
+
+    // TODO: document implementation range flattening.
+    pub(crate) fn pop_source_position(&mut self, current_start_pc: u32) {
+        let Some(index) = self.stack.pop().map(|index| index as usize) else {
+            panic!("popped more than pushed");
+        };
+
+        self.entries[index].end = current_start_pc;
+
+        if self.entries[index].range().is_empty() {
+            return;
+        }
+
+        let Some(parent) = self.stack.last().copied().map(|index| index as usize) else {
+            return;
+        };
+
+        let ordering = self.entries[parent].start.cmp(&self.entries[index].start);
+
+        let new_parent_index = match ordering {
+            Ordering::Equal => {
+                self.entries.swap(parent, index);
+                let (parent, index) = (index, parent);
+
+                self.entries[parent].start = self.entries[index].end;
+
+                parent
+            }
+            Ordering::Less => {
+                let old_end = self.entries[parent].end;
+                assert_eq!(old_end, u32::MAX, "parent end position should not be set");
+
+                self.entries[parent].end = self.entries[index].start;
+
+                let new_index = self.entries.len();
+                self.entries.push(EntryRange {
+                    start: self.entries[index].end,
+                    end: u32::MAX,
+                    position: self.entries[parent].position,
+                });
+                new_index
+            }
+            Ordering::Greater => {
+                unreachable!("Parent source scope cannot be greater than child scope")
+            }
+        };
+
+        if let Some(parent) = self.stack.last_mut() {
+            *parent = new_parent_index as u32;
+        }
+    }
+}

--- a/core/engine/src/vm/source_info/builder/tests.rs
+++ b/core/engine/src/vm/source_info/builder/tests.rs
@@ -1,0 +1,356 @@
+use crate::vm::source_info::{
+    Entry,
+    builder::{EntryRange, SourceMapBuilder},
+};
+
+fn entries(mut builder: SourceMapBuilder) -> Vec<EntryRange> {
+    builder.entries.retain(|entry| !entry.is_empty());
+    // println!("\n{:#?}", builder.entries);
+    builder.entries.clone()
+}
+
+#[test]
+fn empty() {
+    let builder = SourceMapBuilder::default();
+
+    assert_eq!(entries(builder), Vec::<EntryRange>::new());
+}
+
+#[test]
+fn single_source_non_overlapping() {
+    let mut builder = SourceMapBuilder::default();
+    builder.push_source_position(0, Some((1, 1).into()));
+    builder.pop_source_position(10);
+
+    assert_eq!(
+        entries(builder),
+        vec![EntryRange {
+            start: 0,
+            end: 10,
+            position: Some((1, 1).into())
+        }]
+    );
+}
+
+#[test]
+fn single_source_overlapping() {
+    let mut builder = SourceMapBuilder::default();
+    builder.push_source_position(0, Some((1, 1).into()));
+    builder.pop_source_position(0);
+
+    assert_eq!(entries(builder), Vec::<EntryRange>::new());
+}
+
+#[test]
+fn multiple_source_non_overlapping() {
+    let mut builder = SourceMapBuilder::default();
+    builder.push_source_position(0, Some((1, 1).into()));
+    {
+        builder.push_source_position(2, Some((3, 1).into()));
+        builder.pop_source_position(4);
+    }
+    builder.pop_source_position(10);
+
+    assert_eq!(
+        entries(builder),
+        vec![
+            EntryRange {
+                start: 0,
+                end: 2,
+                position: Some((1, 1).into())
+            },
+            EntryRange {
+                start: 2,
+                end: 4,
+                position: Some((3, 1).into())
+            },
+            EntryRange {
+                start: 4,
+                end: 10,
+                position: Some((1, 1).into())
+            },
+        ]
+    );
+}
+
+#[test]
+fn multiple_source_full_overlapping() {
+    let mut builder = SourceMapBuilder::default();
+    builder.push_source_position(0, Some((1, 1).into()));
+    {
+        builder.push_source_position(0, Some((3, 1).into()));
+        builder.pop_source_position(0);
+    }
+    builder.pop_source_position(0);
+
+    assert_eq!(entries(builder), Vec::<EntryRange>::new(),);
+}
+
+#[test]
+fn multiple_source_inner_overlapping() {
+    let mut builder = SourceMapBuilder::default();
+    builder.push_source_position(0, Some((1, 1).into()));
+    {
+        builder.push_source_position(3, Some((3, 1).into()));
+        builder.pop_source_position(3);
+    }
+    builder.pop_source_position(10);
+
+    assert_eq!(
+        entries(builder),
+        vec![EntryRange {
+            start: 0,
+            end: 10,
+            position: Some((1, 1).into())
+        }]
+    );
+}
+
+#[test]
+fn multiple_source_multiple_inner_non_overlapping() {
+    let mut builder = SourceMapBuilder::default();
+    builder.push_source_position(0, Some((1, 1).into()));
+    {
+        builder.push_source_position(3, Some((3, 1).into()));
+        builder.pop_source_position(5);
+
+        builder.push_source_position(5, Some((5, 1).into()));
+        builder.pop_source_position(7);
+    }
+    builder.pop_source_position(10);
+
+    assert_eq!(
+        entries(builder),
+        vec![
+            EntryRange {
+                start: 0,
+                end: 3,
+                position: Some((1, 1).into())
+            },
+            EntryRange {
+                start: 3,
+                end: 5,
+                position: Some((3, 1).into())
+            },
+            EntryRange {
+                start: 5,
+                end: 7,
+                position: Some((5, 1).into())
+            },
+            EntryRange {
+                start: 7,
+                end: 10,
+                position: Some((1, 1).into())
+            }
+        ]
+    );
+}
+
+#[test]
+fn multiple_source_multiple_inner_non_overlapping_with_gap() {
+    let mut builder = SourceMapBuilder::default();
+    builder.push_source_position(0, Some((1, 1).into()));
+    {
+        builder.push_source_position(3, Some((3, 1).into()));
+        builder.pop_source_position(4);
+
+        builder.push_source_position(5, Some((5, 1).into()));
+        builder.pop_source_position(7);
+    }
+    builder.pop_source_position(10);
+
+    assert_eq!(
+        entries(builder),
+        vec![
+            EntryRange {
+                start: 0,
+                end: 3,
+                position: Some((1, 1).into())
+            },
+            EntryRange {
+                start: 3,
+                end: 4,
+                position: Some((3, 1).into())
+            },
+            EntryRange {
+                start: 4,
+                end: 5,
+                position: Some((1, 1).into())
+            },
+            EntryRange {
+                start: 5,
+                end: 7,
+                position: Some((5, 1).into())
+            },
+            EntryRange {
+                start: 7,
+                end: 10,
+                position: Some((1, 1).into())
+            }
+        ]
+    );
+}
+
+#[test]
+fn multiple_source_outer_overlapping() {
+    let mut builder = SourceMapBuilder::default();
+    builder.push_source_position(0, Some((1, 1).into()));
+    {
+        builder.push_source_position(0, Some((3, 1).into()));
+        builder.pop_source_position(10);
+    }
+    builder.pop_source_position(10);
+
+    assert_eq!(
+        entries(builder),
+        vec![EntryRange {
+            start: 0,
+            end: 10,
+            position: Some((3, 1).into())
+        }]
+    );
+}
+
+#[test]
+fn finish_does_not_insert_none_position_if_len_is_equal() {
+    let mut builder = SourceMapBuilder::default();
+    builder.push_source_position(0, Some((1, 1).into()));
+    builder.pop_source_position(10);
+
+    assert_eq!(
+        builder.build(10),
+        vec![Entry {
+            pc: 0,
+            position: Some((1, 1).into()),
+        }]
+        .into()
+    );
+}
+
+#[test]
+fn finish_inserts_none_position_if_len_is_not_equal() {
+    let mut builder = SourceMapBuilder::default();
+    builder.push_source_position(0, Some((1, 1).into()));
+    builder.pop_source_position(10);
+
+    assert_eq!(
+        builder.build(20),
+        vec![
+            Entry {
+                pc: 0,
+                position: Some((1, 1).into()),
+            },
+            Entry {
+                pc: 10,
+                position: None,
+            }
+        ]
+        .into()
+    );
+}
+
+#[test]
+fn finish_full_consecutive_duplicates() {
+    let mut builder = SourceMapBuilder::default();
+    builder.push_source_position(0, Some((1, 1).into()));
+    {
+        builder.push_source_position(2, Some((1, 1).into()));
+        {
+            builder.push_source_position(4, Some((1, 1).into()));
+            builder.pop_source_position(6);
+        }
+        builder.pop_source_position(8);
+    }
+    builder.pop_source_position(10);
+
+    assert_eq!(
+        builder.build(20),
+        vec![
+            Entry {
+                pc: 0,
+                position: Some((1, 1).into()),
+            },
+            Entry {
+                pc: 10,
+                position: None,
+            }
+        ]
+        .into()
+    );
+}
+
+#[test]
+fn finish_outer_consecutive_duplicates() {
+    let mut builder = SourceMapBuilder::default();
+    builder.push_source_position(0, Some((1, 1).into()));
+    {
+        builder.push_source_position(2, Some((1, 1).into()));
+        {
+            builder.push_source_position(4, Some((2, 1).into()));
+            builder.pop_source_position(6);
+        }
+        builder.pop_source_position(8);
+    }
+    builder.pop_source_position(10);
+
+    assert_eq!(
+        builder.build(20),
+        vec![
+            Entry {
+                pc: 0,
+                position: Some((1, 1).into()),
+            },
+            Entry {
+                pc: 4,
+                position: Some((2, 1).into()),
+            },
+            Entry {
+                pc: 6,
+                position: Some((1, 1).into()),
+            },
+            Entry {
+                pc: 10,
+                position: None,
+            }
+        ]
+        .into()
+    );
+}
+
+#[test]
+fn finish_inner_consecutive_duplicates() {
+    let mut builder = SourceMapBuilder::default();
+    builder.push_source_position(0, Some((2, 1).into()));
+    {
+        builder.push_source_position(2, Some((1, 1).into()));
+        {
+            builder.push_source_position(4, Some((1, 1).into()));
+            builder.pop_source_position(6);
+        }
+        builder.pop_source_position(8);
+    }
+    builder.pop_source_position(10);
+
+    assert_eq!(
+        builder.build(20),
+        vec![
+            Entry {
+                pc: 0,
+                position: Some((2, 1).into()),
+            },
+            Entry {
+                pc: 2,
+                position: Some((1, 1).into()),
+            },
+            Entry {
+                pc: 8,
+                position: Some((2, 1).into()),
+            },
+            Entry {
+                pc: 10,
+                position: None,
+            }
+        ]
+        .into()
+    );
+}

--- a/core/engine/src/vm/source_info/mod.rs
+++ b/core/engine/src/vm/source_info/mod.rs
@@ -1,0 +1,182 @@
+use std::{
+    fmt::Display,
+    path::{Path, PathBuf},
+    rc::Rc,
+};
+
+use boa_ast::Position;
+
+mod builder;
+
+use boa_gc::{Finalize, Trace};
+use boa_string::JsString;
+pub(crate) use builder::SourceMapBuilder;
+
+use crate::SpannedSourceText;
+
+#[cfg(test)]
+mod tests;
+
+/// Source information.
+#[derive(Debug, Default, Clone, Finalize, Trace)]
+// SAFETY: Nothing in Inner needs tracing, so this is safe.
+#[boa_gc(unsafe_empty_trace)]
+pub(crate) struct SourceInfo {
+    inner: Rc<Inner>,
+}
+
+impl SourceInfo {
+    pub(crate) fn new(
+        source_map: SourceMap,
+        function_name: JsString,
+        source_text_spanned: SpannedSourceText,
+    ) -> Self {
+        Self {
+            inner: Rc::new(Inner {
+                map: source_map,
+                function_name,
+                text_spanned: source_text_spanned,
+            }),
+        }
+    }
+
+    pub(crate) fn map(&self) -> &SourceMap {
+        &self.inner.map
+    }
+
+    pub(crate) fn function_name(&self) -> &JsString {
+        &self.inner.function_name
+    }
+
+    pub(crate) fn text_spanned(&self) -> &SpannedSourceText {
+        &self.inner.text_spanned
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+struct Inner {
+    map: SourceMap,
+    function_name: JsString,
+
+    text_spanned: SpannedSourceText,
+}
+
+/// Bytecode to source code mapping.
+#[derive(Debug, Default, Clone)]
+pub(crate) struct SourceMap {
+    entries: Box<[Entry]>,
+    path: SourcePath,
+}
+
+impl SourceMap {
+    pub(crate) fn new(entries: Box<[Entry]>, path: SourcePath) -> Self {
+        Self { entries, path }
+    }
+
+    pub(crate) fn entries(&self) -> &[Entry] {
+        &self.entries
+    }
+
+    pub(crate) fn find(&self, pc: u32) -> Option<Position> {
+        find_entry(self.entries(), pc)
+    }
+
+    pub(crate) fn path(&self) -> &SourcePath {
+        &self.path
+    }
+}
+
+fn find_entry(entries: &[Entry], pc: u32) -> Option<Position> {
+    let first = entries.first()?;
+
+    if pc < first.pc() {
+        return None;
+    }
+
+    let mut low = 0;
+    let mut high = entries.len() - 1;
+
+    while low <= high {
+        let mid = low.midpoint(high);
+        let entry = &entries[mid];
+        let start = entry.pc;
+
+        let end = entries.get(mid + 1).map_or(u32::MAX, |entry| entry.pc);
+
+        if pc < start {
+            high = mid;
+        } else if pc >= end {
+            low = mid + 1;
+        } else {
+            return entry.position();
+        }
+    }
+
+    // Since the last element defines the start of the end of the range,
+    // therefore we return the last element's position.
+    entries.last().and_then(Entry::position)
+}
+
+// TODO: The line number increments slower than column,
+//       maybe we can take advantage of this, for memory optimization?
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct Entry {
+    /// Represents the start of a bytecode range that falls under the given position.
+    ///
+    /// The end of the range is the pc of the next entry.
+    /// If the entry is the last the the end of the range is [`u32::MAX`].
+    pub(crate) pc: u32,
+
+    /// Source code [`Position`].
+    pub(crate) position: Option<Position>,
+}
+
+impl Entry {
+    pub(crate) const fn pc(&self) -> u32 {
+        self.pc
+    }
+
+    pub(crate) const fn position(&self) -> Option<Position> {
+        self.position
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub(crate) enum SourcePath {
+    #[default]
+    None,
+    // TODO: Could add more information, like path in which the eval is located.
+    Eval,
+    // TODO: Could add more information, like path in which the JSON.parse is located.
+    Json,
+    Path(Rc<Path>),
+}
+
+impl From<Option<PathBuf>> for SourcePath {
+    fn from(value: Option<PathBuf>) -> Self {
+        match value {
+            None => Self::None,
+            Some(path) => Self::Path(path.into()),
+        }
+    }
+}
+
+impl From<Option<Rc<Path>>> for SourcePath {
+    fn from(value: Option<Rc<Path>>) -> Self {
+        match value {
+            None => Self::None,
+            Some(path) => Self::Path(path),
+        }
+    }
+}
+
+impl Display for SourcePath {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SourcePath::None => f.write_str("unknown at "),
+            SourcePath::Eval => f.write_str("eval at "),
+            SourcePath::Json => f.write_str("json at "),
+            SourcePath::Path(path) => write!(f, "{}", path.display()),
+        }
+    }
+}

--- a/core/engine/src/vm/source_info/tests.rs
+++ b/core/engine/src/vm/source_info/tests.rs
@@ -1,0 +1,173 @@
+use crate::vm::source_info::find_entry;
+
+use super::Entry;
+
+#[test]
+fn find_empty() {
+    let entries = &[];
+
+    assert_eq!(find_entry(entries, 0), None);
+}
+
+#[test]
+fn find_unit_ranges() {
+    let entries = &[
+        Entry {
+            pc: 0,
+            position: Some((1, 1).into()),
+        },
+        Entry {
+            pc: 1,
+            position: Some((2, 1).into()),
+        },
+        Entry {
+            pc: 2,
+            position: Some((3, 1).into()),
+        },
+        Entry {
+            pc: 3,
+            position: Some((4, 1).into()),
+        },
+    ];
+
+    assert_eq!(find_entry(entries, 0), Some((1, 1).into()));
+    assert_eq!(find_entry(entries, 1), Some((2, 1).into()));
+    assert_eq!(find_entry(entries, 2), Some((3, 1).into()));
+    assert_eq!(find_entry(entries, 3), Some((4, 1).into()));
+
+    assert_eq!(find_entry(entries, 4), Some((4, 1).into()));
+    assert_eq!(find_entry(entries, u32::MAX), Some((4, 1).into()));
+}
+
+#[test]
+fn find_before_first_entry() {
+    let entries = &[Entry {
+        pc: 10,
+        position: Some((1, 1).into()),
+    }];
+
+    assert_eq!(find_entry(entries, 0), None);
+    assert_eq!(find_entry(entries, 5), None);
+    assert_eq!(find_entry(entries, 10), Some((1, 1).into()));
+}
+
+#[test]
+fn find_past_last_entry() {
+    let entries = &[Entry {
+        pc: 0,
+        position: Some((1, 1).into()),
+    }];
+
+    assert_eq!(find_entry(entries, 0), Some((1, 1).into()));
+    assert_eq!(find_entry(entries, 10), Some((1, 1).into()));
+    assert_eq!(find_entry(entries, u32::MAX), Some((1, 1).into()));
+}
+
+#[test]
+fn find_wide_spaced_ranges_odd() {
+    let entries = &[
+        Entry {
+            pc: 0,
+            position: Some((1, 1).into()),
+        },
+        Entry {
+            pc: 10,
+            position: Some((2, 1).into()),
+        },
+        Entry {
+            pc: 20,
+            position: Some((3, 1).into()),
+        },
+        Entry {
+            pc: 30,
+            position: Some((4, 1).into()),
+        },
+    ];
+
+    assert_eq!(find_entry(entries, 0), Some((1, 1).into()));
+    assert_eq!(find_entry(entries, 5), Some((1, 1).into()));
+    assert_eq!(find_entry(entries, 9), Some((1, 1).into()));
+
+    assert_eq!(find_entry(entries, 10), Some((2, 1).into()));
+    assert_eq!(find_entry(entries, 15), Some((2, 1).into()));
+    assert_eq!(find_entry(entries, 19), Some((2, 1).into()));
+
+    assert_eq!(find_entry(entries, 20), Some((3, 1).into()));
+    assert_eq!(find_entry(entries, 25), Some((3, 1).into()));
+    assert_eq!(find_entry(entries, 29), Some((3, 1).into()));
+
+    assert_eq!(find_entry(entries, 30), Some((4, 1).into()));
+    assert_eq!(find_entry(entries, 35), Some((4, 1).into()));
+    assert_eq!(find_entry(entries, 39), Some((4, 1).into()));
+}
+
+#[test]
+fn find_wide_spaced_ranges_even() {
+    let entries = &[
+        Entry {
+            pc: 0,
+            position: Some((1, 1).into()),
+        },
+        Entry {
+            pc: 10,
+            position: Some((2, 1).into()),
+        },
+        Entry {
+            pc: 20,
+            position: Some((3, 1).into()),
+        },
+        Entry {
+            pc: 30,
+            position: Some((4, 1).into()),
+        },
+        Entry {
+            pc: 40,
+            position: Some((5, 1).into()),
+        },
+    ];
+
+    assert_eq!(find_entry(entries, 0), Some((1, 1).into()));
+    assert_eq!(find_entry(entries, 5), Some((1, 1).into()));
+    assert_eq!(find_entry(entries, 9), Some((1, 1).into()));
+
+    assert_eq!(find_entry(entries, 10), Some((2, 1).into()));
+    assert_eq!(find_entry(entries, 15), Some((2, 1).into()));
+    assert_eq!(find_entry(entries, 19), Some((2, 1).into()));
+
+    assert_eq!(find_entry(entries, 20), Some((3, 1).into()));
+    assert_eq!(find_entry(entries, 25), Some((3, 1).into()));
+    assert_eq!(find_entry(entries, 29), Some((3, 1).into()));
+
+    assert_eq!(find_entry(entries, 30), Some((4, 1).into()));
+    assert_eq!(find_entry(entries, 35), Some((4, 1).into()));
+    assert_eq!(find_entry(entries, 39), Some((4, 1).into()));
+
+    assert_eq!(find_entry(entries, 40), Some((5, 1).into()));
+    assert_eq!(find_entry(entries, 45), Some((5, 1).into()));
+    assert_eq!(find_entry(entries, 49), Some((5, 1).into()));
+}
+
+#[test]
+fn find_with_single_entry() {
+    let entries = &[
+        Entry {
+            pc: 22,
+            position: Some((1, 1).into()),
+        },
+        Entry {
+            pc: 33,
+            position: None,
+        },
+    ];
+
+    assert_eq!(find_entry(entries, 0), None);
+    assert_eq!(find_entry(entries, 10), None);
+    assert_eq!(find_entry(entries, 21), None);
+
+    assert_eq!(find_entry(entries, 22), Some((1, 1).into()));
+    assert_eq!(find_entry(entries, 30), Some((1, 1).into()));
+    assert_eq!(find_entry(entries, 32), Some((1, 1).into()));
+
+    assert_eq!(find_entry(entries, 33), None);
+    assert_eq!(find_entry(entries, u32::MAX), None);
+}

--- a/core/interop/tests/fibonacci.rs
+++ b/core/interop/tests/fibonacci.rs
@@ -80,7 +80,7 @@ fn fibonacci_test() {
     let fibonacci_throw = fibonacci_throw
         .into_js_function_copied(context)
         .to_js_function(context.realm());
-    assert_eq!(
+    assert!(
         fibonacci_js
             .call(
                 context,
@@ -91,7 +91,7 @@ fn fibonacci_test() {
                 )
             )
             .unwrap_err()
-            .to_string(),
-        "\"a is too small\""
+            .to_string()
+            .contains("\"a is too small\""),
     );
 }

--- a/core/runtime/src/lib.rs
+++ b/core/runtime/src/lib.rs
@@ -152,7 +152,7 @@ pub(crate) mod test {
         },
         AssertNativeError {
             source: Cow<'static, str>,
-            kind: builtins::error::Error,
+            kind: builtins::error::ErrorKind,
             message: &'static str,
         },
         AssertContext {

--- a/docs/boa_object.md
+++ b/docs/boa_object.md
@@ -314,6 +314,32 @@ function x() {
 x(); // RuntimeLimit: Maximum recursion limit 100 exceeded
 ```
 
+### Getter & Setter `$boa.limits.backtrace`
+
+This is an accessor property on the module, its getter returns the backtrace limit for a thrown error.
+Its setter can be used to set the backtrace limit.
+
+```javascript
+$boa.limits.backtrace = 100;
+
+function x() {
+  function y() {
+    function z() {
+      throw "Hello";
+    }
+    z();
+  }
+  y();
+}
+x();
+
+// Uncaught "Hello"
+//     at z (test.js:6:13)
+//     at y (test.js:8:6)
+//     at x (test.js:10:4)
+//     at <main> (test.js:12:2)
+```
+
 ## Module `$boa.string`
 
 This module contains helpful functions for getting information about a strings.


### PR DESCRIPTION
This Pull Request closes #1313 and closes #3726.

It changes the following:

- Add position to the `JsError` where error was thrown.
- Add position to all `Error` types where the constructor was called.
- Add shadow stack for keeping track of native and bytecode calls.
- Add limits for backtrace (`$boa.limits.backtrace`)
