### PR TITLE
Use `AsyncFnOnce` in constructors of `NativeAsyncJob`

### DIFF
--- a/core/engine/src/job.rs
+++ b/core/engine/src/job.rs
@@ -215,24 +215,24 @@ impl Debug for NativeAsyncJob {
 }
 
 impl NativeAsyncJob {
-    /// Creates a new `NativeAsyncJob` from a closure.
+    /// Creates a new `NativeAsyncJob` from an async closure.
     pub fn new<F>(f: F) -> Self
     where
-        F: for<'a> FnOnce(&'a RefCell<&mut Context>) -> BoxedFuture<'a> + 'static,
+        F: AsyncFnOnce(&RefCell<&mut Context>) -> JsResult<JsValue> + 'static,
     {
         Self {
-            f: Box::new(f),
+            f: Box::new(move |ctx| Box::pin(async move { f(ctx).await })),
             realm: None,
         }
     }
 
-    /// Creates a new `NativeAsyncJob` from a closure and an execution realm.
+    /// Creates a new `NativeAsyncJob` from an async closure and an execution realm.
     pub fn with_realm<F>(f: F, realm: Realm) -> Self
     where
-        F: for<'a> FnOnce(&'a RefCell<&mut Context>) -> BoxedFuture<'a> + 'static,
+        F: AsyncFnOnce(&RefCell<&mut Context>) -> JsResult<JsValue> + 'static,
     {
         Self {
-            f: Box::new(f),
+            f: Box::new(move |ctx| Box::pin(async move { f(ctx).await })),
             realm: Some(realm),
         }
     }

--- a/core/engine/src/module/source.rs
+++ b/core/engine/src/module/source.rs
@@ -486,12 +486,10 @@ impl SourceTextModule {
                     let src = module_self.clone();
                     let state = state.clone();
                     let async_job = NativeAsyncJob::with_realm(
-                        move |context| {
-                            Box::pin(async move {
-                                finish_loading_imported_module(name_specifier, src, state, context)
-                                    .await;
-                                Ok(JsValue::undefined())
-                            })
+                        async move |context| {
+                            finish_loading_imported_module(name_specifier, src, state, context)
+                                .await;
+                            Ok(JsValue::undefined())
                         },
                         context.realm().clone(),
                     );

--- a/core/engine/src/native_function/mod.rs
+++ b/core/engine/src/native_function/mod.rs
@@ -293,19 +293,17 @@ impl NativeFunction {
             let args = args.to_vec();
 
             context.enqueue_job(
-                NativeAsyncJob::new(move |context| {
-                    Box::pin(async move {
-                        let result = f(&this, &args, context).await;
+                NativeAsyncJob::new(async move |context| {
+                    let result = f(&this, &args, context).await;
 
-                        let context = &mut context.borrow_mut();
-                        match result {
-                            Ok(v) => resolvers.resolve.call(&JsValue::undefined(), &[v], context),
-                            Err(e) => {
-                                let e = e.to_opaque(context);
-                                resolvers.reject.call(&JsValue::undefined(), &[e], context)
-                            }
+                    let context = &mut context.borrow_mut();
+                    match result {
+                        Ok(v) => resolvers.resolve.call(&JsValue::undefined(), &[v], context),
+                        Err(e) => {
+                            let e = e.to_opaque(context);
+                            resolvers.reject.call(&JsValue::undefined(), &[e], context)
                         }
-                    })
+                    }
                 })
                 .into(),
             );

--- a/core/engine/src/object/builtins/jspromise.rs
+++ b/core/engine/src/object/builtins/jspromise.rs
@@ -293,19 +293,17 @@ impl JsPromise {
         let (promise, resolvers) = Self::new_pending(context);
 
         context.enqueue_job(
-            NativeAsyncJob::new(move |context| {
-                Box::pin(async move {
-                    let result = future.await;
+            NativeAsyncJob::new(async move |context| {
+                let result = future.await;
 
-                    let context = &mut context.borrow_mut();
-                    match result {
-                        Ok(v) => resolvers.resolve.call(&JsValue::undefined(), &[v], context),
-                        Err(e) => {
-                            let e = e.to_opaque(context);
-                            resolvers.reject.call(&JsValue::undefined(), &[e], context)
-                        }
+                let context = &mut context.borrow_mut();
+                match result {
+                    Ok(v) => resolvers.resolve.call(&JsValue::undefined(), &[v], context),
+                    Err(e) => {
+                        let e = e.to_opaque(context);
+                        resolvers.reject.call(&JsValue::undefined(), &[e], context)
                     }
-                })
+                }
             })
             .into(),
         );

--- a/core/engine/src/vm/opcode/call/mod.rs
+++ b/core/engine/src/vm/opcode/call/mod.rs
@@ -473,11 +473,9 @@ impl ImportCall {
             // 8. Perform HostLoadImportedModule(referrer, specifierString, empty, promiseCapability).
             Ok(specifier) => {
                 let job = NativeAsyncJob::with_realm(
-                    move |context| {
-                        Box::pin(async move {
-                            load_dyn_import(referrer, specifier, cap, context).await;
-                            Ok(JsValue::undefined())
-                        })
+                    async move |context| {
+                        load_dyn_import(referrer, specifier, cap, context).await;
+                        Ok(JsValue::undefined())
                     },
                     context.realm().clone(),
                 );

--- a/examples/src/bin/smol_event_loop.rs
+++ b/examples/src/bin/smol_event_loop.rs
@@ -170,8 +170,8 @@ fn delay(
     }
 }
 
-// Example interval function. We cannot use a function returning async in this case since it would
-// borrow the context for too long, but using a `NativeAsyncJob` we can!
+// Example interval function, but using a `NativeAsyncJob` instead of an async
+// function to schedule the async job.
 fn interval(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
     let Some(function) = args.get_or_undefined(0).as_callable() else {
         return Err(JsNativeError::typ()
@@ -185,17 +185,15 @@ fn interval(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult
 
     context.enqueue_job(
         NativeAsyncJob::with_realm(
-            move |context| {
-                Box::pin(async move {
-                    let mut timer = smol::Timer::interval(Duration::from_millis(u64::from(delay)));
-                    for _ in 0..10 {
-                        timer.next().await;
-                        if let Err(err) = function.call(&this, &args, &mut context.borrow_mut()) {
-                            eprintln!("Uncaught {err}");
-                        }
+            async move |context: &RefCell<&mut Context>| {
+                let mut timer = smol::Timer::interval(Duration::from_millis(u64::from(delay)));
+                for _ in 0..10 {
+                    timer.next().await;
+                    if let Err(err) = function.call(&this, &args, &mut context.borrow_mut()) {
+                        eprintln!("Uncaught {err}");
                     }
-                    Ok(JsValue::undefined())
-                })
+                }
+                Ok(JsValue::undefined())
             },
             context.realm().clone(),
         )

--- a/examples/src/bin/tokio_event_loop.rs
+++ b/examples/src/bin/tokio_event_loop.rs
@@ -178,8 +178,8 @@ fn delay(
     }
 }
 
-// Example interval function. We cannot use a function returning async in this case since it would
-// borrow the context for too long, but using a `NativeAsyncJob` we can!
+// Example interval function, but using a `NativeAsyncJob` instead of an async
+// function to schedule the async job.
 fn interval(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
     let Some(function) = args.get_or_undefined(0).as_callable() else {
         return Err(JsNativeError::typ()
@@ -193,17 +193,15 @@ fn interval(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult
 
     context.enqueue_job(
         NativeAsyncJob::with_realm(
-            move |context| {
-                Box::pin(async move {
-                    let mut timer = time::interval(Duration::from_millis(u64::from(delay)));
-                    for _ in 0..10 {
-                        timer.tick().await;
-                        if let Err(err) = function.call(&this, &args, &mut context.borrow_mut()) {
-                            eprintln!("Uncaught {err}");
-                        }
+            async move |context: &RefCell<&mut Context>| {
+                let mut timer = time::interval(Duration::from_millis(u64::from(delay)));
+                for _ in 0..10 {
+                    timer.tick().await;
+                    if let Err(err) = function.call(&this, &args, &mut context.borrow_mut()) {
+                        eprintln!("Uncaught {err}");
                     }
-                    Ok(JsValue::undefined())
-                })
+                }
+                Ok(JsValue::undefined())
             },
             context.realm().clone(),
         )


### PR DESCRIPTION
Changes the signature of the constructors of `NativeAsyncJob`, avoiding having to manually `Box::pin` the provided closure.