### PR TITLE
Simplify SourcePositionGuard creation

### DIFF
--- a/core/ast/src/expression/access.rs
+++ b/core/ast/src/expression/access.rs
@@ -14,10 +14,10 @@
 //! [spec]: https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-property-accessors
 //! [access]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Property_Accessors
 
-use crate::Span;
 use crate::expression::Expression;
 use crate::function::PrivateName;
 use crate::visitor::{VisitWith, Visitor, VisitorMut};
+use crate::{Span, Spanned};
 use boa_interner::{Interner, ToInternedString};
 use core::ops::ControlFlow;
 
@@ -45,6 +45,12 @@ impl PropertyAccessField {
             Self::Const(identifier) => identifier.span(),
             Self::Expr(expression) => expression.span(),
         }
+    }
+}
+
+impl Spanned for PropertyAccessField {
+    fn span(&self) -> Span {
+        self.span()
     }
 }
 
@@ -194,6 +200,12 @@ impl SimplePropertyAccess {
     #[must_use]
     pub fn span(&self) -> Span {
         Span::new(self.target.span().start(), self.field.span().end())
+    }
+}
+
+impl Spanned for SimplePropertyAccess {
+    fn span(&self) -> Span {
+        self.span()
     }
 }
 

--- a/core/ast/src/expression/call.rs
+++ b/core/ast/src/expression/call.rs
@@ -1,5 +1,5 @@
 use crate::visitor::{VisitWith, Visitor, VisitorMut};
-use crate::{Span, join_nodes};
+use crate::{Span, Spanned, join_nodes};
 use boa_interner::{Interner, ToInternedString};
 use core::ops::ControlFlow;
 
@@ -59,6 +59,13 @@ impl Call {
     #[must_use]
     pub fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl Spanned for Call {
+    #[inline]
+    fn span(&self) -> Span {
+        self.span()
     }
 }
 

--- a/core/ast/src/expression/mod.rs
+++ b/core/ast/src/expression/mod.rs
@@ -15,7 +15,7 @@ use self::{
     operator::{Assign, Binary, BinaryInPrivate, Conditional, Unary, Update},
 };
 use super::{
-    Statement,
+    Spanned, Statement,
     function::{
         ArrowFunction, AsyncFunctionExpression, AsyncGeneratorExpression, ClassExpression,
         FunctionExpression, GeneratorExpression,
@@ -329,6 +329,12 @@ impl Expression {
             // TODO: Remove `FormalParameterList` and `Debugger` nodes
             Self::FormalParameterList(_) | Self::Debugger => Span::EMPTY,
         }
+    }
+}
+
+impl Spanned for Expression {
+    fn span(&self) -> Span {
+        self.span()
     }
 }
 

--- a/core/ast/src/expression/operator/assign/mod.rs
+++ b/core/ast/src/expression/operator/assign/mod.rs
@@ -20,7 +20,7 @@ pub use op::*;
 use boa_interner::{Interner, Sym, ToInternedString};
 
 use crate::{
-    Span,
+    Span, Spanned,
     expression::{Expression, access::PropertyAccess, identifier::Identifier},
     pattern::Pattern,
     visitor::{VisitWith, Visitor, VisitorMut},
@@ -76,6 +76,12 @@ impl Assign {
     #[must_use]
     pub fn span(&self) -> Span {
         Span::new(self.lhs.span().start(), self.rhs.span().end())
+    }
+}
+
+impl Spanned for Assign {
+    fn span(&self) -> Span {
+        self.span()
     }
 }
 

--- a/core/ast/src/expression/operator/unary/mod.rs
+++ b/core/ast/src/expression/operator/unary/mod.rs
@@ -12,7 +12,7 @@
 mod op;
 
 use crate::{
-    Span,
+    Span, Spanned,
     expression::Expression,
     visitor::{VisitWith, Visitor, VisitorMut},
 };
@@ -75,6 +75,13 @@ impl Unary {
     #[inline]
     #[must_use]
     pub const fn span(&self) -> Span {
+        self.span
+    }
+}
+
+impl Spanned for Unary {
+    #[inline]
+    fn span(&self) -> Span {
         self.span
     }
 }

--- a/core/ast/src/expression/operator/update/mod.rs
+++ b/core/ast/src/expression/operator/update/mod.rs
@@ -10,7 +10,7 @@
 mod op;
 
 use crate::{
-    Expression, Span,
+    Expression, Span, Spanned,
     expression::{Identifier, access::PropertyAccess},
     visitor::{VisitWith, Visitor, VisitorMut},
 };
@@ -66,6 +66,13 @@ impl Update {
     #[inline]
     #[must_use]
     pub const fn span(&self) -> Span {
+        self.span
+    }
+}
+
+impl Spanned for Update {
+    #[inline]
+    fn span(&self) -> Span {
         self.span
     }
 }

--- a/core/ast/src/function/class.rs
+++ b/core/ast/src/function/class.rs
@@ -1,6 +1,6 @@
 use super::{FormalParameterList, FunctionBody, FunctionExpression};
 use crate::{
-    Declaration, LinearPosition, LinearSpan, LinearSpanIgnoreEq, Span, block_to_string,
+    Declaration, LinearPosition, LinearSpan, LinearSpanIgnoreEq, Span, Spanned, block_to_string,
     expression::{Expression, Identifier},
     join_nodes,
     operations::{ContainsSymbol, contains},
@@ -882,6 +882,12 @@ impl PrivateName {
     #[inline]
     #[must_use]
     pub fn span(&self) -> Span {
+        self.span
+    }
+}
+
+impl Spanned for PrivateName {
+    fn span(&self) -> Span {
         self.span
     }
 }

--- a/core/ast/src/function/mod.rs
+++ b/core/ast/src/function/mod.rs
@@ -48,7 +48,7 @@ pub use ordinary_function::{FunctionDeclaration, FunctionExpression};
 pub use parameters::{FormalParameter, FormalParameterList, FormalParameterListFlags};
 
 use crate::{
-    LinearPosition, Span, StatementList, StatementListItem,
+    LinearPosition, Span, Spanned, StatementList, StatementListItem,
     visitor::{VisitWith, Visitor, VisitorMut},
 };
 
@@ -109,6 +109,13 @@ impl FunctionBody {
     #[inline]
     #[must_use]
     pub const fn span(&self) -> Span {
+        self.span
+    }
+}
+
+impl Spanned for FunctionBody {
+    #[inline]
+    fn span(&self) -> Span {
         self.span
     }
 }

--- a/core/ast/src/function/ordinary_function.rs
+++ b/core/ast/src/function/ordinary_function.rs
@@ -1,6 +1,6 @@
 use super::{FormalParameterList, FunctionBody};
 use crate::{
-    Declaration, LinearSpan, LinearSpanIgnoreEq, Span, block_to_string,
+    Declaration, LinearSpan, LinearSpanIgnoreEq, Span, Spanned, block_to_string,
     expression::{Expression, Identifier},
     join_nodes,
     operations::{ContainsSymbol, contains},
@@ -176,6 +176,12 @@ impl PartialEq for FunctionExpression {
             && self.name_scope == other.name_scope
             && self.scopes == other.scopes
             && self.span == other.span
+    }
+}
+
+impl Spanned for FunctionExpression {
+    fn span(&self) -> Span {
+        self.span
     }
 }
 

--- a/core/ast/src/lib.rs
+++ b/core/ast/src/lib.rs
@@ -52,7 +52,9 @@ pub use self::{
     expression::Expression,
     keyword::Keyword,
     module_item_list::{ModuleItem, ModuleItemList},
-    position::{LinearPosition, LinearSpan, LinearSpanIgnoreEq, Position, PositionGroup, Span},
+    position::{
+        LinearPosition, LinearSpan, LinearSpanIgnoreEq, Position, PositionGroup, Span, Spanned,
+    },
     punctuator::Punctuator,
     source::{Module, Script},
     source_text::SourceText,

--- a/core/ast/src/position.rs
+++ b/core/ast/src/position.rs
@@ -203,12 +203,38 @@ impl Span {
     }
 }
 
+impl From<Span> for Option<Position> {
+    fn from(value: Span) -> Self {
+        Some(value.start)
+    }
+}
+
+impl<'a> From<&'a Span> for Option<Position> {
+    fn from(value: &'a Span) -> Self {
+        Some(value.start)
+    }
+}
+
 impl From<Position> for Span {
     fn from(pos: Position) -> Self {
         Self {
             start: pos,
             end: pos,
         }
+    }
+}
+
+impl Spanned for Span {
+    #[inline]
+    fn span(&self) -> Span {
+        *self
+    }
+}
+
+impl<T: Spanned> Spanned for &T {
+    #[inline]
+    fn span(&self) -> Span {
+        T::span(*self)
     }
 }
 
@@ -230,6 +256,12 @@ impl fmt::Display for Span {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "[{}..{}]", self.start, self.end)
     }
+}
+
+/// An element of the AST or any type that can be located in the source with a Span.
+pub trait Spanned {
+    /// Returns a span from the current type.
+    fn span(&self) -> Span;
 }
 
 /// A linear span in the ECMAScript source code.

--- a/core/engine/src/bytecompiler/class.rs
+++ b/core/engine/src/bytecompiler/class.rs
@@ -1,6 +1,4 @@
-use super::{
-    BindingAccessOpcode, ByteCompiler, Literal, Register, SourcePositionGuard, ToJsString,
-};
+use super::{BindingAccessOpcode, ByteCompiler, Literal, Register, ToJsString};
 use crate::{
     js_string,
     vm::{CodeBlock, CodeBlockFlags, opcode::BindingOpcode},
@@ -131,7 +129,7 @@ impl ByteCompiler<'_> {
             );
 
             {
-                let mut compiler = SourcePositionGuard::new(&mut compiler, expr.span().start());
+                let mut compiler = compiler.position_guard(expr);
                 compiler.compile_statement_list(expr.body().statement_list(), false, false);
             }
 
@@ -623,10 +621,7 @@ impl ByteCompiler<'_> {
                     );
 
                     {
-                        let mut compiler = SourcePositionGuard::new(
-                            &mut compiler,
-                            block.statements().span().start(),
-                        );
+                        let mut compiler = compiler.position_guard(block.statements());
                         compiler.compile_statement_list(
                             block.statements().statement_list(),
                             false,

--- a/core/engine/src/bytecompiler/expression/assign.rs
+++ b/core/engine/src/bytecompiler/expression/assign.rs
@@ -1,7 +1,5 @@
 use crate::{
-    bytecompiler::{
-        Access, BindingAccessOpcode, ByteCompiler, Label, Register, SourcePositionGuard, ToJsString,
-    },
+    bytecompiler::{Access, BindingAccessOpcode, ByteCompiler, Label, Register, ToJsString},
     vm::opcode::BindingOpcode,
 };
 use boa_ast::{
@@ -15,7 +13,7 @@ use boa_ast::{
 
 impl ByteCompiler<'_> {
     pub(crate) fn compile_assign(&mut self, assign: &Assign, dst: &Register) {
-        let mut compiler = SourcePositionGuard::new(self, assign.span().start());
+        let mut compiler = self.position_guard(assign);
 
         if assign.op() == AssignOp::Assign {
             match Access::from_assign_target(assign.lhs()) {

--- a/core/engine/src/bytecompiler/expression/unary.rs
+++ b/core/engine/src/bytecompiler/expression/unary.rs
@@ -1,16 +1,12 @@
-use crate::bytecompiler::{
-    Access, BindingAccessOpcode, ByteCompiler, Register, SourcePositionGuard, ToJsString,
-};
-use boa_ast::{
-    Expression,
-    expression::operator::{Unary, unary::UnaryOp},
-};
+use crate::bytecompiler::{Access, BindingAccessOpcode, ByteCompiler, Register, ToJsString};
+use boa_ast::Expression;
+use boa_ast::expression::operator::{Unary, unary::UnaryOp};
 
 impl ByteCompiler<'_> {
     pub(crate) fn compile_unary(&mut self, unary: &Unary, dst: &Register) {
         match unary.op() {
             UnaryOp::Delete => {
-                let mut compiler = SourcePositionGuard::new(self, unary.span().start());
+                let mut compiler = self.position_guard(unary);
 
                 if let Some(access) = Access::from_expression(unary.target()) {
                     compiler.access_delete(access, dst);

--- a/core/engine/src/bytecompiler/expression/update.rs
+++ b/core/engine/src/bytecompiler/expression/update.rs
@@ -1,17 +1,15 @@
-use crate::bytecompiler::{
-    Access, BindingAccessOpcode, ByteCompiler, Register, SourcePositionGuard, ToJsString,
-};
+use crate::bytecompiler::{Access, BindingAccessOpcode, ByteCompiler, Register, ToJsString};
 use boa_ast::{
     expression::{
         access::{PropertyAccess, PropertyAccessField},
-        operator::{Update, update::UpdateOp},
+        operator::{update::UpdateOp, Update},
     },
     scope::BindingLocatorError,
 };
 
 impl ByteCompiler<'_> {
     pub(crate) fn compile_update(&mut self, update: &Update, dst: &Register) {
-        let mut compiler = SourcePositionGuard::new(self, update.span().start());
+        let mut compiler = self.position_guard(update);
         let increment = matches!(
             update.op(),
             UpdateOp::IncrementPost | UpdateOp::IncrementPre

--- a/core/engine/src/bytecompiler/function.rs
+++ b/core/engine/src/bytecompiler/function.rs
@@ -12,8 +12,6 @@ use boa_ast::{
 use boa_gc::Gc;
 use boa_interner::Interner;
 
-use super::SourcePositionGuard;
-
 /// `FunctionCompiler` is used to compile AST functions to bytecode.
 #[derive(Debug, Clone)]
 #[allow(clippy::struct_excessive_bools)]
@@ -224,7 +222,7 @@ impl FunctionCompiler {
         }
 
         {
-            let mut compiler = SourcePositionGuard::new(&mut compiler, body.span().start());
+            let mut compiler = compiler.position_guard(body);
             compiler.compile_statement_list(body.statement_list(), false, false);
         }
 

--- a/core/engine/src/bytecompiler/statement/mod.rs
+++ b/core/engine/src/bytecompiler/statement/mod.rs
@@ -1,7 +1,4 @@
-use super::{
-    SourcePositionGuard,
-    jump_control::{JumpRecord, JumpRecordAction, JumpRecordKind},
-};
+use super::jump_control::{JumpRecord, JumpRecordAction, JumpRecordKind};
 use crate::bytecompiler::ByteCompiler;
 use boa_ast::Statement;
 
@@ -61,7 +58,7 @@ impl ByteCompiler<'_> {
                 self.compile_break(*node, use_expr);
             }
             Statement::Throw(throw) => {
-                let mut compiler = SourcePositionGuard::new(self, throw.target().span().start());
+                let mut compiler = self.position_guard(throw.target());
 
                 let error = compiler.register_allocator.alloc();
                 compiler.compile_expr(throw.target(), &error);


### PR DESCRIPTION
Add a Spanned trait for any types/elements of an AST to be able to generate a Span, and implement that for any types that are used in the source position backtrace.

Then added a method to simplify the creation of the source position. Since it's always created from a ByteCompiler it makes sense to have it as an associated method.
