### PR TITLE
Migrate temporal_rs from 0.0.9 to 0.0.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3597,9 +3597,9 @@ checksum = "1ac9aa371f599d22256307c24a9d748c041e548cbf599f35d890f9d365361790"
 
 [[package]]
 name = "temporal_rs"
-version = "0.0.9"
+version = "0.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7995a53f8d6e4a4dae21067190ee433eb209b7b2b71140c36cec4910c2bc7c37"
+checksum = "bc86c57c167d92f33d5dd199a9ea608524ee42ec21c92c8869f6b243a2f814e2"
 dependencies = [
  "combine",
  "core_maths",
@@ -3948,9 +3948,9 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "tzif"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cecffbab91858408738280e7bb6aac788f59a522dda961cd6b15542f0c08559"
+checksum = "e5e762ac355f0c204d09ae644b3d59423d5ddfc5603997d60c8c56f24e429a9d"
 dependencies = [
  "combine",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,7 +121,7 @@ intrusive-collections = "0.9.7"
 cfg-if = "1.0.1"
 either = "1.15.0"
 sys-locale = "0.3.2"
-temporal_rs = { version = "0.0.9", default-features = false, features = [
+temporal_rs = { version = "0.0.10", default-features = false, features = [
     "tzdb",
 ] }
 web-time = "1.1.0"

--- a/core/engine/src/builtins/temporal/plain_year_month/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_year_month/mod.rs
@@ -21,7 +21,7 @@ use boa_gc::{Finalize, Trace};
 use temporal_rs::{
     Calendar, Duration, MonthCode, PlainYearMonth as InnerYearMonth,
     options::{ArithmeticOverflow, DisplayCalendar},
-    partial::PartialDate,
+    partial::{PartialDate, PartialYearMonth},
 };
 
 use super::{
@@ -698,7 +698,7 @@ fn add_or_subtract_duration(
 fn to_partial_year_month(
     partial_object: &JsObject,
     context: &mut Context,
-) -> JsResult<PartialDate> {
+) -> JsResult<PartialYearMonth> {
     // a. Let calendar be ? ToTemporalCalendar(item).
     let calendar = get_temporal_calendar_slot_value_with_default(partial_object, context)?;
 
@@ -732,11 +732,9 @@ fn to_partial_year_month(
         })
         .transpose()?;
 
-    Ok(PartialDate {
-        year,
-        month,
-        month_code,
-        calendar,
-        ..Default::default()
-    })
+    Ok(PartialYearMonth::new()
+        .with_year(year)
+        .with_month(month)
+        .with_month_code(month_code)
+        .with_calendar(calendar))
 }


### PR DESCRIPTION
This PR migrates `temporal_rs` to the recent `0.0.10` version.
