### PR TITLE
Implement native backtrace positions

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -28,7 +28,13 @@ color-eyre.workspace = true
 cow-utils.workspace = true
 
 [features]
-default = ["boa_engine/annex-b", "boa_engine/experimental", "boa_engine/intl_bundled", "fast-allocator"]
+default = [
+    "boa_engine/annex-b",
+    "boa_engine/experimental",
+    "boa_engine/intl_bundled",
+    "boa_engine/native-backtrace",
+    "fast-allocator",
+]
 dhat = ["dep:dhat"]
 fast-allocator = ["dep:mimalloc-safe", "dep:jemallocator"]
 
@@ -36,7 +42,9 @@ fast-allocator = ["dep:mimalloc-safe", "dep:jemallocator"]
 jemallocator = { workspace = true, optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-mimalloc-safe = { workspace = true, optional = true, features = ["skip_collect_on_exit"] }
+mimalloc-safe = { workspace = true, optional = true, features = [
+    "skip_collect_on_exit",
+] }
 
 [[bin]]
 name = "boa"

--- a/core/engine/Cargo.toml
+++ b/core/engine/Cargo.toml
@@ -72,6 +72,9 @@ experimental = ["temporal"]
 # Enable binding to JS APIs for system related utilities.
 js = ["dep:web-time", "dep:getrandom"]
 
+# Native Backtraces
+native-backtrace = []
+
 [dependencies]
 tag_ptr.workspace = true
 boa_interner.workspace = true

--- a/core/engine/src/builtins/array/mod.rs
+++ b/core/engine/src/builtins/array/mod.rs
@@ -21,7 +21,7 @@ use crate::{
     object::{
         CONSTRUCTOR, IndexedProperties, JsData, JsObject,
         internal_methods::{
-            InternalMethodContext, InternalObjectMethods, ORDINARY_INTERNAL_METHODS,
+            InternalMethodPropertyContext, InternalObjectMethods, ORDINARY_INTERNAL_METHODS,
             get_prototype_from_constructor, ordinary_define_own_property,
             ordinary_get_own_property,
         },
@@ -378,7 +378,7 @@ impl Array {
                 .enumerable(false)
                 .configurable(false)
                 .build(),
-            &mut InternalMethodContext::new(context),
+            &mut InternalMethodPropertyContext::new(context),
         )?;
 
         Ok(array)
@@ -3422,7 +3422,7 @@ fn array_exotic_define_own_property(
     obj: &JsObject,
     key: &PropertyKey,
     desc: PropertyDescriptor,
-    context: &mut InternalMethodContext<'_>,
+    context: &mut InternalMethodPropertyContext<'_>,
 ) -> JsResult<bool> {
     // 1. Assert: IsPropertyKey(P) is true.
     match key {
@@ -3531,7 +3531,7 @@ fn array_exotic_define_own_property(
 fn array_set_length(
     obj: &JsObject,
     desc: PropertyDescriptor,
-    context: &mut InternalMethodContext<'_>,
+    context: &mut InternalMethodPropertyContext<'_>,
 ) -> JsResult<bool> {
     // 1. If Desc.[[Value]] is absent, then
     let Some(new_len_val) = desc.value() else {

--- a/core/engine/src/builtins/function/arguments.rs
+++ b/core/engine/src/builtins/function/arguments.rs
@@ -5,7 +5,7 @@ use crate::{
     object::{
         JsObject,
         internal_methods::{
-            InternalMethodContext, InternalObjectMethods, ORDINARY_INTERNAL_METHODS,
+            InternalMethodPropertyContext, InternalObjectMethods, ORDINARY_INTERNAL_METHODS,
             ordinary_define_own_property, ordinary_delete, ordinary_get, ordinary_get_own_property,
             ordinary_set, ordinary_try_get,
         },
@@ -282,7 +282,7 @@ impl MappedArguments {
 pub(crate) fn arguments_exotic_get_own_property(
     obj: &JsObject,
     key: &PropertyKey,
-    context: &mut InternalMethodContext<'_>,
+    context: &mut InternalMethodPropertyContext<'_>,
 ) -> JsResult<Option<PropertyDescriptor>> {
     // 1. Let desc be OrdinaryGetOwnProperty(args, P).
     // 2. If desc is undefined, return desc.
@@ -325,7 +325,7 @@ pub(crate) fn arguments_exotic_define_own_property(
     obj: &JsObject,
     key: &PropertyKey,
     desc: PropertyDescriptor,
-    context: &mut InternalMethodContext<'_>,
+    context: &mut InternalMethodPropertyContext<'_>,
 ) -> JsResult<bool> {
     // 2. Let isMapped be HasOwnProperty(map, P).
     let mapped = if let &PropertyKey::Index(index) = &key {
@@ -418,7 +418,7 @@ pub(crate) fn arguments_exotic_try_get(
     obj: &JsObject,
     key: &PropertyKey,
     receiver: JsValue,
-    context: &mut InternalMethodContext<'_>,
+    context: &mut InternalMethodPropertyContext<'_>,
 ) -> JsResult<Option<JsValue>> {
     // 1. Let map be args.[[ParameterMap]].
     // 2. Let isMapped be ! HasOwnProperty(map, P).
@@ -448,7 +448,7 @@ pub(crate) fn arguments_exotic_get(
     obj: &JsObject,
     key: &PropertyKey,
     receiver: JsValue,
-    context: &mut InternalMethodContext<'_>,
+    context: &mut InternalMethodPropertyContext<'_>,
 ) -> JsResult<JsValue> {
     // 1. Let map be args.[[ParameterMap]].
     // 2. Let isMapped be ! HasOwnProperty(map, P).
@@ -479,7 +479,7 @@ pub(crate) fn arguments_exotic_set(
     key: PropertyKey,
     value: JsValue,
     receiver: JsValue,
-    context: &mut InternalMethodContext<'_>,
+    context: &mut InternalMethodPropertyContext<'_>,
 ) -> JsResult<bool> {
     // 1. If SameValue(args, Receiver) is false, then
     // a. Let isMapped be false.
@@ -510,7 +510,7 @@ pub(crate) fn arguments_exotic_set(
 pub(crate) fn arguments_exotic_delete(
     obj: &JsObject,
     key: &PropertyKey,
-    context: &mut InternalMethodContext<'_>,
+    context: &mut InternalMethodPropertyContext<'_>,
 ) -> JsResult<bool> {
     // 3. Let result be ? OrdinaryDelete(args, P).
     let result = ordinary_delete(obj, key, context)?;

--- a/core/engine/src/builtins/function/bound.rs
+++ b/core/engine/src/builtins/function/bound.rs
@@ -6,6 +6,7 @@ use crate::{
         JsData,
         internal_methods::{CallValue, InternalObjectMethods, ORDINARY_INTERNAL_METHODS},
     },
+    vm::source_info::NativeSourceInfo,
 };
 
 /// Binds a `Function Object` when `bind` is called.
@@ -103,6 +104,7 @@ impl BoundFunction {
 fn bound_function_exotic_call(
     obj: &JsObject,
     argument_count: usize,
+    _native_source_info: NativeSourceInfo,
     context: &mut Context,
 ) -> JsResult<CallValue> {
     let bound_function = obj
@@ -146,6 +148,7 @@ fn bound_function_exotic_call(
 fn bound_function_exotic_construct(
     function_object: &JsObject,
     argument_count: usize,
+    _native_source_info: NativeSourceInfo,
     context: &mut Context,
 ) -> JsResult<CallValue> {
     let new_target = context.vm.stack.pop();

--- a/core/engine/src/builtins/function/bound.rs
+++ b/core/engine/src/builtins/function/bound.rs
@@ -4,9 +4,10 @@ use crate::{
     Context, JsObject, JsResult, JsValue,
     object::{
         JsData,
-        internal_methods::{CallValue, InternalObjectMethods, ORDINARY_INTERNAL_METHODS},
+        internal_methods::{
+            CallValue, InternalMethodCallContext, InternalObjectMethods, ORDINARY_INTERNAL_METHODS,
+        },
     },
-    vm::source_info::NativeSourceInfo,
 };
 
 /// Binds a `Function Object` when `bind` is called.
@@ -104,8 +105,7 @@ impl BoundFunction {
 fn bound_function_exotic_call(
     obj: &JsObject,
     argument_count: usize,
-    _native_source_info: NativeSourceInfo,
-    context: &mut Context,
+    context: &mut InternalMethodCallContext<'_>,
 ) -> JsResult<CallValue> {
     let bound_function = obj
         .downcast_ref::<BoundFunction>()
@@ -148,8 +148,7 @@ fn bound_function_exotic_call(
 fn bound_function_exotic_construct(
     function_object: &JsObject,
     argument_count: usize,
-    _native_source_info: NativeSourceInfo,
-    context: &mut Context,
+    context: &mut InternalMethodCallContext<'_>,
 ) -> JsResult<CallValue> {
     let new_target = context.vm.stack.pop();
 

--- a/core/engine/src/builtins/function/mod.rs
+++ b/core/engine/src/builtins/function/mod.rs
@@ -1132,6 +1132,15 @@ fn function_construct(
         .flags
         .set(CallFrameFlags::THIS_VALUE_CACHED, this.is_some());
 
+    #[cfg(feature = "native-backtrace")]
+    {
+        let native_source_info = context.native_source_info();
+        context
+            .vm
+            .shadow_stack
+            .patch_last_native(native_source_info);
+    }
+
     context.vm.push_frame(frame);
 
     let mut last_env = 0;

--- a/core/engine/src/builtins/json/mod.rs
+++ b/core/engine/src/builtins/json/mod.rs
@@ -26,7 +26,7 @@ use crate::{
     context::intrinsics::Intrinsics,
     error::JsNativeError,
     js_string,
-    object::{JsObject, internal_methods::InternalMethodContext},
+    object::{JsObject, internal_methods::InternalMethodPropertyContext},
     property::{Attribute, PropertyNameKind},
     realm::Realm,
     string::{CodePoint, StaticJsStrings},
@@ -205,7 +205,10 @@ impl Json {
                     // 3. If newElement is undefined, then
                     if new_element.is_undefined() {
                         // a. Perform ? val.[[Delete]](prop).
-                        obj.__delete__(&i.into(), &mut InternalMethodContext::new(context))?;
+                        obj.__delete__(
+                            &i.into(),
+                            &mut InternalMethodPropertyContext::new(context),
+                        )?;
                     }
                     // 4. Else,
                     else {
@@ -233,7 +236,10 @@ impl Json {
                     // 2. If newElement is undefined, then
                     if new_element.is_undefined() {
                         // a. Perform ? val.[[Delete]](P).
-                        obj.__delete__(&p.into(), &mut InternalMethodContext::new(context))?;
+                        obj.__delete__(
+                            &p.into(),
+                            &mut InternalMethodPropertyContext::new(context),
+                        )?;
                     }
                     // 3. Else,
                     else {

--- a/core/engine/src/builtins/object/for_in_iterator.rs
+++ b/core/engine/src/builtins/object/for_in_iterator.rs
@@ -14,7 +14,7 @@ use crate::{
     context::intrinsics::Intrinsics,
     error::JsNativeError,
     js_string,
-    object::{JsObject, internal_methods::InternalMethodContext},
+    object::{JsObject, internal_methods::InternalMethodPropertyContext},
     property::PropertyKey,
     realm::Realm,
 };
@@ -103,8 +103,8 @@ impl ForInIterator {
         let mut object = iterator.object.to_object(context)?;
         loop {
             if !iterator.object_was_visited {
-                let keys =
-                    object.__own_property_keys__(&mut InternalMethodContext::new(context))?;
+                let keys = object
+                    .__own_property_keys__(&mut InternalMethodPropertyContext::new(context))?;
                 for k in keys {
                     match k {
                         PropertyKey::String(ref k) => {
@@ -122,7 +122,7 @@ impl ForInIterator {
                 if !iterator.visited_keys.contains(&r)
                     && let Some(desc) = object.__get_own_property__(
                         &PropertyKey::from(r.clone()),
-                        &mut InternalMethodContext::new(context),
+                        &mut InternalMethodPropertyContext::new(context),
                     )?
                 {
                     iterator.visited_keys.insert(r.clone());

--- a/core/engine/src/builtins/proxy/mod.rs
+++ b/core/engine/src/builtins/proxy/mod.rs
@@ -23,8 +23,8 @@ use crate::{
     object::{
         JsData, JsFunction, JsObject, JsPrototype,
         internal_methods::{
-            CallValue, InternalMethodContext, InternalObjectMethods, ORDINARY_INTERNAL_METHODS,
-            is_compatible_property_descriptor,
+            CallValue, InternalMethodPropertyContext, InternalObjectMethods,
+            ORDINARY_INTERNAL_METHODS, is_compatible_property_descriptor,
         },
         shape::slot::SlotAttributes,
     },
@@ -465,7 +465,7 @@ pub(crate) fn proxy_exotic_prevent_extensions(
 pub(crate) fn proxy_exotic_get_own_property(
     obj: &JsObject,
     key: &PropertyKey,
-    context: &mut InternalMethodContext<'_>,
+    context: &mut InternalMethodPropertyContext<'_>,
 ) -> JsResult<Option<PropertyDescriptor>> {
     context.slot().attributes |= SlotAttributes::NOT_CACHABLE;
 
@@ -590,7 +590,7 @@ pub(crate) fn proxy_exotic_define_own_property(
     obj: &JsObject,
     key: &PropertyKey,
     desc: PropertyDescriptor,
-    context: &mut InternalMethodContext<'_>,
+    context: &mut InternalMethodPropertyContext<'_>,
 ) -> JsResult<bool> {
     context.slot().attributes |= SlotAttributes::NOT_CACHABLE;
 
@@ -702,7 +702,7 @@ pub(crate) fn proxy_exotic_define_own_property(
 pub(crate) fn proxy_exotic_has_property(
     obj: &JsObject,
     key: &PropertyKey,
-    context: &mut InternalMethodContext<'_>,
+    context: &mut InternalMethodPropertyContext<'_>,
 ) -> JsResult<bool> {
     context.slot().attributes |= SlotAttributes::NOT_CACHABLE;
 
@@ -773,7 +773,7 @@ pub(crate) fn proxy_exotic_try_get(
     obj: &JsObject,
     key: &PropertyKey,
     receiver: JsValue,
-    context: &mut InternalMethodContext<'_>,
+    context: &mut InternalMethodPropertyContext<'_>,
 ) -> JsResult<Option<JsValue>> {
     // Note: For now, this just calls the normal methods. Could be optimized further.
     if proxy_exotic_has_property(obj, key, context)? {
@@ -793,7 +793,7 @@ pub(crate) fn proxy_exotic_get(
     obj: &JsObject,
     key: &PropertyKey,
     receiver: JsValue,
-    context: &mut InternalMethodContext<'_>,
+    context: &mut InternalMethodPropertyContext<'_>,
 ) -> JsResult<JsValue> {
     // Proxy object can't be cached.
     context.slot().attributes |= SlotAttributes::NOT_CACHABLE;
@@ -864,7 +864,7 @@ pub(crate) fn proxy_exotic_set(
     key: PropertyKey,
     value: JsValue,
     receiver: JsValue,
-    context: &mut InternalMethodContext<'_>,
+    context: &mut InternalMethodPropertyContext<'_>,
 ) -> JsResult<bool> {
     context.slot().attributes |= SlotAttributes::NOT_CACHABLE;
 
@@ -946,7 +946,7 @@ pub(crate) fn proxy_exotic_set(
 pub(crate) fn proxy_exotic_delete(
     obj: &JsObject,
     key: &PropertyKey,
-    context: &mut InternalMethodContext<'_>,
+    context: &mut InternalMethodPropertyContext<'_>,
 ) -> JsResult<bool> {
     // 1. Let handler be O.[[ProxyHandler]].
     // 2. If handler is null, throw a TypeError exception.

--- a/core/engine/src/builtins/proxy/mod.rs
+++ b/core/engine/src/builtins/proxy/mod.rs
@@ -11,8 +11,8 @@
 //! [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy
 
 use super::{BuiltInBuilder, BuiltInConstructor, IntrinsicObject, OrdinaryObject};
+use crate::object::internal_methods::InternalMethodCallContext;
 use crate::value::JsVariant;
-use crate::vm::source_info::NativeSourceInfo;
 use crate::{
     Context, JsArgs, JsResult, JsString, JsValue,
     builtins::{BuiltInObject, array},
@@ -1145,8 +1145,7 @@ pub(crate) fn proxy_exotic_own_property_keys(
 fn proxy_exotic_call(
     obj: &JsObject,
     argument_count: usize,
-    _native_source_info: NativeSourceInfo,
-    context: &mut Context,
+    context: &mut InternalMethodCallContext<'_>,
 ) -> JsResult<CallValue> {
     // 1. Let handler be O.[[ProxyHandler]].
     // 2. If handler is null, throw a TypeError exception.
@@ -1194,8 +1193,7 @@ fn proxy_exotic_call(
 fn proxy_exotic_construct(
     obj: &JsObject,
     argument_count: usize,
-    _native_source_info: NativeSourceInfo,
-    context: &mut Context,
+    context: &mut InternalMethodCallContext<'_>,
 ) -> JsResult<CallValue> {
     // 1. Let handler be O.[[ProxyHandler]].
     // 2. If handler is null, throw a TypeError exception.

--- a/core/engine/src/builtins/proxy/mod.rs
+++ b/core/engine/src/builtins/proxy/mod.rs
@@ -12,6 +12,7 @@
 
 use super::{BuiltInBuilder, BuiltInConstructor, IntrinsicObject, OrdinaryObject};
 use crate::value::JsVariant;
+use crate::vm::source_info::NativeSourceInfo;
 use crate::{
     Context, JsArgs, JsResult, JsString, JsValue,
     builtins::{BuiltInObject, array},
@@ -1144,6 +1145,7 @@ pub(crate) fn proxy_exotic_own_property_keys(
 fn proxy_exotic_call(
     obj: &JsObject,
     argument_count: usize,
+    _native_source_info: NativeSourceInfo,
     context: &mut Context,
 ) -> JsResult<CallValue> {
     // 1. Let handler be O.[[ProxyHandler]].
@@ -1192,6 +1194,7 @@ fn proxy_exotic_call(
 fn proxy_exotic_construct(
     obj: &JsObject,
     argument_count: usize,
+    _native_source_info: NativeSourceInfo,
     context: &mut Context,
 ) -> JsResult<CallValue> {
     // 1. Let handler be O.[[ProxyHandler]].

--- a/core/engine/src/builtins/reflect/mod.rs
+++ b/core/engine/src/builtins/reflect/mod.rs
@@ -18,7 +18,7 @@ use crate::{
     context::intrinsics::Intrinsics,
     error::JsNativeError,
     js_string,
-    object::{JsObject, internal_methods::InternalMethodContext},
+    object::{JsObject, internal_methods::InternalMethodPropertyContext},
     property::Attribute,
     realm::Realm,
     string::StaticJsStrings,
@@ -167,7 +167,7 @@ impl Reflect {
             .__define_own_property__(
                 &key,
                 prop_desc.to_property_descriptor(context)?,
-                &mut InternalMethodContext::new(context),
+                &mut InternalMethodPropertyContext::new(context),
             )
             .map(Into::into)
     }
@@ -192,7 +192,7 @@ impl Reflect {
         let key = args.get_or_undefined(1).to_property_key(context)?;
 
         Ok(target
-            .__delete__(&key, &mut InternalMethodContext::new(context))?
+            .__delete__(&key, &mut InternalMethodPropertyContext::new(context))?
             .into())
     }
 
@@ -220,7 +220,11 @@ impl Reflect {
             .unwrap_or_else(|| target.clone().into());
         // 4. Return ? target.[[Get]](key, receiver).
 
-        target.__get__(&key, receiver, &mut InternalMethodContext::new(context))
+        target.__get__(
+            &key,
+            receiver,
+            &mut InternalMethodPropertyContext::new(context),
+        )
     }
 
     /// Gets a property of an object.
@@ -269,7 +273,7 @@ impl Reflect {
             .and_then(JsValue::as_object)
             .ok_or_else(|| JsNativeError::typ().with_message("target must be an object"))?;
         Ok(target
-            .__get_prototype_of__(&mut InternalMethodContext::new(context))?
+            .__get_prototype_of__(&mut InternalMethodPropertyContext::new(context))?
             .map_or(JsValue::null(), JsValue::new))
     }
 
@@ -292,7 +296,7 @@ impl Reflect {
             .to_property_key(context)?;
 
         Ok(target
-            .__has_property__(&key, &mut InternalMethodContext::new(context))?
+            .__has_property__(&key, &mut InternalMethodPropertyContext::new(context))?
             .into())
     }
 
@@ -314,7 +318,7 @@ impl Reflect {
             .and_then(JsValue::as_object)
             .ok_or_else(|| JsNativeError::typ().with_message("target must be an object"))?;
         Ok(target
-            .__is_extensible__(&mut InternalMethodContext::new(context))?
+            .__is_extensible__(&mut InternalMethodPropertyContext::new(context))?
             .into())
     }
 
@@ -337,7 +341,7 @@ impl Reflect {
             .ok_or_else(|| JsNativeError::typ().with_message("target must be an object"))?;
 
         let keys: Vec<JsValue> = target
-            .__own_property_keys__(&mut InternalMethodContext::new(context))?
+            .__own_property_keys__(&mut InternalMethodPropertyContext::new(context))?
             .into_iter()
             .map(Into::into)
             .collect();
@@ -364,7 +368,7 @@ impl Reflect {
             .ok_or_else(|| JsNativeError::typ().with_message("target must be an object"))?;
 
         Ok(target
-            .__prevent_extensions__(&mut InternalMethodContext::new(context))?
+            .__prevent_extensions__(&mut InternalMethodPropertyContext::new(context))?
             .into())
     }
 
@@ -393,7 +397,7 @@ impl Reflect {
                 key,
                 value.clone(),
                 receiver,
-                &mut InternalMethodContext::new(context),
+                &mut InternalMethodPropertyContext::new(context),
             )?
             .into())
     }
@@ -425,7 +429,7 @@ impl Reflect {
             }
         };
         Ok(target
-            .__set_prototype_of__(proto, &mut InternalMethodContext::new(context))?
+            .__set_prototype_of__(proto, &mut InternalMethodPropertyContext::new(context))?
             .into())
     }
 }

--- a/core/engine/src/builtins/temporal/error.rs
+++ b/core/engine/src/builtins/temporal/error.rs
@@ -3,6 +3,7 @@ use temporal_rs::error::{ErrorKind, TemporalError};
 use crate::{JsError, JsNativeError};
 
 impl From<TemporalError> for JsNativeError {
+    #[cfg_attr(feature = "native-backtrace", track_caller)]
     fn from(value: TemporalError) -> Self {
         match value.kind() {
             ErrorKind::Range | ErrorKind::Syntax => {
@@ -16,6 +17,7 @@ impl From<TemporalError> for JsNativeError {
 }
 
 impl From<TemporalError> for JsError {
+    #[cfg_attr(feature = "native-backtrace", track_caller)]
     fn from(value: TemporalError) -> Self {
         let native: JsNativeError = value.into();
         native.into()

--- a/core/engine/src/builtins/typed_array/object.rs
+++ b/core/engine/src/builtins/typed_array/object.rs
@@ -8,7 +8,7 @@ use crate::{
     object::{
         JsData, JsObject,
         internal_methods::{
-            InternalMethodContext, InternalObjectMethods, ORDINARY_INTERNAL_METHODS,
+            InternalMethodPropertyContext, InternalObjectMethods, ORDINARY_INTERNAL_METHODS,
             ordinary_define_own_property, ordinary_delete, ordinary_get, ordinary_get_own_property,
             ordinary_has_property, ordinary_set, ordinary_try_get,
         },
@@ -289,7 +289,7 @@ fn canonical_numeric_index_string(argument: &JsString) -> Option<f64> {
 pub(crate) fn typed_array_exotic_get_own_property(
     obj: &JsObject,
     key: &PropertyKey,
-    context: &mut InternalMethodContext<'_>,
+    context: &mut InternalMethodPropertyContext<'_>,
 ) -> JsResult<Option<PropertyDescriptor>> {
     let p = match key {
         PropertyKey::String(key) => {
@@ -331,7 +331,7 @@ pub(crate) fn typed_array_exotic_get_own_property(
 pub(crate) fn typed_array_exotic_has_property(
     obj: &JsObject,
     key: &PropertyKey,
-    context: &mut InternalMethodContext<'_>,
+    context: &mut InternalMethodPropertyContext<'_>,
 ) -> JsResult<bool> {
     let p = match key {
         PropertyKey::String(key) => {
@@ -362,7 +362,7 @@ pub(crate) fn typed_array_exotic_define_own_property(
     obj: &JsObject,
     key: &PropertyKey,
     desc: PropertyDescriptor,
-    context: &mut InternalMethodContext<'_>,
+    context: &mut InternalMethodPropertyContext<'_>,
 ) -> JsResult<bool> {
     let p = match key {
         PropertyKey::String(key) => {
@@ -428,7 +428,7 @@ pub(crate) fn typed_array_exotic_try_get(
     obj: &JsObject,
     key: &PropertyKey,
     receiver: JsValue,
-    context: &mut InternalMethodContext<'_>,
+    context: &mut InternalMethodPropertyContext<'_>,
 ) -> JsResult<Option<JsValue>> {
     let p = match key {
         PropertyKey::String(key) => {
@@ -460,7 +460,7 @@ pub(crate) fn typed_array_exotic_get(
     obj: &JsObject,
     key: &PropertyKey,
     receiver: JsValue,
-    context: &mut InternalMethodContext<'_>,
+    context: &mut InternalMethodPropertyContext<'_>,
 ) -> JsResult<JsValue> {
     let p = match key {
         PropertyKey::String(key) => {
@@ -493,7 +493,7 @@ pub(crate) fn typed_array_exotic_set(
     key: PropertyKey,
     value: JsValue,
     receiver: JsValue,
-    context: &mut InternalMethodContext<'_>,
+    context: &mut InternalMethodPropertyContext<'_>,
 ) -> JsResult<bool> {
     let p = match &key {
         PropertyKey::String(key) => {
@@ -535,7 +535,7 @@ pub(crate) fn typed_array_exotic_set(
 pub(crate) fn typed_array_exotic_delete(
     obj: &JsObject,
     key: &PropertyKey,
-    context: &mut InternalMethodContext<'_>,
+    context: &mut InternalMethodPropertyContext<'_>,
 ) -> JsResult<bool> {
     let p = match &key {
         PropertyKey::String(key) => {
@@ -654,7 +654,7 @@ pub(crate) fn typed_array_set_element(
     obj: &JsObject,
     index: f64,
     value: &JsValue,
-    context: &mut InternalMethodContext<'_>,
+    context: &mut InternalMethodPropertyContext<'_>,
 ) -> JsResult<()> {
     let obj = obj
         .clone()

--- a/core/engine/src/context/hooks.rs
+++ b/core/engine/src/context/hooks.rs
@@ -76,6 +76,7 @@ pub trait HostHooks {
     /// - It must perform and return the result of `Call(jobCallback.[[Callback]], V, argumentsList)`.
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-hostcalljobcallback
+    #[cfg_attr(feature = "native-backtrace", track_caller)]
     fn call_job_callback(
         &self,
         job: JobCallback,

--- a/core/engine/src/context/icu.rs
+++ b/core/engine/src/context/icu.rs
@@ -20,12 +20,14 @@ pub enum IcuError {
 }
 
 impl From<IcuError> for JsNativeError {
+    #[cfg_attr(feature = "native-backtrace", track_caller)]
     fn from(value: IcuError) -> Self {
         JsNativeError::typ().with_message(value.to_string())
     }
 }
 
 impl From<IcuError> for JsError {
+    #[cfg_attr(feature = "native-backtrace", track_caller)]
     fn from(value: IcuError) -> Self {
         JsNativeError::from(value).into()
     }

--- a/core/engine/src/error.rs
+++ b/core/engine/src/error.rs
@@ -670,8 +670,22 @@ impl fmt::Display for JsError {
             for entry in shadow_stack.iter().rev() {
                 write!(f, "\n    at ")?;
                 match entry {
-                    ShadowEntry::Native { function_name } => {
-                        write!(f, "{} (native)", function_name.to_std_string_escaped())?;
+                    ShadowEntry::Native {
+                        function_name,
+                        source_info,
+                    } => {
+                        if let Some(loc) = source_info.as_location() {
+                            write!(
+                                f,
+                                "{} (native at {}:{}:{})",
+                                function_name.to_std_string_escaped(),
+                                loc.file(),
+                                loc.line(),
+                                loc.column()
+                            )?;
+                        } else {
+                            write!(f, "{} (native)", function_name.to_std_string_escaped())?;
+                        }
                     }
                     ShadowEntry::Bytecode { pc, source_info } => {
                         let has_function_name = !source_info.function_name().is_empty();

--- a/core/engine/src/error.rs
+++ b/core/engine/src/error.rs
@@ -733,7 +733,7 @@ impl fmt::Display for JsError {
 }
 
 /// Helper struct that ignores equality operator.
-#[derive(Debug, Clone, Finalize, Error)]
+#[derive(Debug, Clone, Finalize)]
 pub(crate) struct IgnoreEq<T>(pub(crate) T);
 
 impl<T> Eq for IgnoreEq<T> {}
@@ -743,6 +743,10 @@ impl<T> PartialEq for IgnoreEq<T> {
     fn eq(&self, _: &Self) -> bool {
         true
     }
+}
+
+impl<T> std::hash::Hash for IgnoreEq<T> {
+    fn hash<H: std::hash::Hasher>(&self, _state: &mut H) {}
 }
 
 impl<T> From<T> for IgnoreEq<T> {

--- a/core/engine/src/error.rs
+++ b/core/engine/src/error.rs
@@ -10,10 +10,17 @@ use crate::{
     object::JsObject,
     property::PropertyDescriptor,
     realm::Realm,
-    vm::shadow_stack::{Backtrace, ShadowEntry},
+    vm::{
+        NativeSourceInfo,
+        shadow_stack::{Backtrace, ShadowEntry},
+    },
 };
 use boa_gc::{Finalize, Trace, custom_trace};
-use std::{borrow::Cow, error, fmt};
+use std::{
+    borrow::Cow,
+    error,
+    fmt::{self},
+};
 use thiserror::Error;
 
 /// Create an error object from a value or string literal. Optionally the
@@ -223,7 +230,7 @@ impl PartialEq for JsError {
 #[derive(Debug, Clone, PartialEq, Eq, Trace, Finalize)]
 #[boa_gc(unsafe_no_drop)]
 enum Repr {
-    Native(JsNativeError),
+    Native(Box<JsNativeError>),
     Opaque(JsValue),
 }
 
@@ -295,9 +302,9 @@ impl JsError {
     /// assert!(error.as_native().is_some());
     /// ```
     #[must_use]
-    pub const fn from_native(err: JsNativeError) -> Self {
+    pub fn from_native(err: JsNativeError) -> Self {
         Self {
-            inner: Repr::Native(err),
+            inner: Repr::Native(Box::new(err)),
             backtrace: None,
         }
     }
@@ -405,7 +412,7 @@ impl JsError {
     /// ```
     pub fn try_native(&self, context: &mut Context) -> Result<JsNativeError, TryNativeError> {
         match &self.inner {
-            Repr::Native(e) => Ok(e.clone()),
+            Repr::Native(e) => Ok(e.as_ref().clone()),
             Repr::Opaque(val) => {
                 let obj = val
                     .as_object()
@@ -440,6 +447,7 @@ impl JsError {
 
                 let cause = try_get_property(js_string!("cause"), "cause", context)?;
 
+                let position = error_data.position.clone();
                 let kind = match error_data.tag {
                     ErrorKind::Error => JsNativeErrorKind::Error,
                     ErrorKind::Eval => JsNativeErrorKind::Eval,
@@ -494,6 +502,7 @@ impl JsError {
                     message,
                     cause: cause.map(|v| Box::new(Self::from_opaque(v))),
                     realm: Some(realm),
+                    position,
                 })
             }
         }
@@ -645,6 +654,7 @@ impl JsError {
 }
 
 impl From<boa_parser::Error> for JsError {
+    #[cfg_attr(feature = "native-backtrace", track_caller)]
     fn from(err: boa_parser::Error) -> Self {
         Self::from(JsNativeError::from(err))
     }
@@ -653,7 +663,7 @@ impl From<boa_parser::Error> for JsError {
 impl From<JsNativeError> for JsError {
     fn from(error: JsNativeError) -> Self {
         Self {
-            inner: Repr::Native(error),
+            inner: Repr::Native(Box::new(error)),
             backtrace: None,
         }
     }
@@ -674,17 +684,22 @@ impl fmt::Display for JsError {
                         function_name,
                         source_info,
                     } => {
+                        if let Some(function_name) = function_name {
+                            write!(f, "{}", function_name.to_std_string_escaped())?;
+                        } else {
+                            f.write_str("<anonymous>")?;
+                        }
+
                         if let Some(loc) = source_info.as_location() {
                             write!(
                                 f,
-                                "{} (native at {}:{}:{})",
-                                function_name.to_std_string_escaped(),
+                                " (native at {}:{}:{})",
                                 loc.file(),
                                 loc.line(),
                                 loc.column()
                             )?;
                         } else {
-                            write!(f, "{} (native)", function_name.to_std_string_escaped())?;
+                            f.write_str(" (native)")?;
                         }
                     }
                     ShadowEntry::Bytecode { pc, source_info } => {
@@ -717,6 +732,26 @@ impl fmt::Display for JsError {
     }
 }
 
+/// Helper struct that ignores equality operator.
+#[derive(Debug, Clone, Finalize, Error)]
+pub(crate) struct IgnoreEq<T>(pub(crate) T);
+
+impl<T> Eq for IgnoreEq<T> {}
+
+impl<T> PartialEq for IgnoreEq<T> {
+    #[inline]
+    fn eq(&self, _: &Self) -> bool {
+        true
+    }
+}
+
+impl<T> From<T> for IgnoreEq<T> {
+    #[inline]
+    fn from(value: T) -> Self {
+        Self(value)
+    }
+}
+
 /// Native representation of an ideal `Error` object from Javascript.
 ///
 /// This representation is more space efficient than its [`JsObject`] equivalent,
@@ -746,6 +781,7 @@ pub struct JsNativeError {
     #[source]
     cause: Option<Box<JsError>>,
     realm: Option<Realm>,
+    position: IgnoreEq<Option<ShadowEntry>>,
 }
 
 impl fmt::Display for JsNativeError {
@@ -755,6 +791,10 @@ impl fmt::Display for JsNativeError {
         let message = self.message.trim();
         if !message.is_empty() {
             write!(f, ": {message}")?;
+        }
+
+        if let Some(position) = &self.position.0 {
+            position.fmt(f)?;
         }
 
         Ok(())
@@ -804,6 +844,7 @@ impl JsNativeError {
     pub const RUNTIME_LIMIT: Self = Self::runtime_limit();
 
     /// Creates a new `JsNativeError` from its `kind`, `message` and (optionally) its `cause`.
+    #[cfg_attr(feature = "native-backtrace", track_caller)]
     const fn new(
         kind: JsNativeErrorKind,
         message: Cow<'static, str>,
@@ -814,6 +855,10 @@ impl JsNativeError {
             message,
             cause,
             realm: None,
+            position: IgnoreEq(Some(ShadowEntry::Native {
+                function_name: None,
+                source_info: NativeSourceInfo::caller(),
+            })),
         }
     }
 
@@ -837,6 +882,7 @@ impl JsNativeError {
     /// ```
     #[must_use]
     #[inline]
+    #[cfg_attr(feature = "native-backtrace", track_caller)]
     pub const fn aggregate(errors: Vec<JsError>) -> Self {
         Self::new(
             JsNativeErrorKind::Aggregate(errors),
@@ -864,6 +910,7 @@ impl JsNativeError {
     /// ```
     #[must_use]
     #[inline]
+    #[cfg_attr(feature = "native-backtrace", track_caller)]
     pub const fn error() -> Self {
         Self::new(JsNativeErrorKind::Error, Cow::Borrowed(""), None)
     }
@@ -887,6 +934,7 @@ impl JsNativeError {
     /// ```
     #[must_use]
     #[inline]
+    #[cfg_attr(feature = "native-backtrace", track_caller)]
     pub const fn eval() -> Self {
         Self::new(JsNativeErrorKind::Eval, Cow::Borrowed(""), None)
     }
@@ -910,6 +958,7 @@ impl JsNativeError {
     /// ```
     #[must_use]
     #[inline]
+    #[cfg_attr(feature = "native-backtrace", track_caller)]
     pub const fn range() -> Self {
         Self::new(JsNativeErrorKind::Range, Cow::Borrowed(""), None)
     }
@@ -933,6 +982,7 @@ impl JsNativeError {
     /// ```
     #[must_use]
     #[inline]
+    #[cfg_attr(feature = "native-backtrace", track_caller)]
     pub const fn reference() -> Self {
         Self::new(JsNativeErrorKind::Reference, Cow::Borrowed(""), None)
     }
@@ -956,6 +1006,7 @@ impl JsNativeError {
     /// ```
     #[must_use]
     #[inline]
+    #[cfg_attr(feature = "native-backtrace", track_caller)]
     pub const fn syntax() -> Self {
         Self::new(JsNativeErrorKind::Syntax, Cow::Borrowed(""), None)
     }
@@ -979,6 +1030,7 @@ impl JsNativeError {
     /// ```
     #[must_use]
     #[inline]
+    #[cfg_attr(feature = "native-backtrace", track_caller)]
     pub const fn typ() -> Self {
         Self::new(JsNativeErrorKind::Type, Cow::Borrowed(""), None)
     }
@@ -1002,6 +1054,7 @@ impl JsNativeError {
     /// ```
     #[must_use]
     #[inline]
+    #[cfg_attr(feature = "native-backtrace", track_caller)]
     pub const fn uri() -> Self {
         Self::new(JsNativeErrorKind::Uri, Cow::Borrowed(""), None)
     }
@@ -1017,6 +1070,7 @@ impl JsNativeError {
     /// is only used in a fuzzing context.
     #[cfg(feature = "fuzz")]
     #[must_use]
+    #[cfg_attr(feature = "native-backtrace", track_caller)]
     pub const fn no_instructions_remain() -> Self {
         Self::new(
             JsNativeErrorKind::NoInstructionsRemain,
@@ -1036,6 +1090,7 @@ impl JsNativeError {
     /// Creates a new `JsNativeError` that indicates that the context exceeded the runtime limits.
     #[must_use]
     #[inline]
+    #[cfg_attr(feature = "native-backtrace", track_caller)]
     pub const fn runtime_limit() -> Self {
         Self::new(JsNativeErrorKind::RuntimeLimit, Cow::Borrowed(""), None)
     }
@@ -1160,6 +1215,7 @@ impl JsNativeError {
             message,
             cause,
             realm,
+            position,
         } = self;
         let constructors = realm.as_ref().map_or_else(
             || context.intrinsics().constructors(),
@@ -1196,7 +1252,7 @@ impl JsNativeError {
         let o = JsObject::from_proto_and_data_with_shared_shape(
             context.root_shape(),
             prototype,
-            Error::new(tag),
+            Error::with_shadow_entry(tag, position.0.clone()),
         );
 
         o.create_non_enumerable_data_property_or_throw(
@@ -1247,6 +1303,7 @@ impl JsNativeError {
 }
 
 impl From<boa_parser::Error> for JsNativeError {
+    #[cfg_attr(feature = "native-backtrace", track_caller)]
     fn from(err: boa_parser::Error) -> Self {
         Self::syntax().with_message(err.to_string())
     }

--- a/core/engine/src/module/namespace.rs
+++ b/core/engine/src/module/namespace.rs
@@ -7,7 +7,7 @@ use boa_gc::{Finalize, Trace};
 
 use crate::object::internal_methods::immutable_prototype::immutable_prototype_exotic_set_prototype_of;
 use crate::object::internal_methods::{
-    InternalMethodContext, InternalObjectMethods, ORDINARY_INTERNAL_METHODS,
+    InternalMethodPropertyContext, InternalObjectMethods, ORDINARY_INTERNAL_METHODS,
     ordinary_define_own_property, ordinary_delete, ordinary_get, ordinary_get_own_property,
     ordinary_has_property, ordinary_own_property_keys, ordinary_try_get,
 };
@@ -142,7 +142,7 @@ fn module_namespace_exotic_prevent_extensions(_: &JsObject, _: &mut Context) -> 
 fn module_namespace_exotic_get_own_property(
     obj: &JsObject,
     key: &PropertyKey,
-    context: &mut InternalMethodContext<'_>,
+    context: &mut InternalMethodPropertyContext<'_>,
 ) -> JsResult<Option<PropertyDescriptor>> {
     // 1. If P is a Symbol, return OrdinaryGetOwnProperty(O, P).
     let key = match key {
@@ -185,7 +185,7 @@ fn module_namespace_exotic_define_own_property(
     obj: &JsObject,
     key: &PropertyKey,
     desc: PropertyDescriptor,
-    context: &mut InternalMethodContext<'_>,
+    context: &mut InternalMethodPropertyContext<'_>,
 ) -> JsResult<bool> {
     // 1. If P is a Symbol, return ! OrdinaryDefineOwnProperty(O, P, Desc).
     if let PropertyKey::Symbol(_) = key {
@@ -221,7 +221,7 @@ fn module_namespace_exotic_define_own_property(
 fn module_namespace_exotic_has_property(
     obj: &JsObject,
     key: &PropertyKey,
-    context: &mut InternalMethodContext<'_>,
+    context: &mut InternalMethodPropertyContext<'_>,
 ) -> JsResult<bool> {
     // 1. If P is a Symbol, return ! OrdinaryHasProperty(O, P).
     let key = match key {
@@ -256,7 +256,7 @@ fn module_namespace_exotic_try_get(
     obj: &JsObject,
     key: &PropertyKey,
     receiver: JsValue,
-    context: &mut InternalMethodContext<'_>,
+    context: &mut InternalMethodPropertyContext<'_>,
 ) -> JsResult<Option<JsValue>> {
     // 1. If P is a Symbol, then
     //     a. Return ! OrdinaryGet(O, P, Receiver).
@@ -337,7 +337,7 @@ fn module_namespace_exotic_get(
     obj: &JsObject,
     key: &PropertyKey,
     receiver: JsValue,
-    context: &mut InternalMethodContext<'_>,
+    context: &mut InternalMethodPropertyContext<'_>,
 ) -> JsResult<JsValue> {
     // 1. If P is a Symbol, then
     //     a. Return ! OrdinaryGet(O, P, Receiver).
@@ -419,7 +419,7 @@ fn module_namespace_exotic_set(
     _key: PropertyKey,
     _value: JsValue,
     _receiver: JsValue,
-    _context: &mut InternalMethodContext<'_>,
+    _context: &mut InternalMethodPropertyContext<'_>,
 ) -> JsResult<bool> {
     // 1. Return false.
     Ok(false)
@@ -431,7 +431,7 @@ fn module_namespace_exotic_set(
 fn module_namespace_exotic_delete(
     obj: &JsObject,
     key: &PropertyKey,
-    context: &mut InternalMethodContext<'_>,
+    context: &mut InternalMethodPropertyContext<'_>,
 ) -> JsResult<bool> {
     // 1. If P is a Symbol, then
     //     a. Return ! OrdinaryDelete(O, P).

--- a/core/engine/src/native_function/mod.rs
+++ b/core/engine/src/native_function/mod.rs
@@ -10,6 +10,7 @@ use boa_string::JsString;
 
 use crate::job::NativeAsyncJob;
 use crate::value::JsVariant;
+use crate::vm::source_info::NativeSourceInfo;
 use crate::{
     Context, JsNativeError, JsObject, JsResult, JsValue,
     builtins::{OrdinaryObject, function::ConstructorKind},
@@ -412,6 +413,7 @@ impl NativeFunction {
 pub(crate) fn native_function_call(
     obj: &JsObject,
     argument_count: usize,
+    native_source_info: NativeSourceInfo,
     context: &mut Context,
 ) -> JsResult<CallValue> {
     let args = context
@@ -439,7 +441,7 @@ pub(crate) fn native_function_call(
     context
         .vm
         .shadow_stack
-        .push_native(context.vm.frame.pc, name);
+        .push_native(context.vm.frame.pc, name, native_source_info);
 
     let mut realm = realm.unwrap_or_else(|| context.realm().clone());
 
@@ -472,6 +474,7 @@ pub(crate) fn native_function_call(
 fn native_function_construct(
     obj: &JsObject,
     argument_count: usize,
+    native_source_info: NativeSourceInfo,
     context: &mut Context,
 ) -> JsResult<CallValue> {
     // We technically don't need this since native functions don't push any new frames to the
@@ -492,7 +495,7 @@ fn native_function_construct(
     context
         .vm
         .shadow_stack
-        .push_native(context.vm.frame.pc, name);
+        .push_native(context.vm.frame.pc, name, native_source_info);
 
     let mut realm = realm.unwrap_or_else(|| context.realm().clone());
 

--- a/core/engine/src/object/builtins/jsfunction.rs
+++ b/core/engine/src/object/builtins/jsfunction.rs
@@ -64,12 +64,14 @@ impl<A: TryIntoJsArguments, R: TryFromJs> TypedJsFunction<A, R> {
 
     /// Call the function with the given arguments.
     #[inline]
+    #[cfg_attr(feature = "native-backtrace", track_caller)]
     pub fn call(&self, context: &mut Context, args: A) -> JsResult<R> {
         self.call_with_this(&JsValue::undefined(), context, args)
     }
 
     /// Call the function with the given argument and `this`.
     #[inline]
+    #[cfg_attr(feature = "native-backtrace", track_caller)]
     pub fn call_with_this(&self, this: &JsValue, context: &mut Context, args: A) -> JsResult<R> {
         let arguments = args.into_js_args(context)?;
         let result = self.inner.call(this, &arguments, context)?;

--- a/core/engine/src/object/internal_methods/string.rs
+++ b/core/engine/src/object/internal_methods/string.rs
@@ -4,7 +4,7 @@ use crate::{
     property::{PropertyDescriptor, PropertyKey},
 };
 
-use super::{InternalMethodContext, InternalObjectMethods, ORDINARY_INTERNAL_METHODS};
+use super::{InternalMethodPropertyContext, InternalObjectMethods, ORDINARY_INTERNAL_METHODS};
 
 impl JsData for JsString {
     fn internal_methods(&self) -> &'static InternalObjectMethods {
@@ -28,7 +28,7 @@ impl JsData for JsString {
 pub(crate) fn string_exotic_get_own_property(
     obj: &JsObject,
     key: &PropertyKey,
-    context: &mut InternalMethodContext<'_>,
+    context: &mut InternalMethodPropertyContext<'_>,
 ) -> JsResult<Option<PropertyDescriptor>> {
     // 1. Assert: IsPropertyKey(P) is true.
     // 2. Let desc be OrdinaryGetOwnProperty(S, P).
@@ -53,7 +53,7 @@ pub(crate) fn string_exotic_define_own_property(
     obj: &JsObject,
     key: &PropertyKey,
     desc: PropertyDescriptor,
-    context: &mut InternalMethodContext<'_>,
+    context: &mut InternalMethodPropertyContext<'_>,
 ) -> JsResult<bool> {
     // 1. Assert: IsPropertyKey(P) is true.
     // 2. Let stringDesc be ! StringGetOwnProperty(S, P).

--- a/core/engine/src/object/jsobject.rs
+++ b/core/engine/src/object/jsobject.rs
@@ -4,7 +4,9 @@
 
 use super::{
     JsPrototype, NativeObject, Object, PrivateName, PropertyMap,
-    internal_methods::{InternalMethodContext, InternalObjectMethods, ORDINARY_INTERNAL_METHODS},
+    internal_methods::{
+        InternalMethodPropertyContext, InternalObjectMethods, ORDINARY_INTERNAL_METHODS,
+    },
     shape::RootShape,
 };
 use crate::{
@@ -568,7 +570,7 @@ Cannot both specify accessors and a value or writable attribute",
     where
         K: Into<PropertyKey>,
     {
-        let context = &mut InternalMethodContext::new(context);
+        let context = &mut InternalMethodPropertyContext::new(context);
 
         // 1. Assert: Type(target) is Object.
         // 2. Assert: excludedItems is a List of property keys.

--- a/core/engine/src/object/operations.rs
+++ b/core/engine/src/object/operations.rs
@@ -1,4 +1,4 @@
-use super::internal_methods::InternalMethodContext;
+use super::internal_methods::InternalMethodPropertyContext;
 use crate::value::JsVariant;
 use crate::{
     Context, JsResult, JsSymbol, JsValue,
@@ -80,7 +80,7 @@ impl JsObject {
         self.__get__(
             &key.into(),
             self.clone().into(),
-            &mut InternalMethodContext::new(context),
+            &mut InternalMethodPropertyContext::new(context),
         )
     }
 
@@ -104,7 +104,7 @@ impl JsObject {
             key.clone(),
             value.into(),
             self.clone().into(),
-            &mut InternalMethodContext::new(context),
+            &mut InternalMethodPropertyContext::new(context),
         )?;
         // 5. If success is false and Throw is true, throw a TypeError exception.
         if !success && throw {
@@ -144,7 +144,7 @@ impl JsObject {
         self.__define_own_property__(
             &key.into(),
             new_desc.into(),
-            &mut InternalMethodContext::new(context),
+            &mut InternalMethodPropertyContext::new(context),
         )
     }
 
@@ -158,7 +158,7 @@ impl JsObject {
         &self,
         key: K,
         value: V,
-        context: &mut InternalMethodContext<'_>,
+        context: &mut InternalMethodPropertyContext<'_>,
     ) -> JsResult<bool>
     where
         K: Into<PropertyKey>,
@@ -269,7 +269,7 @@ impl JsObject {
         let success = self.__define_own_property__(
             &key,
             desc.into(),
-            &mut InternalMethodContext::new(context),
+            &mut InternalMethodPropertyContext::new(context),
         )?;
         // 4. If success is false, throw a TypeError exception.
         if !success {
@@ -295,7 +295,7 @@ impl JsObject {
         // 1. Assert: Type(O) is Object.
         // 2. Assert: IsPropertyKey(P) is true.
         // 3. Let success be ? O.[[Delete]](P).
-        let success = self.__delete__(&key, &mut InternalMethodContext::new(context))?;
+        let success = self.__delete__(&key, &mut InternalMethodPropertyContext::new(context))?;
         // 4. If success is false, throw a TypeError exception.
         if !success {
             return Err(JsNativeError::typ()
@@ -320,7 +320,10 @@ impl JsObject {
         // 2. Assert: IsPropertyKey(P) is true.
         // 3. Return ? O.[[HasProperty]](P).
 
-        self.__has_property__(&key.into(), &mut InternalMethodContext::new(context))
+        self.__has_property__(
+            &key.into(),
+            &mut InternalMethodPropertyContext::new(context),
+        )
     }
 
     /// Abstract optimization operation.
@@ -341,7 +344,7 @@ impl JsObject {
         self.__try_get__(
             &key.into(),
             self.clone().into(),
-            &mut InternalMethodContext::new(context),
+            &mut InternalMethodPropertyContext::new(context),
         )
     }
 
@@ -359,7 +362,8 @@ impl JsObject {
         // 1. Assert: Type(O) is Object.
         // 2. Assert: IsPropertyKey(P) is true.
         // 3. Let desc be ? O.[[GetOwnProperty]](P).
-        let desc = self.__get_own_property__(&key, &mut InternalMethodContext::new(context))?;
+        let desc =
+            self.__get_own_property__(&key, &mut InternalMethodPropertyContext::new(context))?;
         // 4. If desc is undefined, return false.
         // 5. Return true.
         Ok(desc.is_some())
@@ -491,14 +495,15 @@ impl JsObject {
         // 2. Assert: level is either sealed or frozen.
 
         // 3. Let status be ? O.[[PreventExtensions]]().
-        let status = self.__prevent_extensions__(&mut InternalMethodContext::new(context))?;
+        let status =
+            self.__prevent_extensions__(&mut InternalMethodPropertyContext::new(context))?;
         // 4. If status is false, return false.
         if !status {
             return Ok(false);
         }
 
         // 5. Let keys be ? O.[[OwnPropertyKeys]]().
-        let keys = self.__own_property_keys__(&mut InternalMethodContext::new(context))?;
+        let keys = self.__own_property_keys__(&mut InternalMethodPropertyContext::new(context))?;
 
         match level {
             // 6. If level is sealed, then
@@ -519,8 +524,10 @@ impl JsObject {
                 // b. For each element k of keys, do
                 for k in keys {
                     // i. Let currentDesc be ? O.[[GetOwnProperty]](k).
-                    let current_desc =
-                        self.__get_own_property__(&k, &mut InternalMethodContext::new(context))?;
+                    let current_desc = self.__get_own_property__(
+                        &k,
+                        &mut InternalMethodPropertyContext::new(context),
+                    )?;
                     // ii. If currentDesc is not undefined, then
                     if let Some(current_desc) = current_desc {
                         // 1. If IsAccessorDescriptor(currentDesc) is true, then
@@ -570,13 +577,13 @@ impl JsObject {
 
         // 5. NOTE: If the object is extensible, none of its properties are examined.
         // 6. Let keys be ? O.[[OwnPropertyKeys]]().
-        let keys = self.__own_property_keys__(&mut InternalMethodContext::new(context))?;
+        let keys = self.__own_property_keys__(&mut InternalMethodPropertyContext::new(context))?;
 
         // 7. For each element k of keys, do
         for k in keys {
             // a. Let currentDesc be ? O.[[GetOwnProperty]](k).
             let current_desc =
-                self.__get_own_property__(&k, &mut InternalMethodContext::new(context))?;
+                self.__get_own_property__(&k, &mut InternalMethodPropertyContext::new(context))?;
             // b. If currentDesc is not undefined, then
             if let Some(current_desc) = current_desc {
                 // i. If currentDesc.[[Configurable]] is true, return false.
@@ -686,7 +693,8 @@ impl JsObject {
     ) -> JsResult<Vec<JsValue>> {
         // 1. Assert: Type(O) is Object.
         // 2. Let ownKeys be ? O.[[OwnPropertyKeys]]().
-        let own_keys = self.__own_property_keys__(&mut InternalMethodContext::new(context))?;
+        let own_keys =
+            self.__own_property_keys__(&mut InternalMethodPropertyContext::new(context))?;
         // 3. Let properties be a new empty List.
         let mut properties = vec![];
 
@@ -701,8 +709,8 @@ impl JsObject {
 
             if let Some(key_str) = key_str {
                 // i. Let desc be ? O.[[GetOwnProperty]](key).
-                let desc =
-                    self.__get_own_property__(&key, &mut InternalMethodContext::new(context))?;
+                let desc = self
+                    .__get_own_property__(&key, &mut InternalMethodPropertyContext::new(context))?;
                 // ii. If desc is not undefined and desc.[[Enumerable]] is true, then
                 if let Some(desc) = desc
                     && desc.expect_enumerable()
@@ -758,7 +766,7 @@ impl JsObject {
             .__get__(
                 &key.into(),
                 self.clone().into(),
-                &mut InternalMethodContext::new(context),
+                &mut InternalMethodPropertyContext::new(context),
             )?
             .variant()
         {
@@ -1175,7 +1183,7 @@ impl JsObject {
         let func = self.__get__(
             &key.into(),
             this_value.clone(),
-            &mut InternalMethodContext::new(context),
+            &mut InternalMethodPropertyContext::new(context),
         )?;
 
         // 3. Return ? Call(func, V, argumentsList)
@@ -1206,7 +1214,7 @@ impl JsValue {
         o.__get__(
             &key.into(),
             self.clone(),
-            &mut InternalMethodContext::new(context),
+            &mut InternalMethodPropertyContext::new(context),
         )
     }
 
@@ -1373,7 +1381,9 @@ impl JsValue {
         // 6. Repeat,
         loop {
             // a. Set O to ? O.[[GetPrototypeOf]]().
-            object = match object.__get_prototype_of__(&mut InternalMethodContext::new(context))? {
+            object = match object
+                .__get_prototype_of__(&mut InternalMethodPropertyContext::new(context))?
+            {
                 Some(obj) => obj,
                 // b. If O is null, return false.
                 None => return Ok(false),

--- a/core/engine/src/object/operations.rs
+++ b/core/engine/src/object/operations.rs
@@ -1298,6 +1298,7 @@ impl JsValue {
     ///
     /// [call]: https://tc39.es/ecma262/#sec-call
     #[inline]
+    #[cfg_attr(feature = "native-backtrace", track_caller)]
     pub(crate) fn call(&self, this: &Self, args: &[Self], context: &mut Context) -> JsResult<Self> {
         let Some(object) = self.as_object() else {
             return Err(JsNativeError::typ()
@@ -1319,6 +1320,7 @@ impl JsValue {
     /// - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-invoke
+    #[cfg_attr(feature = "native-backtrace", track_caller)]
     pub(crate) fn invoke<K>(&self, key: K, args: &[Self], context: &mut Context) -> JsResult<Self>
     where
         K: Into<PropertyKey>,

--- a/core/engine/src/value/conversions/serde_json.rs
+++ b/core/engine/src/value/conversions/serde_json.rs
@@ -308,12 +308,13 @@ mod tests {
         let obj = JsObject::with_null_proto();
         obj.create_data_property(js_string!("a"), obj.clone(), &mut context)
             .expect("should create data property");
-        assert_eq!(
+
+        assert!(
             JsValue::from(obj)
                 .to_json(&mut context)
                 .unwrap_err()
-                .to_string(),
-            "TypeError: cyclic object value"
+                .to_string()
+                .starts_with("TypeError: cyclic object value"),
         );
     }
 

--- a/core/engine/src/value/display.rs
+++ b/core/engine/src/value/display.rs
@@ -234,13 +234,20 @@ pub(crate) fn log_string_from(x: &JsValue, print_internals: bool, print_children
 
                 if let Some(position) = &data.position {
                     match position {
-                        ShadowEntry::Native { function_name } => {
+                        ShadowEntry::Native {
+                            function_name,
+                            source_info,
+                        } => {
                             write!(
                                 &mut result,
-                                " (native at {})",
+                                " (native {}",
                                 function_name.to_std_string_escaped()
                             )
                             .expect("should not fail");
+                            if let Some(location) = source_info.as_location() {
+                                write!(&mut result, " at {location}").expect("should not fail");
+                            }
+                            result.push(')');
                         }
                         ShadowEntry::Bytecode { pc, source_info } => {
                             write!(&mut result, " ({}", source_info.map().path())

--- a/core/engine/src/value/display.rs
+++ b/core/engine/src/value/display.rs
@@ -7,7 +7,6 @@ use crate::{
     },
     js_string,
     property::PropertyDescriptor,
-    vm::shadow_stack::ShadowEntry,
 };
 use std::{borrow::Cow, fmt::Write};
 
@@ -232,40 +231,8 @@ pub(crate) fn log_string_from(x: &JsValue, print_internals: bool, print_children
                     .downcast_ref::<Error>()
                     .expect("already checked object type");
 
-                if let Some(position) = &data.position {
-                    match position {
-                        ShadowEntry::Native {
-                            function_name,
-                            source_info,
-                        } => {
-                            write!(
-                                &mut result,
-                                " (native {}",
-                                function_name.to_std_string_escaped()
-                            )
-                            .expect("should not fail");
-                            if let Some(location) = source_info.as_location() {
-                                write!(&mut result, " at {location}").expect("should not fail");
-                            }
-                            result.push(')');
-                        }
-                        ShadowEntry::Bytecode { pc, source_info } => {
-                            write!(&mut result, " ({}", source_info.map().path())
-                                .expect("should not fail");
-
-                            if let Some(position) = source_info.map().find(*pc) {
-                                write!(
-                                    &mut result,
-                                    ":{}:{}",
-                                    position.line_number(),
-                                    position.column_number()
-                                )
-                                .expect("should not fail");
-                            }
-
-                            result.push(')');
-                        }
-                    }
+                if let Some(position) = &data.position.0 {
+                    write!(&mut result, "{position}").expect("should not fail");
                 }
                 result
             } else if let Some(promise) = v.downcast_ref::<Promise>() {

--- a/core/engine/src/value/tests.rs
+++ b/core/engine/src/value/tests.rs
@@ -2,7 +2,7 @@ use boa_macros::js_str;
 use indoc::indoc;
 
 use super::*;
-use crate::object::internal_methods::InternalMethodContext;
+use crate::object::internal_methods::InternalMethodPropertyContext;
 use crate::{TestAction, js_string, run_test_actions};
 
 use std::collections::hash_map::DefaultHasher;
@@ -206,7 +206,7 @@ fn string_length_is_not_enumerable() {
         let length_desc = object
             .__get_own_property__(
                 &PropertyKey::from(js_string!("length")),
-                &mut InternalMethodContext::new(context),
+                &mut InternalMethodPropertyContext::new(context),
             )
             .unwrap()
             .unwrap();
@@ -223,7 +223,7 @@ fn string_length_is_in_utf16_codeunits() {
         let length_desc = object
             .__get_own_property__(
                 &PropertyKey::from(js_string!("length")),
-                &mut InternalMethodContext::new(context),
+                &mut InternalMethodPropertyContext::new(context),
             )
             .unwrap()
             .unwrap();

--- a/core/engine/src/vm/inline_cache/tests.rs
+++ b/core/engine/src/vm/inline_cache/tests.rs
@@ -7,7 +7,7 @@ use crate::{
     js_string,
     object::{
         ObjectInitializer,
-        internal_methods::InternalMethodContext,
+        internal_methods::InternalMethodPropertyContext,
         shape::{WeakShape, slot::SlotAttributes},
     },
     property::{Attribute, PropertyDescriptor, PropertyKey},
@@ -30,7 +30,7 @@ fn get_own_property_internal_method() {
     o.set(property.clone(), value, true, context)
         .expect("should not fail");
 
-    let context = &mut InternalMethodContext::new(context);
+    let context = &mut InternalMethodPropertyContext::new(context);
 
     assert_eq!(context.slot().index, 0);
     assert_eq!(context.slot().attributes, SlotAttributes::empty());
@@ -75,7 +75,7 @@ fn get_internal_method() {
     o.set(property.clone(), value, true, context)
         .expect("should not fail");
 
-    let context = &mut InternalMethodContext::new(context);
+    let context = &mut InternalMethodPropertyContext::new(context);
 
     assert_eq!(context.slot().index, 0);
     assert_eq!(context.slot().attributes, SlotAttributes::empty());
@@ -123,7 +123,7 @@ fn get_internal_method_in_prototype() {
         .set(property.clone(), value, true, context)
         .expect("should not fail");
 
-    let context = &mut InternalMethodContext::new(context);
+    let context = &mut InternalMethodPropertyContext::new(context);
 
     assert_eq!(context.slot().index, 0);
     assert_eq!(context.slot().attributes, SlotAttributes::empty());
@@ -168,7 +168,7 @@ fn define_own_property_internal_method_non_existant_property() {
     o.set(property.clone(), value, true, context)
         .expect("should not fail");
 
-    let context = &mut InternalMethodContext::new(context);
+    let context = &mut InternalMethodPropertyContext::new(context);
 
     assert_eq!(context.slot().index, 0);
     assert_eq!(context.slot().attributes, SlotAttributes::empty());
@@ -234,7 +234,7 @@ fn define_own_property_internal_method_existing_property_property() {
     )
     .expect("should not fail");
 
-    let context = &mut InternalMethodContext::new(context);
+    let context = &mut InternalMethodPropertyContext::new(context);
 
     assert_eq!(context.slot().index, 0);
     assert_eq!(context.slot().attributes, SlotAttributes::empty());
@@ -288,7 +288,7 @@ fn set_internal_method() {
     o.set(property.clone(), value, true, context)
         .expect("should not fail");
 
-    let context = &mut InternalMethodContext::new(context);
+    let context = &mut InternalMethodPropertyContext::new(context);
 
     assert_eq!(context.slot().index, 0);
     assert_eq!(context.slot().attributes, SlotAttributes::empty());

--- a/core/engine/src/vm/mod.rs
+++ b/core/engine/src/vm/mod.rs
@@ -38,6 +38,7 @@ pub use runtime_limits::RuntimeLimits;
 pub use {
     call_frame::{CallFrame, GeneratorResumeKind},
     code_block::CodeBlock,
+    source_info::NativeSourceInfo,
 };
 
 mod call_frame;

--- a/core/engine/src/vm/opcode/define/class/getter.rs
+++ b/core/engine/src/vm/opcode/define/class/getter.rs
@@ -3,7 +3,7 @@ use boa_macros::js_str;
 use crate::{
     Context, JsResult,
     builtins::function::{OrdinaryFunction, set_function_name},
-    object::internal_methods::InternalMethodContext,
+    object::internal_methods::InternalMethodPropertyContext,
     property::PropertyDescriptor,
     vm::opcode::{Operation, VaryingOperand},
 };
@@ -41,7 +41,7 @@ impl DefineClassStaticGetterByName {
                 .set_home_object(class.clone());
         }
         let set = class
-            .__get_own_property__(&key, &mut InternalMethodContext::new(context))?
+            .__get_own_property__(&key, &mut InternalMethodPropertyContext::new(context))?
             .as_ref()
             .and_then(PropertyDescriptor::set)
             .cloned();
@@ -53,7 +53,7 @@ impl DefineClassStaticGetterByName {
                 .enumerable(false)
                 .configurable(true)
                 .build(),
-            &mut InternalMethodContext::new(context),
+            &mut InternalMethodPropertyContext::new(context),
         )?;
         Ok(())
     }
@@ -98,7 +98,7 @@ impl DefineClassGetterByName {
                 .set_home_object(class_proto.clone());
         }
         let set = class_proto
-            .__get_own_property__(&key, &mut InternalMethodContext::new(context))?
+            .__get_own_property__(&key, &mut InternalMethodPropertyContext::new(context))?
             .as_ref()
             .and_then(PropertyDescriptor::set)
             .cloned();
@@ -110,7 +110,7 @@ impl DefineClassGetterByName {
                 .enumerable(false)
                 .configurable(true)
                 .build(),
-            &mut InternalMethodContext::new(context),
+            &mut InternalMethodPropertyContext::new(context),
         )?;
         Ok(())
     }
@@ -154,7 +154,7 @@ impl DefineClassStaticGetterByValue {
         }
 
         let set = class
-            .__get_own_property__(&key, &mut InternalMethodContext::new(context))?
+            .__get_own_property__(&key, &mut InternalMethodPropertyContext::new(context))?
             .as_ref()
             .and_then(PropertyDescriptor::set)
             .cloned();
@@ -209,7 +209,7 @@ impl DefineClassGetterByValue {
                 .set_home_object(class_proto.clone());
         }
         let set = class_proto
-            .__get_own_property__(&key, &mut InternalMethodContext::new(context))?
+            .__get_own_property__(&key, &mut InternalMethodPropertyContext::new(context))?
             .as_ref()
             .and_then(PropertyDescriptor::set)
             .cloned();
@@ -221,7 +221,7 @@ impl DefineClassGetterByValue {
                 .enumerable(false)
                 .configurable(true)
                 .build(),
-            &mut InternalMethodContext::new(context),
+            &mut InternalMethodPropertyContext::new(context),
         )?;
         Ok(())
     }

--- a/core/engine/src/vm/opcode/define/class/method.rs
+++ b/core/engine/src/vm/opcode/define/class/method.rs
@@ -1,7 +1,7 @@
 use crate::{
     Context, JsResult,
     builtins::function::{OrdinaryFunction, set_function_name},
-    object::internal_methods::InternalMethodContext,
+    object::internal_methods::InternalMethodPropertyContext,
     property::PropertyDescriptor,
     vm::opcode::{Operation, VaryingOperand},
 };
@@ -47,7 +47,7 @@ impl DefineClassStaticMethodByName {
                 .enumerable(false)
                 .configurable(true)
                 .build(),
-            &mut InternalMethodContext::new(context),
+            &mut InternalMethodPropertyContext::new(context),
         )?;
         Ok(())
     }
@@ -100,7 +100,7 @@ impl DefineClassMethodByName {
                 .enumerable(false)
                 .configurable(true)
                 .build(),
-            &mut InternalMethodContext::new(context),
+            &mut InternalMethodPropertyContext::new(context),
         )?;
         Ok(())
     }
@@ -202,7 +202,7 @@ impl DefineClassMethodByValue {
                 .enumerable(false)
                 .configurable(true)
                 .build(),
-            &mut InternalMethodContext::new(context),
+            &mut InternalMethodPropertyContext::new(context),
         )?;
         Ok(())
     }

--- a/core/engine/src/vm/opcode/define/class/setter.rs
+++ b/core/engine/src/vm/opcode/define/class/setter.rs
@@ -3,7 +3,7 @@ use boa_macros::js_str;
 use crate::{
     Context, JsResult,
     builtins::function::{OrdinaryFunction, set_function_name},
-    object::internal_methods::InternalMethodContext,
+    object::internal_methods::InternalMethodPropertyContext,
     property::PropertyDescriptor,
     vm::opcode::{Operation, VaryingOperand},
 };
@@ -41,7 +41,7 @@ impl DefineClassStaticSetterByName {
                 .set_home_object(class.clone());
         }
         let get = class
-            .__get_own_property__(&key, &mut InternalMethodContext::new(context))?
+            .__get_own_property__(&key, &mut InternalMethodPropertyContext::new(context))?
             .as_ref()
             .and_then(PropertyDescriptor::get)
             .cloned();
@@ -54,7 +54,7 @@ impl DefineClassStaticSetterByName {
                 .enumerable(false)
                 .configurable(true)
                 .build(),
-            &mut InternalMethodContext::new(context),
+            &mut InternalMethodPropertyContext::new(context),
         )?;
         Ok(())
     }
@@ -99,7 +99,7 @@ impl DefineClassSetterByName {
                 .set_home_object(class_proto.clone());
         }
         let get = class_proto
-            .__get_own_property__(&key, &mut InternalMethodContext::new(context))?
+            .__get_own_property__(&key, &mut InternalMethodPropertyContext::new(context))?
             .as_ref()
             .and_then(PropertyDescriptor::get)
             .cloned();
@@ -112,7 +112,7 @@ impl DefineClassSetterByName {
                 .enumerable(false)
                 .configurable(true)
                 .build(),
-            &mut InternalMethodContext::new(context),
+            &mut InternalMethodPropertyContext::new(context),
         )?;
 
         Ok(())
@@ -156,7 +156,7 @@ impl DefineClassStaticSetterByValue {
                 .set_home_object(class.clone());
         }
         let get = class
-            .__get_own_property__(&key, &mut InternalMethodContext::new(context))?
+            .__get_own_property__(&key, &mut InternalMethodPropertyContext::new(context))?
             .as_ref()
             .and_then(PropertyDescriptor::get)
             .cloned();
@@ -213,7 +213,7 @@ impl DefineClassSetterByValue {
                 .set_home_object(class_proto.clone());
         }
         let get = class_proto
-            .__get_own_property__(&key, &mut InternalMethodContext::new(context))?
+            .__get_own_property__(&key, &mut InternalMethodPropertyContext::new(context))?
             .as_ref()
             .and_then(PropertyDescriptor::get)
             .cloned();
@@ -226,7 +226,7 @@ impl DefineClassSetterByValue {
                 .enumerable(false)
                 .configurable(true)
                 .build(),
-            &mut InternalMethodContext::new(context),
+            &mut InternalMethodPropertyContext::new(context),
         )?;
 
         Ok(())

--- a/core/engine/src/vm/opcode/define/own_property.rs
+++ b/core/engine/src/vm/opcode/define/own_property.rs
@@ -1,6 +1,6 @@
 use crate::{
     Context, JsNativeError, JsResult,
-    object::internal_methods::InternalMethodContext,
+    object::internal_methods::InternalMethodPropertyContext,
     property::PropertyDescriptor,
     vm::opcode::{Operation, VaryingOperand},
 };
@@ -34,7 +34,7 @@ impl DefineOwnPropertyByName {
                 .enumerable(true)
                 .configurable(true)
                 .build(),
-            &mut InternalMethodContext::new(context),
+            &mut InternalMethodPropertyContext::new(context),
         )?;
         Ok(())
     }
@@ -72,7 +72,7 @@ impl DefineOwnPropertyByValue {
                 .enumerable(true)
                 .configurable(true)
                 .build(),
-            &mut InternalMethodContext::new(context),
+            &mut InternalMethodPropertyContext::new(context),
         )?;
         if !success {
             return Err(JsNativeError::typ()

--- a/core/engine/src/vm/opcode/delete/mod.rs
+++ b/core/engine/src/vm/opcode/delete/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
     Context, JsError, JsResult, error::JsNativeError,
-    object::internal_methods::InternalMethodContext, vm::opcode::Operation,
+    object::internal_methods::InternalMethodPropertyContext, vm::opcode::Operation,
 };
 
 use super::VaryingOperand;
@@ -24,7 +24,7 @@ impl DeletePropertyByName {
         let key = code_block.constant_string(index.into()).into();
         let strict = code_block.strict();
 
-        let result = object.__delete__(&key, &mut InternalMethodContext::new(context))?;
+        let result = object.__delete__(&key, &mut InternalMethodPropertyContext::new(context))?;
         if !result && strict {
             return Err(JsNativeError::typ()
                 .with_message("Cannot delete property")
@@ -61,7 +61,10 @@ impl DeletePropertyByValue {
         let object = object.to_object(context)?;
         let property_key = key.to_property_key(context)?;
 
-        let result = object.__delete__(&property_key, &mut InternalMethodContext::new(context))?;
+        let result = object.__delete__(
+            &property_key,
+            &mut InternalMethodPropertyContext::new(context),
+        )?;
         if !result && context.vm.frame().code_block().strict() {
             return Err(JsNativeError::typ()
                 .with_message("Cannot delete property")

--- a/core/engine/src/vm/opcode/environment/mod.rs
+++ b/core/engine/src/vm/opcode/environment/mod.rs
@@ -3,7 +3,7 @@ use crate::{
     Context, JsResult, JsValue,
     builtins::function::OrdinaryFunction,
     error::JsNativeError,
-    object::internal_methods::InternalMethodContext,
+    object::internal_methods::InternalMethodPropertyContext,
     vm::{CallFrameFlags, opcode::Operation},
 };
 
@@ -100,7 +100,7 @@ impl Super {
         };
 
         let value = home_object
-            .map(|o| o.__get_prototype_of__(&mut InternalMethodContext::new(context)))
+            .map(|o| o.__get_prototype_of__(&mut InternalMethodPropertyContext::new(context)))
             .transpose()?
             .flatten()
             .map_or_else(JsValue::null, JsValue::from);
@@ -134,7 +134,7 @@ impl SuperCallPrepare {
             .expect("super call must be in function environment");
         let active_function = this_env.slots().function_object().clone();
         let super_constructor = active_function
-            .__get_prototype_of__(&mut InternalMethodContext::new(context))
+            .__get_prototype_of__(&mut InternalMethodPropertyContext::new(context))
             .expect("function object must have prototype");
         context.vm.set_register(
             dst.into(),
@@ -286,7 +286,7 @@ impl SuperCallDerived {
             .clone();
         let active_function = this_env.slots().function_object().clone();
         let super_constructor = active_function
-            .__get_prototype_of__(&mut InternalMethodContext::new(context))
+            .__get_prototype_of__(&mut InternalMethodPropertyContext::new(context))
             .expect("function object must have prototype")
             .expect("function object must have prototype");
 

--- a/core/engine/src/vm/opcode/get/name.rs
+++ b/core/engine/src/vm/opcode/get/name.rs
@@ -1,7 +1,7 @@
 use crate::{
     Context, JsResult, JsValue,
     error::JsNativeError,
-    object::{internal_methods::InternalMethodContext, shape::slot::SlotAttributes},
+    object::{internal_methods::InternalMethodPropertyContext, shape::slot::SlotAttributes},
     property::PropertyKey,
     vm::opcode::{Operation, VaryingOperand},
 };
@@ -85,7 +85,7 @@ impl GetNameGlobal {
 
             let key: PropertyKey = ic.name.clone().into();
 
-            let context = &mut InternalMethodContext::new(context);
+            let context = &mut InternalMethodPropertyContext::new(context);
             let Some(result) = object.__try_get__(&key, object.clone().into(), context)? else {
                 let name = binding_locator.name().to_std_string_escaped();
                 return Err(JsNativeError::reference()

--- a/core/engine/src/vm/opcode/get/property.rs
+++ b/core/engine/src/vm/opcode/get/property.rs
@@ -1,6 +1,6 @@
 use crate::{
     Context, JsResult,
-    object::{internal_methods::InternalMethodContext, shape::slot::SlotAttributes},
+    object::{internal_methods::InternalMethodPropertyContext, shape::slot::SlotAttributes},
     property::PropertyKey,
     vm::opcode::{Operation, VaryingOperand},
 };
@@ -54,7 +54,7 @@ impl GetPropertyByName {
 
         let key: PropertyKey = ic.name.clone().into();
 
-        let context = &mut InternalMethodContext::new(context);
+        let context = &mut InternalMethodPropertyContext::new(context);
         let result = object.__get__(&key, receiver.clone(), context)?;
 
         // Cache the property.
@@ -118,7 +118,7 @@ impl GetPropertyByValue {
         let result = object.__get__(
             &key,
             receiver.clone(),
-            &mut InternalMethodContext::new(context),
+            &mut InternalMethodPropertyContext::new(context),
         )?;
 
         context.vm.set_register(dst.into(), result);
@@ -174,7 +174,7 @@ impl GetPropertyByValuePush {
         let result = object.__get__(
             &key_value,
             receiver.clone(),
-            &mut InternalMethodContext::new(context),
+            &mut InternalMethodPropertyContext::new(context),
         )?;
 
         context.vm.set_register(key.into(), key_value.into());

--- a/core/engine/src/vm/opcode/push/class/private.rs
+++ b/core/engine/src/vm/opcode/push/class/private.rs
@@ -2,7 +2,7 @@ use crate::{
     Context,
     builtins::function::OrdinaryFunction,
     js_str, js_string,
-    object::{PrivateElement, internal_methods::InternalMethodContext},
+    object::{PrivateElement, internal_methods::InternalMethodPropertyContext},
     property::PropertyDescriptor,
     vm::opcode::{Operation, VaryingOperand},
 };
@@ -51,7 +51,7 @@ impl PushClassPrivateMethod {
             .__define_own_property__(
                 &js_string!("name").into(),
                 desc,
-                &mut InternalMethodContext::new(context),
+                &mut InternalMethodPropertyContext::new(context),
             )
             .expect("failed to set name property on private method");
         value

--- a/core/engine/src/vm/opcode/set/class_prototype.rs
+++ b/core/engine/src/vm/opcode/set/class_prototype.rs
@@ -3,7 +3,7 @@ use crate::vm::opcode::VaryingOperand;
 use crate::{
     Context,
     builtins::{OrdinaryObject, function::OrdinaryFunction},
-    object::{CONSTRUCTOR, JsObject, PROTOTYPE, internal_methods::InternalMethodContext},
+    object::{CONSTRUCTOR, JsObject, PROTOTYPE, internal_methods::InternalMethodPropertyContext},
     property::PropertyDescriptorBuilder,
     vm::opcode::Operation,
 };
@@ -65,7 +65,7 @@ impl SetClassPrototype {
                     .enumerable(false)
                     .configurable(true)
                     .build(),
-                &mut InternalMethodContext::new(context),
+                &mut InternalMethodPropertyContext::new(context),
             )
             .expect("cannot fail per spec");
 

--- a/core/engine/src/vm/opcode/set/property.rs
+++ b/core/engine/src/vm/opcode/set/property.rs
@@ -5,7 +5,7 @@ use crate::vm::opcode::VaryingOperand;
 use crate::{
     Context, JsNativeError, JsResult,
     builtins::function::set_function_name,
-    object::{internal_methods::InternalMethodContext, shape::slot::SlotAttributes},
+    object::{internal_methods::InternalMethodPropertyContext, shape::slot::SlotAttributes},
     property::{PropertyDescriptor, PropertyKey},
     vm::opcode::Operation,
 };
@@ -73,7 +73,7 @@ impl SetPropertyByName {
 
         let name: PropertyKey = ic.name.clone().into();
 
-        let context = &mut InternalMethodContext::new(context);
+        let context = &mut InternalMethodPropertyContext::new(context);
         let succeeded = object.__set__(name.clone(), value.clone(), receiver.clone(), context)?;
         if !succeeded && context.vm.frame().code_block.strict() {
             return Err(JsNativeError::typ()
@@ -194,7 +194,7 @@ impl SetPropertyGetterByName {
 
         let object = object.to_object(context)?;
         let set = object
-            .__get_own_property__(&name, &mut InternalMethodContext::new(context))?
+            .__get_own_property__(&name, &mut InternalMethodPropertyContext::new(context))?
             .as_ref()
             .and_then(PropertyDescriptor::set)
             .cloned();
@@ -206,7 +206,7 @@ impl SetPropertyGetterByName {
                 .enumerable(true)
                 .configurable(true)
                 .build(),
-            &mut InternalMethodContext::new(context),
+            &mut InternalMethodPropertyContext::new(context),
         )?;
         Ok(())
     }
@@ -238,7 +238,7 @@ impl SetPropertyGetterByValue {
         let name = key.to_property_key(context)?;
 
         let set = object
-            .__get_own_property__(&name, &mut InternalMethodContext::new(context))?
+            .__get_own_property__(&name, &mut InternalMethodPropertyContext::new(context))?
             .as_ref()
             .and_then(PropertyDescriptor::set)
             .cloned();
@@ -250,7 +250,7 @@ impl SetPropertyGetterByValue {
                 .enumerable(true)
                 .configurable(true)
                 .build(),
-            &mut InternalMethodContext::new(context),
+            &mut InternalMethodPropertyContext::new(context),
         )?;
         Ok(())
     }
@@ -287,7 +287,7 @@ impl SetPropertySetterByName {
         let object = object.to_object(context)?;
 
         let get = object
-            .__get_own_property__(&name, &mut InternalMethodContext::new(context))?
+            .__get_own_property__(&name, &mut InternalMethodPropertyContext::new(context))?
             .as_ref()
             .and_then(PropertyDescriptor::get)
             .cloned();
@@ -299,7 +299,7 @@ impl SetPropertySetterByName {
                 .enumerable(true)
                 .configurable(true)
                 .build(),
-            &mut InternalMethodContext::new(context),
+            &mut InternalMethodPropertyContext::new(context),
         )?;
         Ok(())
     }
@@ -332,7 +332,7 @@ impl SetPropertySetterByValue {
         let name = key.to_property_key(context)?;
 
         let get = object
-            .__get_own_property__(&name, &mut InternalMethodContext::new(context))?
+            .__get_own_property__(&name, &mut InternalMethodPropertyContext::new(context))?
             .as_ref()
             .and_then(PropertyDescriptor::get)
             .cloned();
@@ -344,7 +344,7 @@ impl SetPropertySetterByValue {
                 .enumerable(true)
                 .configurable(true)
                 .build(),
-            &mut InternalMethodContext::new(context),
+            &mut InternalMethodPropertyContext::new(context),
         )?;
         Ok(())
     }

--- a/core/engine/src/vm/opcode/set/prototype.rs
+++ b/core/engine/src/vm/opcode/set/prototype.rs
@@ -1,6 +1,6 @@
 use crate::{
     Context,
-    object::internal_methods::InternalMethodContext,
+    object::internal_methods::InternalMethodPropertyContext,
     vm::opcode::{Operation, VaryingOperand},
 };
 
@@ -30,7 +30,7 @@ impl SetPrototype {
 
         let object = object.as_object().expect("object is not an object");
         object
-            .__set_prototype_of__(prototype, &mut InternalMethodContext::new(context))
+            .__set_prototype_of__(prototype, &mut InternalMethodPropertyContext::new(context))
             .expect("cannot fail per spec");
     }
 }

--- a/core/engine/src/vm/source_info/mod.rs
+++ b/core/engine/src/vm/source_info/mod.rs
@@ -181,6 +181,16 @@ impl Display for SourcePath {
     }
 }
 
+impl SourcePath {
+    pub(crate) fn is_none(&self) -> bool {
+        matches!(self, Self::None)
+    }
+
+    pub(crate) fn is_some(&self) -> bool {
+        !self.is_none()
+    }
+}
+
 /// A struct containing information about native source code.
 ///
 /// # Note

--- a/core/engine/src/vm/source_info/mod.rs
+++ b/core/engine/src/vm/source_info/mod.rs
@@ -180,3 +180,54 @@ impl Display for SourcePath {
         }
     }
 }
+
+/// A struct containing information about native source code.
+///
+/// # Note
+///
+/// If the `native-backtrace` feature is not enabled the this becomes [zero sized type][zst].
+///
+/// [zst]: https://doc.rust-lang.org/nomicon/exotic-sizes.html#zero-sized-types-zsts
+#[derive(Debug, Clone, Copy)]
+pub struct NativeSourceInfo {
+    #[cfg(feature = "native-backtrace")]
+    inner: &'static std::panic::Location<'static>,
+
+    #[cfg(not(feature = "native-backtrace"))]
+    inner: std::marker::PhantomData<()>,
+}
+
+impl NativeSourceInfo {
+    /// Returns the source location of the caller of this function.
+    ///
+    /// If that function’s caller is annotated with `#[track_caller]`, then its call
+    /// location will be returned, and so on up the stack to the first call within
+    /// a non-tracked function body.
+    #[inline]
+    #[must_use]
+    #[cfg_attr(feature = "native-backtrace", track_caller)]
+    pub const fn caller() -> Self {
+        Self {
+            #[cfg(feature = "native-backtrace")]
+            inner: std::panic::Location::caller(),
+
+            #[cfg(not(feature = "native-backtrace"))]
+            inner: std::marker::PhantomData,
+        }
+    }
+
+    /// Return a [`std::panic::Location`].
+    ///
+    /// # Note
+    ///
+    /// If the `native-backtrace` feature is not enabled, then this always returns [`None`].
+    #[inline]
+    #[must_use]
+    pub const fn as_location(self) -> Option<&'static std::panic::Location<'static>> {
+        #[cfg(feature = "native-backtrace")]
+        return Some(self.inner);
+
+        #[cfg(not(feature = "native-backtrace"))]
+        return None;
+    }
+}


### PR DESCRIPTION
This implements a native source code positions for backtraces

```JavaScript
Array.prototype.every.call([
  [10]
], element => element.forEach(
  (element) => {
    throw value
  }
))
```

```
cargo run -- test.js
Uncaught ReferenceError: value is not defined (native at core/engine/src/vm/opcode/get/name.rs:91:28)
    at <anonymous> (test.js:5:15)
    at forEach (native at core/engine/src/builtins/array/mod.rs:968:26)
    at <anonymous> (test.js:3:30)
    at every (native at core/engine/src/builtins/array/mod.rs:1375:22)
    at call (native at core/engine/src/builtins/function/mod.rs:825:14)
    at <main> (test.js:1:27)
```