### PR TITLE
Mark the error path in `Call::operation` as cold.

### DIFF
--- a/core/engine/src/vm/opcode/call/mod.rs
+++ b/core/engine/src/vm/opcode/call/mod.rs
@@ -1,6 +1,6 @@
 use super::VaryingOperand;
 use crate::{
-    Context, JsObject, JsResult, JsValue, NativeFunction,
+    Context, JsError, JsObject, JsResult, JsValue, NativeFunction,
     builtins::{Promise, promise::PromiseCapability},
     error::JsNativeError,
     module::{ModuleKind, Referrer},
@@ -184,14 +184,20 @@ impl Call {
             .calling_convention_get_function(argument_count.into());
 
         let Some(object) = func.as_object() else {
-            return Err(JsNativeError::typ()
-                .with_message("not a callable function")
-                .into());
+            return Err(Self::handle_not_callable());
         };
 
         object.__call__(argument_count.into()).resolve(context)?;
 
         Ok(())
+    }
+
+    #[cold]
+    #[inline(never)]
+    fn handle_not_callable() -> JsError {
+        JsNativeError::typ()
+            .with_message("not a callable function")
+            .into()
     }
 }
 


### PR DESCRIPTION
It will bring a slight performance improvement.

## Benchmark

main:

```
PROGRESS Richards
RESULT Richards 105
PROGRESS DeltaBlue
RESULT DeltaBlue 108
PROGRESS Encrypt
PROGRESS Decrypt
RESULT Crypto 118
PROGRESS RayTrace
RESULT RayTrace 255
PROGRESS Earley
PROGRESS Boyer
RESULT EarleyBoyer 297
PROGRESS RegExp
RESULT RegExp 59.5
PROGRESS Splay
RESULT Splay 420
PROGRESS NavierStokes
RESULT NavierStokes 268
SCORE 169
undefined
```

PR:

```
PROGRESS Richards
RESULT Richards 109
PROGRESS DeltaBlue
RESULT DeltaBlue 114
PROGRESS Encrypt
PROGRESS Decrypt
RESULT Crypto 119
PROGRESS RayTrace
RESULT RayTrace 262
PROGRESS Earley
PROGRESS Boyer
RESULT EarleyBoyer 299
PROGRESS RegExp
RESULT RegExp 59.6
PROGRESS Splay
RESULT Splay 450
PROGRESS NavierStokes
RESULT NavierStokes 277
SCORE 175
undefined
```
