### PR TITLE
fix destructuring property reference target order

### DIFF
--- a/core/engine/src/bytecompiler/declaration/declaration_pattern.rs
+++ b/core/engine/src/bytecompiler/declaration/declaration_pattern.rs
@@ -100,6 +100,7 @@ impl ByteCompiler<'_> {
                                 let skip = self.emit_jump_if_not_undefined(&dst);
                                 self.compile_expr(init, &dst);
                                 self.patch_jump(skip);
+                                self.emit_binding(def, ident.to_js_string(self.interner()), &dst);
                             }
 
                             self.register_allocator.dealloc(dst);


### PR DESCRIPTION


<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This PR fixes failing test [language/destructuring/binding/keyed-destructuring-property-reference-target-evaluation-order-with-bindings](https://github.com/tc39/test262/blob/main/test/language/destructuring/binding/keyed-destructuring-property-reference-target-evaluation-order-with-bindings.js)

It changes the following:

- when destructuring an object with a computed property name, first convert the property key value to a proper property key
- ! immediately after converting the value to a key, emit the binding for the new variable. before, this happened after the next step:
- instead of allowing `GetPropertyByValue{,Push}` instr to convert the property key value to the property key, use the property key directly
