### PR TITLE
Avoid fully awaiting futures in async event loops

### DIFF
--- a/examples/src/bin/module_fetch_async.rs
+++ b/examples/src/bin/module_fetch_async.rs
@@ -220,16 +220,9 @@ impl JobExecutor for Queue {
                 group.insert(job.call(context));
             }
 
-            if self.promise_jobs.borrow().is_empty() {
-                let Some(result) = group.next().await else {
-                    // Both queues are empty. We can exit.
-                    return Ok(());
-                };
-
-                if let Err(err) = result {
-                    eprintln!("Uncaught {err}");
-                }
-                continue;
+            if group.is_empty() && self.promise_jobs.borrow().is_empty() {
+                // Both queues are empty. We can exit.
+                return Ok(());
             }
 
             // We have some jobs pending on the microtask queue. Try to poll the pending

--- a/examples/src/bin/smol_event_loop.rs
+++ b/examples/src/bin/smol_event_loop.rs
@@ -111,16 +111,9 @@ impl JobExecutor for Queue {
                 group.insert(job.call(context));
             }
 
-            if self.promise_jobs.borrow().is_empty() {
-                let Some(result) = group.next().await else {
-                    // Both queues are empty. We can exit.
-                    return Ok(());
-                };
-
-                if let Err(err) = result {
-                    eprintln!("Uncaught {err}");
-                }
-                continue;
+            if group.is_empty() && self.promise_jobs.borrow().is_empty() {
+                // Both queues are empty. We can exit.
+                return Ok(());
             }
 
             // We could have some jobs pending on the microtask queue. Try to poll the pending

--- a/examples/src/bin/tokio_event_loop.rs
+++ b/examples/src/bin/tokio_event_loop.rs
@@ -116,17 +116,9 @@ impl JobExecutor for Queue {
                 group.insert(job.call(context));
             }
 
-            if self.promise_jobs.borrow().is_empty() {
-                let Some(result) = group.next().await else {
-                    // Both queues are empty. We can exit.
-                    return Ok(());
-                };
-
-                if let Err(err) = result {
-                    eprintln!("Uncaught {err}");
-                }
-
-                continue;
+            if group.is_empty() && self.promise_jobs.borrow().is_empty() {
+                // Both queues are empty. We can exit.
+                return Ok(());
             }
 
             // We have some jobs pending on the microtask queue. Try to poll the pending


### PR DESCRIPTION
This fixes a small bug where a single future that enqueues a promise job could block executing the promise job queue. For example:

```
fn delay(
    _this: &JsValue,
    args: &[JsValue],
    context: &RefCell<&mut Context>,
) -> impl Future<Output = JsResult<JsValue>> {
    let millis = args.get_or_undefined(0).to_u32(&mut context.borrow_mut());

    context
        .borrow_mut()
        .enqueue_job(Job::PromiseJob(PromiseJob::new(|_| {
            println!("ran a job!");
            Ok(JsValue::undefined())
        })));

    async move {
        let millis = millis?;
        let now = Instant::now();
        smol::Timer::after(Duration::from_millis(u64::from(millis))).await;
        let elapsed = now.elapsed().as_secs_f64();
        Ok(elapsed.into())
    }
}
```

In the previous version of the event loops, the queued job would only execute if the returned async method finished executing. With the new implementation, every loop only polls the pending futures once before draining the promise job queue again.