### PR TITLE
Allow non-reserved keywords to be used as identifiers

### DIFF
--- a/core/ast/src/keyword/mod.rs
+++ b/core/ast/src/keyword/mod.rs
@@ -548,6 +548,21 @@ impl Keyword {
             Self::Yield => Sym::YIELD,
         }
     }
+
+    /// [ECMAScript reference](https://tc39.es/ecma262/#sec-keywords-and-reserved-words)
+    #[inline]
+    #[must_use]
+    pub const fn is_reserved_keyword(self) -> bool {
+        matches!(
+            self,
+            Self::Await | Self::Break | Self::Case | Self::Catch | Self::Class | Self::Const
+            | Self::Continue | Self::Debugger | Self::Default | Self::Delete | Self::Do | Self::Else
+            | Self::Enum | Self::Export | Self::Extends | Self::Finally | Self::For | Self::Function
+            | Self::If | Self::Import | Self::In | Self::InstanceOf | Self::New | Self::Return
+            | Self::Super | Self::Switch | Self::This | Self::Throw | Self::Try | Self::TypeOf
+            | Self::Var | Self::Void | Self::While | Self::With | Self::Yield
+        )
+    }
 }
 
 // TODO: Should use a proper Error

--- a/core/ast/src/keyword/mod.rs
+++ b/core/ast/src/keyword/mod.rs
@@ -548,50 +548,6 @@ impl Keyword {
             Self::Yield => Sym::YIELD,
         }
     }
-
-    /// [ECMAScript reference](https://tc39.es/ecma262/#sec-keywords-and-reserved-words)
-    #[inline]
-    #[must_use]
-    pub const fn is_reserved_keyword(self) -> bool {
-        matches!(
-            self,
-            Self::Await
-                | Self::Break
-                | Self::Case
-                | Self::Catch
-                | Self::Class
-                | Self::Const
-                | Self::Continue
-                | Self::Debugger
-                | Self::Default
-                | Self::Delete
-                | Self::Do
-                | Self::Else
-                | Self::Enum
-                | Self::Export
-                | Self::Extends
-                | Self::Finally
-                | Self::For
-                | Self::Function
-                | Self::If
-                | Self::Import
-                | Self::In
-                | Self::InstanceOf
-                | Self::New
-                | Self::Return
-                | Self::Super
-                | Self::Switch
-                | Self::This
-                | Self::Throw
-                | Self::Try
-                | Self::TypeOf
-                | Self::Var
-                | Self::Void
-                | Self::While
-                | Self::With
-                | Self::Yield
-        )
-    }
 }
 
 // TODO: Should use a proper Error

--- a/core/ast/src/keyword/mod.rs
+++ b/core/ast/src/keyword/mod.rs
@@ -555,12 +555,41 @@ impl Keyword {
     pub const fn is_reserved_keyword(self) -> bool {
         matches!(
             self,
-            Self::Await | Self::Break | Self::Case | Self::Catch | Self::Class | Self::Const
-            | Self::Continue | Self::Debugger | Self::Default | Self::Delete | Self::Do | Self::Else
-            | Self::Enum | Self::Export | Self::Extends | Self::Finally | Self::For | Self::Function
-            | Self::If | Self::Import | Self::In | Self::InstanceOf | Self::New | Self::Return
-            | Self::Super | Self::Switch | Self::This | Self::Throw | Self::Try | Self::TypeOf
-            | Self::Var | Self::Void | Self::While | Self::With | Self::Yield
+            Self::Await
+                | Self::Break
+                | Self::Case
+                | Self::Catch
+                | Self::Class
+                | Self::Const
+                | Self::Continue
+                | Self::Debugger
+                | Self::Default
+                | Self::Delete
+                | Self::Do
+                | Self::Else
+                | Self::Enum
+                | Self::Export
+                | Self::Extends
+                | Self::Finally
+                | Self::For
+                | Self::Function
+                | Self::If
+                | Self::Import
+                | Self::In
+                | Self::InstanceOf
+                | Self::New
+                | Self::Return
+                | Self::Super
+                | Self::Switch
+                | Self::This
+                | Self::Throw
+                | Self::Try
+                | Self::TypeOf
+                | Self::Var
+                | Self::Void
+                | Self::While
+                | Self::With
+                | Self::Yield
         )
     }
 }

--- a/core/parser/src/parser/statement/declaration/hoistable/class_decl/mod.rs
+++ b/core/parser/src/parser/statement/declaration/hoistable/class_decl/mod.rs
@@ -89,7 +89,15 @@ where
                 BindingIdentifier::new(self.allow_yield, self.allow_await)
                     .parse(cursor, interner)?
             }
-            TokenKind::Keyword((k, _)) if !k.is_reserved_keyword() => {
+            TokenKind::Keyword((k, _)) => {
+                let sym = k.to_sym();
+                if sym.is_reserved_identifier() {
+                    return Err(Error::general(
+                        format!("reserved keyword `{k}` cannot be used as a class name"),
+                        span.start(),
+                    ));
+                }
+
                 BindingIdentifier::new(self.allow_yield, self.allow_await)
                     .parse(cursor, interner)?
             }

--- a/core/parser/src/parser/statement/declaration/hoistable/class_decl/mod.rs
+++ b/core/parser/src/parser/statement/declaration/hoistable/class_decl/mod.rs
@@ -89,6 +89,10 @@ where
                 BindingIdentifier::new(self.allow_yield, self.allow_await)
                     .parse(cursor, interner)?
             }
+            TokenKind::Keyword((k, _)) if !k.is_reserved_keyword() => {
+                BindingIdentifier::new(self.allow_yield, self.allow_await)
+                    .parse(cursor, interner)?
+            }
             _ if self.is_default.0 => Identifier::new(Sym::DEFAULT, span),
             _ => {
                 return Err(Error::unexpected(

--- a/core/parser/src/parser/statement/declaration/hoistable/class_decl/mod.rs
+++ b/core/parser/src/parser/statement/declaration/hoistable/class_decl/mod.rs
@@ -89,15 +89,7 @@ where
                 BindingIdentifier::new(self.allow_yield, self.allow_await)
                     .parse(cursor, interner)?
             }
-            TokenKind::Keyword((k, _)) => {
-                let sym = k.to_sym();
-                if sym.is_reserved_identifier() {
-                    return Err(Error::general(
-                        format!("reserved keyword `{k}` cannot be used as a class name"),
-                        span.start(),
-                    ));
-                }
-
+            TokenKind::Keyword((k, _)) if !k.to_sym().is_reserved_identifier() => {
                 BindingIdentifier::new(self.allow_yield, self.allow_await)
                     .parse(cursor, interner)?
             }

--- a/core/parser/src/parser/statement/declaration/hoistable/class_decl/tests.rs
+++ b/core/parser/src/parser/statement/declaration/hoistable/class_decl/tests.rs
@@ -230,3 +230,28 @@ fn check_new_target_with_property_access() {
         interner,
     );
 }
+
+#[test]
+fn check_non_reserved_keyword_as_identifier() {
+    let interner = &mut Interner::default();
+
+    check_script_parser(
+        indoc! {r#"
+            class of {}
+        "#},
+        [Declaration::ClassDeclaration(
+            ClassDeclaration::new(
+                Identifier::new(
+                    interner.get_or_intern_static("of", utf16!("of")),
+                    Span::new((1, 7), (1, 9)),
+                ),
+                None,
+                None,
+                vec![].into(),
+            )
+            .into(),
+        )
+        .into()],
+        interner,
+    );
+}


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request fixes/closes #4298.

It changes the following:

- Added the `is_reserved_keyword` method to `Keyword` to determine if it is a reserved word.
- Added a check for non-reserved words when parsing class names.
- Added unit tests.
