### PR TITLE
inline `Gc::inner_ptr`

### DIFF
--- a/core/gc/src/pointers/gc.rs
+++ b/core/gc/src/pointers/gc.rs
@@ -279,7 +279,7 @@ impl<T: Trace + ?Sized> Gc<T> {
     #[inline(always)]
     #[allow(clippy::inline_always)]
     pub(crate) fn inner_ptr(&self) -> NonNull<GcBox<T>> {
-        assert!(finalizer_safe());
+        debug_assert!(finalizer_safe());
         self.inner_ptr
     }
 


### PR DESCRIPTION
While profiling `combined.js`, I noticed that the function `Gc::inner_ptr` had a significantly higher overhead(2.57%) compared to the inner function (`finalizer_safe`)(0.35%). So I attempted to inline it. After reprofiling, the overhead indeed decreased (though not by much - 1.87%), and the overall performance of the program improved as well.

Comparison:

main:

```
PROGRESS Richards
RESULT Richards 105
PROGRESS DeltaBlue
RESULT DeltaBlue 108
PROGRESS Encrypt
PROGRESS Decrypt
RESULT Crypto 118
PROGRESS RayTrace
RESULT RayTrace 255
PROGRESS Earley
PROGRESS Boyer
RESULT EarleyBoyer 297
PROGRESS RegExp
RESULT RegExp 59.5
PROGRESS Splay
RESULT Splay 420
PROGRESS NavierStokes
RESULT NavierStokes 268
SCORE 169
undefined
```

![image](https://github.com/user-attachments/assets/4a0698a8-c78a-4377-ab1c-6330a8621770)


PR:

```
PROGRESS Richards
RESULT Richards 116
PROGRESS DeltaBlue
RESULT DeltaBlue 118
PROGRESS Encrypt
PROGRESS Decrypt
RESULT Crypto 123
PROGRESS RayTrace
RESULT RayTrace 273
PROGRESS Earley
PROGRESS Boyer
RESULT EarleyBoyer 313
PROGRESS RegExp
RESULT RegExp 61.4
PROGRESS Splay
RESULT Splay 314
PROGRESS NavierStokes
RESULT NavierStokes 277
SCORE 172
undefined
```
![image](https://github.com/user-attachments/assets/10947246-051e-446f-8256-94a39838b488)
