### PR TITLE
Implement `Atomics.waitAsync`

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -42,7 +42,7 @@
         "program": "${workspaceFolder}/target/debug/boa_tester.exe"
       },
       "program": "${workspaceFolder}/target/debug/boa_tester",
-      "args": ["run", "-s", "${input:testPath}", "-vvv", "-d"],
+      "args": ["run", "-s", "{input:testPath}", "-vvv", "-d"],
       "sourceLanguages": ["rust"],
       "preLaunchTask": "Cargo Build boa_tester"
     }

--- a/core/engine/src/builtins/atomics/futex.rs
+++ b/core/engine/src/builtins/atomics/futex.rs
@@ -1,4 +1,3 @@
-// Implementation mostly based from https://github.com/v8/v8/blob/main/src/execution/futex-emulation.cc
 // TODO: track https://github.com/rust-lang/rfcs/pull/3467 to see if we can use `UnsafeAliased` instead
 // of raw pointers.
 
@@ -136,137 +135,309 @@
 
 #![deny(unsafe_op_in_unsafe_fn)]
 #![deny(clippy::undocumented_unsafe_blocks)]
-#![allow(clippy::expl_impl_clone_on_copy)]
 
-use std::{cell::UnsafeCell, sync::atomic::Ordering};
+use std::{
+    cell::Cell,
+    ptr,
+    sync::{Arc, atomic::Ordering},
+};
 
 use crate::{
-    JsNativeError, JsResult,
+    Context, JsNativeError, JsResult, JsValue,
     builtins::{
         array_buffer::{SharedArrayBuffer, utils::SliceRef},
+        promise::PromiseCapability,
         typed_array::Element,
     },
+    job::{GenericJob, TimeoutJob},
+    js_string,
     sys::time::{Duration, Instant},
 };
 
-mod sync {
-    use std::sync::{Condvar, Mutex, MutexGuard};
+use std::sync::{Condvar, Mutex, MutexGuard};
 
-    use intrusive_collections::{LinkedList, LinkedListLink, UnsafeRef, intrusive_adapter};
-    use small_btree::{Entry, SmallBTreeMap};
+use intrusive_collections::{LinkedList, LinkedListLink, UnsafeRef, intrusive_adapter};
+use portable_atomic::AtomicBool;
+use rustc_hash::FxHashMap;
+use small_btree::{Entry, SmallBTreeMap};
 
-    use crate::{JsNativeError, JsResult};
+#[derive(Debug)]
+struct AsyncWaiterData {
+    buffer: SharedArrayBuffer,
+    notified: AtomicBool,
+    refcount: Cell<u8>,
+}
 
-    /// A waiter of a memory address.
-    #[derive(Debug, Default)]
-    pub(crate) struct FutexWaiter {
-        pub(super) link: LinkedListLink,
-        pub(super) cond_var: Condvar,
-        pub(super) waiting: bool,
-        addr: usize,
+/// A waiter of a memory address.
+#[derive(Debug)]
+struct FutexWaiter {
+    link: LinkedListLink,
+    cond_var: Condvar,
+    addr: usize,
+    async_data: Option<AsyncWaiterData>,
+}
+
+intrusive_adapter!(FutexWaiterAdapter = UnsafeRef<FutexWaiter>: FutexWaiter { link: LinkedListLink });
+
+impl FutexWaiter {
+    fn new_sync(addr: usize) -> Self {
+        Self {
+            link: LinkedListLink::new(),
+            cond_var: Condvar::new(),
+            addr,
+            async_data: None,
+        }
     }
 
-    intrusive_adapter!(FutexWaiterAdapter = UnsafeRef<FutexWaiter>: FutexWaiter { link: LinkedListLink });
-
-    /// List of memory addresses and its corresponding list of waiters for that address.
-    #[derive(Debug)]
-    pub(super) struct FutexWaiters {
-        waiters: SmallBTreeMap<usize, LinkedList<FutexWaiterAdapter>, 16>,
+    fn new_async(buffer: SharedArrayBuffer, addr: usize) -> UnsafeRef<Self> {
+        UnsafeRef::from_box(Box::new(Self {
+            link: LinkedListLink::new(),
+            cond_var: Condvar::new(),
+            addr,
+            async_data: Some(AsyncWaiterData {
+                buffer,
+                notified: AtomicBool::new(true),
+                refcount: Cell::new(0),
+            }),
+        }))
     }
 
-    // SAFETY: `FutexWaiters` is not constructable outside its `get` method, and it's only exposed by
-    //          a global lock, meaning the inner data of `FutexWaiters` (which includes non-Send pointers)
-    //          can only be accessed by a single thread at once.
-    unsafe impl Send for FutexWaiters {}
+    fn increase_refcount(&self) {
+        if let Some(data) = &self.async_data {
+            data.refcount.update(|rc| rc + 1);
+        }
+    }
 
-    impl FutexWaiters {
-        /// Gets the map of all shared data addresses and its corresponding list of agents waiting on that location.
-        pub(super) fn get() -> JsResult<MutexGuard<'static, Self>> {
-            static CRITICAL_SECTION: Mutex<FutexWaiters> = Mutex::new(FutexWaiters {
-                waiters: SmallBTreeMap::new(),
-            });
+    fn decrease_refcount(&self) {
+        if let Some(data) = &self.async_data {
+            data.refcount.update(|rc| rc - 1);
+        }
+    }
 
-            CRITICAL_SECTION.lock().map_err(|_| {
-                JsNativeError::typ()
-                    .with_message("failed to synchronize with the agent cluster")
-                    .into()
-            })
+    fn refcount(&self) -> u8 {
+        self.async_data
+            .as_ref()
+            .map_or(2, |data| data.refcount.get())
+    }
+}
+
+#[derive(Debug, Clone)]
+struct FutexWaiterKey(UnsafeRef<FutexWaiter>);
+
+impl std::hash::Hash for FutexWaiterKey {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        UnsafeRef::into_raw(self.0.clone()).addr().hash(state);
+    }
+}
+
+impl PartialEq for FutexWaiterKey {
+    fn eq(&self, other: &Self) -> bool {
+        UnsafeRef::into_raw(self.0.clone()).addr() == UnsafeRef::into_raw(other.0.clone()).addr()
+    }
+}
+
+impl Eq for FutexWaiterKey {}
+
+#[derive(Debug, Default)]
+pub(crate) struct AsyncPendingWaiters {
+    waiters: FxHashMap<FutexWaiterKey, PromiseCapability>,
+}
+
+impl AsyncPendingWaiters {
+    pub(crate) fn new() -> Self {
+        Self {
+            waiters: FxHashMap::default(),
+        }
+    }
+
+    fn insert(&mut self, waiter: UnsafeRef<FutexWaiter>, cap: PromiseCapability) {
+        // Should have been added to the waiters list at this point.
+        debug_assert!(waiter.link.is_linked());
+        waiter.increase_refcount();
+        self.waiters.insert(FutexWaiterKey(waiter), cap);
+    }
+
+    fn remove(&mut self, waiter: &UnsafeRef<FutexWaiter>) -> Option<PromiseCapability> {
+        let Some(cap) = self.waiters.remove(&FutexWaiterKey(waiter.clone())) else {
+            return None;
+        };
+        waiter.decrease_refcount();
+        Some(cap)
+    }
+
+    pub(crate) fn enqueue_waiter_jobs(&mut self, context: &mut Context) -> bool {
+        for (waiter, cap) in self.waiters.extract_if(|k, _| {
+            k.0.async_data
+                .as_ref()
+                .map_or(false, |data| data.notified.load(Ordering::Relaxed))
+        }) {
+            // Should have been removed from the waiters list at this point.
+            debug_assert!(!waiter.0.link.is_linked());
+            let realm = cap
+                .functions
+                .resolve
+                .get_function_realm(context)
+                .expect("cannot fail for the default resolving functions");
+            context.enqueue_job(
+                GenericJob::new(
+                    move |context| {
+                        cap.functions.resolve.call(
+                            &JsValue::undefined(),
+                            &[js_string!("ok").into()],
+                            context,
+                        )
+                    },
+                    realm,
+                )
+                .into(),
+            );
+
+            if waiter.0.refcount() < 2 {
+                // SAFETY: This is the last reference to the waiter, so it is safe to deallocate.
+                unsafe { UnsafeRef::into_box(waiter.0) };
+            }
         }
 
-        /// Notifies at most `max_count` waiters that are waiting on the address `addr`, and
-        /// returns the number of waiters that were notified.
-        ///
-        /// Equivalent to [`RemoveWaiters`][remove] and [`NotifyWaiter`][notify], but in a single operation.
-        ///
-        /// [remove]: https://tc39.es/ecma262/#sec-removewaiters
-        /// [notify]: https://tc39.es/ecma262/#sec-notifywaiter
-        pub(super) fn notify_many(&mut self, addr: usize, max_count: u64) -> u64 {
-            let Entry::Occupied(mut wl) = self.waiters.entry(addr) else {
-                return 0;
+        !self.waiters.is_empty()
+    }
+}
+
+impl Drop for AsyncPendingWaiters {
+    fn drop(&mut self) {
+        if self.waiters.is_empty() {
+            return;
+        }
+
+        let Ok(mut global_waiters) = FutexWaiters::get() else {
+            // Cannot cleanup a poisoned mutex.
+            return;
+        };
+
+        for waiter in self.waiters.keys() {
+            // SAFETY: All waiters in the pending waiters map must be valid.
+            unsafe {
+                global_waiters.remove_waiter(&waiter.0);
+            }
+
+            if waiter.0.refcount() < 2 {
+                // SAFETY: This is the last reference to the waiter, so it is safe to deallocate.
+                unsafe { UnsafeRef::into_box(waiter.0.clone()) };
+            }
+        }
+    }
+}
+
+/// List of memory addresses and its corresponding list of waiters for that address.
+#[derive(Debug)]
+struct FutexWaiters {
+    waiters: SmallBTreeMap<usize, LinkedList<FutexWaiterAdapter>, 16>,
+}
+
+// SAFETY: `FutexWaiters` is not constructable outside its `get` method, and it's only exposed by
+//          a global lock, meaning the inner data of `FutexWaiters` (which includes non-Send pointers)
+//          can only be accessed by a single thread at once.
+unsafe impl Send for FutexWaiters {}
+
+impl FutexWaiters {
+    /// Gets the map of all shared data addresses and its corresponding list of agents waiting on that location.
+    fn get() -> JsResult<MutexGuard<'static, Self>> {
+        static CRITICAL_SECTION: Mutex<FutexWaiters> = Mutex::new(FutexWaiters {
+            waiters: SmallBTreeMap::new(),
+        });
+
+        CRITICAL_SECTION.lock().map_err(|_| {
+            JsNativeError::typ()
+                .with_message("failed to synchronize with the agent cluster")
+                .into()
+        })
+    }
+
+    /// Notifies at most `max_count` waiters that are waiting on the address `addr`, and
+    /// returns the number of waiters that were notified.
+    ///
+    /// Equivalent to [`RemoveWaiters`][remove] and [`NotifyWaiter`][notify], but in a single operation.
+    ///
+    /// [remove]: https://tc39.es/ecma262/#sec-removewaiters
+    /// [notify]: https://tc39.es/ecma262/#sec-notifywaiter
+    fn notify_many(&mut self, addr: usize, max_count: u64, context: &mut Context) -> u64 {
+        let Entry::Occupied(mut wl) = self.waiters.entry(addr) else {
+            return 0;
+        };
+
+        for i in 0..max_count {
+            let Some(elem) = wl.get_mut().pop_front() else {
+                wl.remove();
+                return i;
             };
 
-            for i in 0..max_count {
-                let Some(elem) = wl.get_mut().pop_front() else {
-                    wl.remove();
-                    return i;
-                };
+            elem.cond_var.notify_one();
 
-                elem.cond_var.notify_one();
+            if let Some(async_data) = &elem.async_data {
+                async_data.notified.store(true, Ordering::Relaxed);
 
-                // SAFETY: all elements of the waiters list are guaranteed to be valid.
-                unsafe {
-                    (*UnsafeRef::into_raw(elem)).waiting = false;
+                if let Some(cap) = context.pending_waiters.remove(&elem) {
+                    // The waiter was part of this context, so we can safely resolve the promise from here.
+                    cap.functions
+                        .resolve
+                        .call(&JsValue::undefined(), &[js_string!("ok").into()], context)
+                        .expect("cannot fail per the spec");
+                }
+
+                if async_data.refcount.get() < 2 {
+                    // SAFETY: This is the last reference to the waiter, so it is safe to deallocate.
+                    unsafe { UnsafeRef::into_box(elem) };
                 }
             }
-
-            if wl.get().is_empty() {
-                wl.remove();
-            }
-
-            max_count
         }
 
-        /// # Safety
-        ///
-        /// - `node` must NOT be linked to an existing waiter list.
-        /// - `node` must always point to a valid instance of `FutexWaiter` until `node` is
-        ///   removed from its linked list. This can happen by either `remove_waiter` or `notify_many`.
-        pub(super) unsafe fn add_waiter(&mut self, node: *mut FutexWaiter, addr: usize) {
-            // SAFETY: `node` must point to a valid instance.
-            let node = unsafe {
-                debug_assert!(!(*node).link.is_linked());
-                (*node).waiting = true;
-                (*node).addr = addr;
-                UnsafeRef::from_raw(node)
-            };
-
-            self.waiters
-                .entry(addr)
-                .or_insert_with(|| LinkedList::new(FutexWaiterAdapter::new()))
-                .push_back(node);
+        if wl.get().is_empty() {
+            wl.remove();
         }
 
-        /// # Safety
-        ///
-        /// - `node` must point to a valid instance of `FutexWaiter`.
-        /// - `node` must be inside the wait list associated with `node.addr`.
-        pub(super) unsafe fn remove_waiter(&mut self, node: *mut FutexWaiter) {
-            // SAFETY: `node` must point to a valid instance.
-            let addr = unsafe { (*node).addr };
+        max_count
+    }
 
-            let mut wl = match self.waiters.entry(addr) {
-                Entry::Occupied(wl) => wl,
-                Entry::Vacant(_) => return,
-            };
+    /// # Safety
+    ///
+    /// - `node` must NOT be linked to an existing waiter list.
+    /// - `node` must always reference a valid instance of `FutexWaiter` until `node` is
+    ///   removed from its linked list. This can happen by either `remove_waiter` or `notify_many`.
+    unsafe fn add_waiter(&mut self, node: &FutexWaiter) {
+        // SAFETY: `node` must point to a valid instance.
+        let node = unsafe { UnsafeRef::from_raw(ptr::from_ref(node)) };
 
-            // SAFETY: `node` must be inside the wait list associated with `node.addr`.
-            unsafe {
-                wl.get_mut().cursor_mut_from_ptr(node).remove();
-            }
+        node.increase_refcount();
 
-            if wl.get().is_empty() {
-                wl.remove();
-            }
+        self.waiters
+            .entry(node.addr)
+            .or_insert_with(|| LinkedList::new(FutexWaiterAdapter::new()))
+            .push_back(node);
+    }
+
+    /// # Safety
+    ///
+    /// - `node` must point to a valid instance of `FutexWaiter`.
+    /// - `node` must be inside the wait list associated with `node.addr`.
+    pub(super) unsafe fn remove_waiter(&mut self, node: &FutexWaiter) {
+        debug_assert!(node.link.is_linked());
+
+        let Entry::Occupied(mut wl) = self.waiters.entry(node.addr) else {
+            panic!("node was not a valid `FutexWaiter`");
+        };
+
+        // SAFETY: `node` must be inside the wait list associated with `node.addr`.
+        unsafe {
+            wl.get_mut()
+                .cursor_mut_from_ptr(ptr::from_ref(node))
+                .remove();
+        }
+
+        if let Some(data) = &node.async_data {
+            data.refcount.update(|rc| rc - 1);
+        }
+
+        if wl.get().is_empty() {
+            wl.remove();
         }
     }
 }
@@ -292,14 +463,14 @@ pub(super) unsafe fn wait<E: Element + PartialEq>(
     check: E,
     timeout: Option<Duration>,
 ) -> JsResult<AtomicsWaitResult> {
-    // 10. Let block be buffer.[[ArrayBufferData]].
-    // 11. Let WL be GetWaiterList(block, indexedPosition).
-    // 12. Perform EnterCriticalSection(WL).
-    let mut waiters = sync::FutexWaiters::get()?;
-
     let time_info = timeout.map(|timeout| (Instant::now(), timeout));
 
+    // 10. Let block be buffer.[[ArrayBufferData]].
     let buffer = &buffer.bytes_with_len(buf_len)[offset..];
+
+    // 11. Let WL be GetWaiterList(block, indexedPosition).
+    // 12. Perform EnterCriticalSection(WL).
+    let mut waiters = FutexWaiters::get()?;
 
     // 13. Let elementType be TypedArrayElementType(typedArray).
     // 14. Let w be GetValueFromBuffer(buffer, indexedPosition, elementType, true, SeqCst).
@@ -318,12 +489,11 @@ pub(super) unsafe fn wait<E: Element + PartialEq>(
     // 17. Perform AddWaiter(WL, W).
 
     // ensure we can have aliased pointers to the waiter in a sound way.
-    let waiter = UnsafeCell::new(sync::FutexWaiter::default());
-    let waiter_ptr = waiter.get();
+    let waiter = FutexWaiter::new_sync(buffer.as_ptr().addr());
 
-    // SAFETY: waiter is valid and we call `remove_node` below.
+    // SAFETY: waiter is valid and we call `remove_waiter` below.
     unsafe {
-        waiters.add_waiter(waiter_ptr, buffer.as_ptr().addr());
+        waiters.add_waiter(&waiter);
     }
 
     // 18. Let notified be SuspendAgent(WL, W, t).
@@ -331,9 +501,12 @@ pub(super) unsafe fn wait<E: Element + PartialEq>(
     // `SuspendAgent(WL, W, t)`
     // https://tc39.es/ecma262/#sec-suspendthisagent
 
+    // In a couple of places here we early return without removing the waiter from
+    // the waiters list. This could seem unsound, but in reality all our early
+    // returns are because the mutex is poisoned, and if that's the case then
+    // no other thread can read the pointer to the waiter, so we can return safely.
     let result = loop {
-        // SAFETY: waiter is still valid
-        if unsafe { !(*waiter_ptr).waiting } {
+        if !waiter.link.is_linked() {
             break AtomicsWaitResult::Ok;
         }
 
@@ -342,43 +515,32 @@ pub(super) unsafe fn wait<E: Element + PartialEq>(
                 break AtomicsWaitResult::TimedOut;
             };
 
-            // Since the mutex is poisoned, `waiter` cannot be read from other threads, meaning
-            // we can return directly.
             // This doesn't use `wait_timeout_while` because it has to mutably borrow `waiter`,
             // which is a big nono since we have pointers to that location while the borrow is
             // active.
-            // SAFETY: waiter is still valid
-            waiters = unsafe {
-                (*waiter_ptr)
-                    .cond_var
-                    .wait_timeout(waiters, remaining)
-                    .map_err(|_| {
-                        JsNativeError::typ()
-                            .with_message("failed to synchronize with the agent cluster")
-                    })?
-                    .0
-            };
-        } else {
-            // SAFETY: waiter is still valid
-            waiters = unsafe {
-                (*waiter_ptr).cond_var.wait(waiters).map_err(|_| {
+            waiters = waiter
+                .cond_var
+                .wait_timeout(waiters, remaining)
+                .map_err(|_| {
                     JsNativeError::typ()
                         .with_message("failed to synchronize with the agent cluster")
                 })?
-            };
+                .0
+        } else {
+            waiters = waiter.cond_var.wait(waiters).map_err(|_| {
+                JsNativeError::typ().with_message("failed to synchronize with the agent cluster")
+            })?;
         }
     };
 
-    // SAFETY: waiter is valid and contained in its waiter list if `waiting == true`.
-    unsafe {
-        // 20. Else,
-        //     a. Perform RemoveWaiter(WL, W).
-        if (*waiter_ptr).waiting {
-            waiters.remove_waiter(waiter_ptr);
-        } else {
-            // 19. If notified is true, then
-            //     a. Assert: W is not on the list of waiters in WL.
-            debug_assert!(!(*waiter_ptr).link.is_linked());
+    // 19. If notified is true, then
+    //     a. Assert: W is not on the list of waiters in WL.
+    // 20. Else,
+    //     a. Perform RemoveWaiter(WL, W).
+    if waiter.link.is_linked() {
+        // SAFETY: waiter is valid and contained in its waiter list if it is still linked.
+        unsafe {
+            waiters.remove_waiter(&waiter);
         }
     }
 
@@ -390,18 +552,143 @@ pub(super) unsafe fn wait<E: Element + PartialEq>(
     Ok(result)
 }
 
+pub(super) unsafe fn wait_async<E: Element + PartialEq>(
+    shared: &SharedArrayBuffer,
+    buf_len: usize,
+    offset: usize,
+    check: E,
+    timeout: Option<Duration>,
+    capability: PromiseCapability,
+    context: &mut Context,
+) -> JsResult<AtomicsWaitResult> {
+    // 11. Let block be buffer.[[ArrayBufferData]].
+    // 12. Let offset be typedArray.[[ByteOffset]].
+    // 13. Let byteIndexInBuffer be (i × 4) + offset..
+    let buffer = &shared.bytes_with_len(buf_len)[offset..];
+
+    // 14. Let WL be GetWaiterList(block, indexedPosition).
+    // 17. Perform EnterCriticalSection(WL).
+    let mut waiters = FutexWaiters::get()?;
+
+    // 18. Let elementType be TypedArrayElementType(typedArray).
+    // 19. Let w be GetValueFromBuffer(buffer, indexedPosition, elementType, true, SeqCst).
+    // SAFETY: The safety of this operation is guaranteed by the caller.
+    let value = unsafe { E::read(SliceRef::AtomicSlice(buffer)).load(Ordering::SeqCst) };
+
+    // 20. If v ≠ w, then
+    //     a. Perform LeaveCriticalSection(WL).
+    //     b. If mode is sync, return "not-equal".
+    if check != value {
+        return Ok(AtomicsWaitResult::NotEqual);
+    }
+
+    // 21. If t = 0 and mode is async, then
+    //     a. NOTE: There is no special handling of synchronous immediate timeouts. Asynchronous immediate
+    //        timeouts have special handling in order to fail fast and avoid unnecessary Promise jobs.
+    //     b. Perform LeaveCriticalSection(WL).
+    if let Some(timeout) = &timeout
+        && timeout.is_zero()
+    {
+        return Ok(AtomicsWaitResult::TimedOut);
+    }
+    // 27. Let waiterRecord be a new Waiter Record { [[AgentSignifier]]: thisAgent,
+    //     [[PromiseCapability]]: promiseCapability, [[TimeoutTime]]: timeoutTime, [[Result]]: "ok" }.
+    // ensure we can have aliased pointers to the waiter in a sound way.
+    let waiter = FutexWaiter::new_async(shared.clone(), buffer.as_ptr().addr());
+
+    // 23. Let now be the time value (UTC) identifying the current time.
+    // 24. Let additionalTimeout be an implementation-defined non-negative mathematical value.
+    // 25. Let timeoutTime be ℝ(now) + t + additionalTimeout.
+    // 26. NOTE: When t is +∞, timeoutTime is also +∞.
+    let timeout_time = timeout.map(|to| Instant::now() + to);
+
+    // 28. Perform AddWaiter(WL, waiterRecord).
+    // SAFETY: `waiter` is pinned to the heap, so it must be valid.
+    unsafe {
+        waiters.add_waiter(&*waiter);
+    }
+
+    context
+        .pending_waiters
+        .insert(waiter.clone(), capability.clone());
+
+    // 30. Else if timeoutTime is finite, then
+    //     a. Perform EnqueueAtomicsWaitAsyncTimeoutJob(WL, waiterRecord).
+    if let Some(timeout_time) = timeout_time {
+        // EnqueueAtomicsWaitAsyncTimeoutJob ( WL, waiterRecord )
+        // https://tc39.es/ecma262/#sec-enqueueatomicswaitasynctimeoutjob
+        #[derive(Debug)]
+        struct WaiterDropGuard(UnsafeRef<FutexWaiter>);
+
+        impl Drop for WaiterDropGuard {
+            fn drop(&mut self) {
+                let Ok(mut global_waiters) = FutexWaiters::get() else {
+                    // Cannot cleanup a poisoned mutex.
+                    return;
+                };
+                if self.0.link.is_linked() {
+                    // The node is linked and still valid thanks to the reference count.
+                    unsafe {
+                        global_waiters.remove_waiter(&*self.0);
+                    }
+                }
+                if waiter.refcount() < 2 {
+                    // SAFETY: This is the last reference to the waiter, so it is safe to deallocate.
+                    unsafe { UnsafeRef::into_box(waiter) }
+                }
+            }
+        }
+
+        let realm = context.realm().clone();
+        let now = Instant::now();
+        waiter.increase_refcount();
+        let waiter_guard = WaiterDropGuard(waiter);
+        let job = TimeoutJob::with_realm(
+            move |context| {
+                let waiter = waiter_guard.0.clone();
+                std::mem::forget(waiter_guard);
+
+                let waiters = FutexWaiters::get()?;
+
+                if waiter.link.is_linked() {
+                    // The node is linked and still valid thanks to the reference count.
+                    unsafe {
+                        waiters.remove_waiter(&waiter);
+                    }
+                    context.pending_waiters.remove(&waiter).expect("cannot ")
+                }
+
+                if waiter.refcount() < 2 {
+                    // SAFETY: This is the last reference to the waiter, so it is safe to deallocate.
+                    unsafe { UnsafeRef::into_box(waiter) }
+                }
+                Ok(JsValue::undefined())
+            },
+            context.realm().clone(),
+            timeout_time - now,
+        );
+    }
+
+    Ok(AtomicsWaitResult::Ok)
+}
+
 /// Notifies at most `count` agents waiting on the memory address pointed to by `buffer[offset..]`.
-pub(super) fn notify(buffer: &SharedArrayBuffer, offset: usize, count: u64) -> JsResult<u64> {
+pub(super) fn notify(
+    buffer: &SharedArrayBuffer,
+    offset: usize,
+    count: u64,
+    context: &mut Context,
+) -> JsResult<u64> {
     let addr = buffer.as_ptr().addr() + offset;
 
     // 7. Let WL be GetWaiterList(block, indexedPosition).
     // 8. Perform EnterCriticalSection(WL).
-    let mut waiters = sync::FutexWaiters::get()?;
+    let mut waiters = FutexWaiters::get()?;
 
     // 9. Let S be RemoveWaiters(WL, c).
     // 10. For each element W of S, do
     //     a. Perform NotifyWaiter(WL, W).
-    let count = waiters.notify_many(addr, count);
+    let count = waiters.notify_many(addr, count, context);
 
     // 11. Perform LeaveCriticalSection(WL).
     drop(waiters);

--- a/core/engine/src/builtins/atomics/mod.rs
+++ b/core/engine/src/builtins/atomics/mod.rs
@@ -11,6 +11,7 @@
 //! [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics
 
 mod futex;
+pub(crate) use futex::AsyncPendingWaiters;
 
 use std::sync::atomic::Ordering;
 
@@ -505,7 +506,7 @@ impl Atomics {
             return Ok(0.into());
         };
 
-        let count = futex::notify(&shared, access.byte_offset, count)?;
+        let count = futex::notify(&shared, access.byte_offset, count, context)?;
 
         // 12. Let n be the number of elements in S.
         // 13. Return 𝔽(n).

--- a/core/engine/src/builtins/atomics/mod.rs
+++ b/core/engine/src/builtins/atomics/mod.rs
@@ -16,9 +16,16 @@ pub(crate) use futex::AsyncPendingWaiters;
 use std::sync::atomic::Ordering;
 
 use crate::{
-    Context, JsArgs, JsNativeError, JsResult, JsString, JsValue, builtins::BuiltInObject,
-    context::intrinsics::Intrinsics, js_string, object::JsObject, property::Attribute,
-    realm::Realm, string::StaticJsStrings, symbol::JsSymbol, sys::time::Duration,
+    Context, JsArgs, JsNativeError, JsResult, JsString, JsValue,
+    builtins::{BuiltInObject, OrdinaryObject},
+    context::intrinsics::Intrinsics,
+    js_string,
+    object::{JsObject, JsPromise},
+    property::Attribute,
+    realm::Realm,
+    string::StaticJsStrings,
+    symbol::JsSymbol,
+    sys::time::Duration,
     value::IntegerOrInfinity,
 };
 
@@ -49,7 +56,8 @@ impl IntrinsicObject for Atomics {
             .static_method(Atomics::bit_or, js_string!("or"), 3)
             .static_method(Atomics::store, js_string!("store"), 3)
             .static_method(Atomics::sub, js_string!("sub"), 3)
-            .static_method(Atomics::wait, js_string!("wait"), 4)
+            .static_method(Atomics::wait::<false>, js_string!("wait"), 4)
+            .static_method(Atomics::wait::<true>, js_string!("waitAsync"), 4)
             .static_method(Atomics::notify, js_string!("notify"), 3)
             .static_method(Atomics::bit_xor, js_string!("xor"), 3);
 
@@ -387,8 +395,11 @@ impl Atomics {
     /// [`Atomics.wait ( typedArray, index, value, timeout )`][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-atomics.wait
-    // TODO: rewrite this to support Atomics.waitAsync
-    fn wait(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    fn wait<const ASYNC: bool>(
+        _: &JsValue,
+        args: &[JsValue],
+        context: &mut Context,
+    ) -> JsResult<JsValue> {
         let array = args.get_or_undefined(0);
         let index = args.get_or_undefined(1);
         let value = args.get_or_undefined(2);
@@ -398,7 +409,7 @@ impl Atomics {
         let (ta, buf_len) = validate_integer_typed_array(array, true)?;
 
         // 2. Let buffer be taRecord.[[Object]].[[ViewedArrayBuffer]].
-        // 2. If IsSharedArrayBuffer(buffer) is false, throw a TypeError exception.
+        // 3. If IsSharedArrayBuffer(buffer) is false, throw a TypeError exception.
         let buffer = match ta.borrow().data.viewed_array_buffer() {
             BufferObject::SharedBuffer(buf) => buf.clone(),
             BufferObject::Buffer(_) => {
@@ -408,22 +419,20 @@ impl Atomics {
             }
         };
 
-        // 3. Let indexedPosition be ? ValidateAtomicAccess(typedArray, index).
+        // 4. Let i be ? ValidateAtomicAccess(taRecord, index).
         let access = validate_atomic_access(&ta, buf_len, index, context)?;
 
-        // spec expects the evaluation of this first, then the timeout.
+        // 5. Let arrayTypeName be typedArray.[[TypedArrayName]].
         let value = if access.kind == TypedArrayKind::BigInt64 {
-            // 4. If typedArray.[[TypedArrayName]] is "BigInt64Array", let v be ? ToBigInt64(value).
+            // 6. If typedArray.[[TypedArrayName]] is "BigInt64Array", let v be ? ToBigInt64(value).
             value.to_big_int64(context)?
         } else {
-            // 5. Otherwise, let v be ? ToInt32(value).
+            // 7. Else, let v be ? ToInt32(value).
             i64::from(value.to_i32(context)?)
         };
 
-        // moving above since we need to make a generic call next.
-
-        // 6. Let q be ? ToNumber(timeout).
-        // 7. If q is either NaN or +∞𝔽, let t be +∞; else if q is -∞𝔽, let t be 0; else let t be max(ℝ(q), 0).
+        // 8. Let q be ? ToNumber(timeout).
+        // 9. If q is either NaN or +∞𝔽, let t be +∞; else if q is -∞𝔽, let t be 0; else let t be max(ℝ(q), 0).
         let mut timeout = timeout.to_number(context)?;
         // convert to nanoseconds to discard any excessively big timeouts.
         timeout = timeout.clamp(0.0, f64::INFINITY) * 1000.0 * 1000.0;
@@ -433,42 +442,82 @@ impl Atomics {
             Some(Duration::from_nanos(timeout as u64))
         };
 
-        // 8. Let B be AgentCanSuspend().
-        // 9. If B is false, throw a TypeError exception.
-        if !context.can_block() {
+        // 10. If mode is sync and AgentCanSuspend() is false, throw a TypeError exception.
+        if !ASYNC && !context.can_block() {
             return Err(JsNativeError::typ()
                 .with_message("agent cannot be suspended")
                 .into());
         }
 
         // SAFETY: the validity of `addr` is verified by our call to `validate_atomic_access`.
-        let result = unsafe {
-            if access.kind == TypedArrayKind::BigInt64 {
-                futex::wait(
-                    &buffer.borrow().data,
-                    buf_len,
-                    access.byte_offset,
-                    value,
-                    timeout,
-                )?
-            } else {
-                // value must fit into `i32` since it came from an `i32` above.
-                futex::wait(
-                    &buffer.borrow().data,
-                    buf_len,
-                    access.byte_offset,
-                    value as i32,
-                    timeout,
-                )?
-            }
-        };
+        if ASYNC {
+            let (promise, resolvers) = JsPromise::new_pending(context);
+            let result = unsafe {
+                if access.kind == TypedArrayKind::BigInt64 {
+                    futex::wait_async(
+                        &buffer.borrow().data,
+                        buf_len,
+                        access.byte_offset,
+                        value,
+                        timeout,
+                        resolvers,
+                        context,
+                    )?
+                } else {
+                    // value must fit into `i32` since it came from an `i32` above.
+                    futex::wait_async(
+                        &buffer.borrow().data,
+                        buf_len,
+                        access.byte_offset,
+                        value as i32,
+                        timeout,
+                        resolvers,
+                        context,
+                    )?
+                }
+            };
 
-        Ok(match result {
-            futex::AtomicsWaitResult::NotEqual => js_string!("not-equal"),
-            futex::AtomicsWaitResult::TimedOut => js_string!("timed-out"),
-            futex::AtomicsWaitResult::Ok => js_string!("ok"),
+            let (is_async, value) = match result {
+                futex::AtomicsWaitResult::NotEqual => (false, js_string!("not-equal").into()),
+                futex::AtomicsWaitResult::TimedOut => (false, js_string!("timed-out").into()),
+                futex::AtomicsWaitResult::Ok => (true, promise.into()),
+            };
+
+            Ok(context
+                .intrinsics()
+                .templates()
+                .wait_async()
+                .create(OrdinaryObject, vec![is_async.into(), value])
+                .into())
+        } else {
+            let result = unsafe {
+                if access.kind == TypedArrayKind::BigInt64 {
+                    futex::wait(
+                        &buffer.borrow().data,
+                        buf_len,
+                        access.byte_offset,
+                        value,
+                        timeout,
+                    )?
+                } else {
+                    // value must fit into `i32` since it came from an `i32` above.
+                    futex::wait(
+                        &buffer.borrow().data,
+                        buf_len,
+                        access.byte_offset,
+                        value as i32,
+                        timeout,
+                    )?
+                }
+            };
+
+            Ok(match result {
+                futex::AtomicsWaitResult::NotEqual => js_string!("not-equal"),
+                futex::AtomicsWaitResult::TimedOut => js_string!("timed-out"),
+                futex::AtomicsWaitResult::Ok => js_string!("ok"),
+            }
+            .into())
         }
-        .into())
     }
 
     /// [`Atomics.notify ( typedArray, index, count )`][spec]
@@ -598,6 +647,7 @@ fn validate_integer_typed_array(
     Ok(ta_record)
 }
 
+#[derive(Debug, Copy, Clone)]
 struct AtomicAccess {
     byte_offset: usize,
     kind: TypedArrayKind,

--- a/core/engine/src/builtins/promise/mod.rs
+++ b/core/engine/src/builtins/promise/mod.rs
@@ -2309,7 +2309,7 @@ fn new_promise_reaction_job(
     };
 
     // 4. Return the Record { [[Job]]: job, [[Realm]]: handlerRealm }.
-    PromiseJob::with_realm(job, realm, context)
+    PromiseJob::with_realm(job, realm)
 }
 
 /// More information:
@@ -2363,5 +2363,5 @@ fn new_promise_resolve_thenable_job(
     };
 
     // 6. Return the Record { [[Job]]: job, [[Realm]]: thenRealm }.
-    PromiseJob::with_realm(job, realm, context)
+    PromiseJob::with_realm(job, realm)
 }

--- a/core/engine/src/context/intrinsics.rs
+++ b/core/engine/src/context/intrinsics.rs
@@ -1384,6 +1384,8 @@ pub(crate) struct ObjectTemplates {
     namespace: ObjectTemplate,
 
     with_resolvers: ObjectTemplate,
+
+    wait_async: ObjectTemplate,
 }
 
 impl ObjectTemplates {
@@ -1518,6 +1520,15 @@ impl ObjectTemplates {
             with_resolvers
         };
 
+        let wait_async = {
+            let mut obj = ordinary_object.clone();
+
+            obj.property(js_string!("async").into(), Attribute::all())
+                .property(js_string!("value").into(), Attribute::all());
+
+            obj
+        };
+
         Self {
             iterator_result,
             ordinary_object,
@@ -1541,6 +1552,7 @@ impl ObjectTemplates {
             function_with_prototype_without_proto,
             namespace,
             with_resolvers,
+            wait_async,
         }
     }
 
@@ -1765,10 +1777,22 @@ impl ObjectTemplates {
     ///
     /// Transitions:
     ///
-    /// 1. `"promise"`: (`WRITABLE`, `ENUMERABLE`, `CONFIGURABLE`)
-    /// 2. `"resolve"`: (`WRITABLE`, `ENUMERABLE`, `CONFIGURABLE`)
-    /// 3. `"reject"`: (`WRITABLE`, `ENUMERABLE`, `CONFIGURABLE`)
+    /// 1. `__proto__`: `Object.prototype`
+    /// 2. `"promise"`: (`WRITABLE`, `ENUMERABLE`, `CONFIGURABLE`)
+    /// 3. `"resolve"`: (`WRITABLE`, `ENUMERABLE`, `CONFIGURABLE`)
+    /// 4. `"reject"`: (`WRITABLE`, `ENUMERABLE`, `CONFIGURABLE`)
     pub(crate) const fn with_resolvers(&self) -> &ObjectTemplate {
         &self.with_resolvers
+    }
+
+    /// Cached object from the `Atomics.waitAsync` method.
+    ///
+    /// Transitions:
+    ///
+    /// 1. `__proto__`: `Object.prototype`
+    /// 2. `"async"`: (`WRITABLE`, `ENUMERABLE`, `CONFIGURABLE`)
+    /// 3. `"value"`: (`WRITABLE`, `ENUMERABLE`, `CONFIGURABLE`)
+    pub(crate) const fn wait_async(&self) -> &ObjectTemplate {
+        &self.wait_async
     }
 }

--- a/core/engine/src/job.rs
+++ b/core/engine/src/job.rs
@@ -75,7 +75,7 @@ impl NativeJob {
     }
 
     /// Creates a new `NativeJob` from a closure and an execution realm.
-    pub fn with_realm<F>(f: F, realm: Realm, _context: &mut Context) -> Self
+    pub fn with_realm<F>(f: F, realm: Realm) -> Self
     where
         F: FnOnce(&mut Context) -> JsResult<JsValue> + 'static,
     {
@@ -162,19 +162,11 @@ impl TimeoutJob {
 
     /// Creates a new `TimeoutJob` from a closure, a timeout, and an execution realm.
     #[must_use]
-    pub fn with_realm<F>(
-        f: F,
-        realm: Realm,
-        timeout: std::time::Duration,
-        context: &mut Context,
-    ) -> Self
+    pub fn with_realm<F>(f: F, realm: Realm, timeout: std::time::Duration) -> Self
     where
         F: FnOnce(&mut Context) -> JsResult<JsValue> + 'static,
     {
-        Self::new(
-            NativeJob::with_realm(f, realm, context),
-            timeout.as_millis() as u64,
-        )
+        Self::new(NativeJob::with_realm(f, realm), timeout.as_millis() as u64)
     }
 
     /// Calls the native job with the specified [`Context`].
@@ -192,6 +184,46 @@ impl TimeoutJob {
     #[must_use]
     pub fn timeout(&self) -> JsDuration {
         self.timeout
+    }
+}
+
+/// An ECMAScript Generic [Job].
+///
+/// This represents the [HostEnqueueGenericJob] operation from the specification, which
+/// enqueues a job that is just like a [`PromiseJob`], but unconstrained in relation
+/// to priority and ordering.
+///
+/// [HostEnqueueGenericJob]: https://tc39.es/ecma262/#sec-hostenqueuegenericjob
+pub struct GenericJob(NativeJob);
+
+impl Debug for GenericJob {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GenericJob").finish_non_exhaustive()
+    }
+}
+
+impl GenericJob {
+    /// Creates a new `GenericJob` from a closure and an execution realm.
+    pub fn new<F>(f: F, realm: Realm) -> Self
+    where
+        F: FnOnce(&mut Context) -> JsResult<JsValue> + 'static,
+    {
+        Self(NativeJob::with_realm(f, realm))
+    }
+
+    /// Gets a reference to the execution realm of the job.
+    #[must_use]
+    pub const fn realm(&self) -> &Realm {
+        self.0
+            .realm
+            .as_ref()
+            .expect("all generic jobs must have an execution realm")
+    }
+
+    /// Calls the `GenericJob` with the specified [`Context`], setting the execution
+    /// context to the job's realm before calling the inner closure, and resets it after execution.
+    pub fn call(self, context: &mut Context) -> JsResult<JsValue> {
+        self.0.call(context)
     }
 }
 
@@ -333,11 +365,11 @@ impl PromiseJob {
     }
 
     /// Creates a new `PromiseJob` from a closure and an execution realm.
-    pub fn with_realm<F>(f: F, realm: Realm, context: &mut Context) -> Self
+    pub fn with_realm<F>(f: F, realm: Realm) -> Self
     where
         F: FnOnce(&mut Context) -> JsResult<JsValue> + 'static,
     {
-        Self(NativeJob::with_realm(f, realm, context))
+        Self(NativeJob::with_realm(f, realm))
     }
 
     /// Gets a reference to the execution realm of the `PromiseJob`.
@@ -441,6 +473,10 @@ pub enum Job {
     ///
     /// See [`TimeoutJob`] for more information.
     TimeoutJob(TimeoutJob),
+    /// A generic job.
+    ///
+    /// See [`GenericJob`] for more information.
+    GenericJob(GenericJob),
 }
 
 impl From<NativeAsyncJob> for Job {
@@ -458,6 +494,12 @@ impl From<PromiseJob> for Job {
 impl From<TimeoutJob> for Job {
     fn from(job: TimeoutJob) -> Self {
         Job::TimeoutJob(job)
+    }
+}
+
+impl From<GenericJob> for Job {
+    fn from(job: GenericJob) -> Self {
+        Job::GenericJob(job)
     }
 }
 
@@ -582,7 +624,10 @@ impl JobExecutor for SimpleJobExecutor {
 
         let context = RefCell::new(context);
         loop {
-            if self.promise_jobs.borrow().is_empty() && self.async_jobs.borrow().is_empty() {
+            if self.promise_jobs.borrow().is_empty()
+                && self.async_jobs.borrow().is_empty()
+                && !context.borrow_mut().enqueue_resolved_context_jobs()
+            {
                 break;
             }
 
@@ -605,6 +650,8 @@ impl JobExecutor for SimpleJobExecutor {
                 }
                 next_job = self.promise_jobs.borrow_mut().pop_front();
             }
+            let context = &mut context.borrow_mut();
+            context.clear_kept_objects();
         }
 
         Ok(())

--- a/core/engine/src/job.rs
+++ b/core/engine/src/job.rs
@@ -30,7 +30,8 @@
 //! [JobCallback]: https://tc39.es/ecma262/#sec-jobcallback-records
 //! [`Gc`]: boa_gc::Gc
 
-use crate::context::time::{JsDuration, JsInstant};
+use crate::context::time::JsDuration;
+use crate::sys::time;
 use crate::{
     Context, JsResult, JsValue,
     object::{JsFunction, NativeObject},
@@ -39,6 +40,7 @@ use crate::{
 use boa_gc::{Finalize, Trace};
 use std::any::Any;
 use std::collections::BTreeMap;
+use std::mem;
 use std::rc::Rc;
 use std::{cell::RefCell, collections::VecDeque, fmt::Debug, future::Future, pin::Pin};
 
@@ -162,7 +164,7 @@ impl TimeoutJob {
 
     /// Creates a new `TimeoutJob` from a closure, a timeout, and an execution realm.
     #[must_use]
-    pub fn with_realm<F>(f: F, realm: Realm, timeout: std::time::Duration) -> Self
+    pub fn with_realm<F>(f: F, realm: Realm, timeout: time::Duration) -> Self
     where
         F: FnOnce(&mut Context) -> JsResult<JsValue> + 'static,
     {
@@ -576,7 +578,17 @@ impl JobExecutor for IdleJobExecutor {
 pub struct SimpleJobExecutor {
     promise_jobs: RefCell<VecDeque<PromiseJob>>,
     async_jobs: RefCell<VecDeque<NativeAsyncJob>>,
-    timeout_jobs: RefCell<BTreeMap<JsInstant, TimeoutJob>>,
+    timeout_jobs: RefCell<BTreeMap<time::Instant, TimeoutJob>>,
+    generic_jobs: RefCell<VecDeque<GenericJob>>,
+}
+
+impl SimpleJobExecutor {
+    fn clear(&self) {
+        self.promise_jobs.borrow_mut().clear();
+        self.async_jobs.borrow_mut().clear();
+        self.timeout_jobs.borrow_mut().clear();
+        self.generic_jobs.borrow_mut().clear();
+    }
 }
 
 impl Debug for SimpleJobExecutor {
@@ -594,64 +606,74 @@ impl SimpleJobExecutor {
 }
 
 impl JobExecutor for SimpleJobExecutor {
-    fn enqueue_job(self: Rc<Self>, job: Job, context: &mut Context) {
+    fn enqueue_job(self: Rc<Self>, job: Job, _context: &mut Context) {
         match job {
             Job::PromiseJob(p) => self.promise_jobs.borrow_mut().push_back(p),
             Job::AsyncJob(a) => self.async_jobs.borrow_mut().push_back(a),
             Job::TimeoutJob(t) => {
-                let now = context.clock().now();
-                self.timeout_jobs.borrow_mut().insert(now + t.timeout(), t);
+                let now = time::Instant::now();
+                self.timeout_jobs
+                    .borrow_mut()
+                    .insert(now + time::Duration::from(t.timeout()), t);
             }
+            Job::GenericJob(g) => self.generic_jobs.borrow_mut().push_back(g),
         }
     }
 
     fn run_jobs(self: Rc<Self>, context: &mut Context) -> JsResult<()> {
-        let now = context.clock().now();
-
-        {
-            let mut timeouts_borrow = self.timeout_jobs.borrow_mut();
-            // `split_off` returns the jobs after (or equal to) the key. So we need to add 1ms to
-            // the current time to get the jobs that are due, then swap with the inner timeout
-            // tree so that we get the jobs to actually run.
-            let jobs_to_keep = timeouts_borrow.split_off(&(now + JsDuration::from_millis(1)));
-            let jobs_to_run = std::mem::replace(&mut *timeouts_borrow, jobs_to_keep);
-            drop(timeouts_borrow);
-
-            for job in jobs_to_run.into_values() {
-                job.call(context)?;
-            }
-        }
-
         let context = RefCell::new(context);
         loop {
             if self.promise_jobs.borrow().is_empty()
                 && self.async_jobs.borrow().is_empty()
-                && !context.borrow_mut().enqueue_resolved_context_jobs()
+                && self.generic_jobs.borrow().is_empty()
+                && self.timeout_jobs.borrow().is_empty()
+                && !context.borrow().has_pending_context_jobs()
             {
                 break;
             }
 
-            // Block on each async jobs running in the queue.
-            let mut next_job = self.async_jobs.borrow_mut().pop_front();
-            while let Some(job) = next_job {
+            context.borrow_mut().enqueue_resolved_context_jobs();
+
+            // Block on each job running in the queue.
+            let jobs = mem::take(&mut *self.async_jobs.borrow_mut());
+            for job in jobs {
                 if let Err(err) = futures_lite::future::block_on(job.call(&context)) {
-                    self.async_jobs.borrow_mut().clear();
-                    self.promise_jobs.borrow_mut().clear();
+                    self.clear();
                     return Err(err);
                 }
-                next_job = self.async_jobs.borrow_mut().pop_front();
             }
-            let mut next_job = self.promise_jobs.borrow_mut().pop_front();
-            while let Some(job) = next_job {
+
+            {
+                let now = time::Instant::now();
+                let mut timeouts_borrow = self.timeout_jobs.borrow_mut();
+                let jobs_to_keep = timeouts_borrow.split_off(&now);
+                let jobs_to_run = mem::replace(&mut *timeouts_borrow, jobs_to_keep);
+                drop(timeouts_borrow);
+
+                for job in jobs_to_run.into_values() {
+                    if let Err(err) = job.call(&mut context.borrow_mut()) {
+                        self.clear();
+                        return Err(err);
+                    }
+                }
+            }
+
+            let jobs = mem::take(&mut *self.promise_jobs.borrow_mut());
+            for job in jobs {
                 if let Err(err) = job.call(&mut context.borrow_mut()) {
-                    self.async_jobs.borrow_mut().clear();
-                    self.promise_jobs.borrow_mut().clear();
+                    self.clear();
                     return Err(err);
                 }
-                next_job = self.promise_jobs.borrow_mut().pop_front();
             }
-            let context = &mut context.borrow_mut();
-            context.clear_kept_objects();
+
+            let jobs = mem::take(&mut *self.generic_jobs.borrow_mut());
+            for job in jobs {
+                if let Err(err) = job.call(&mut context.borrow_mut()) {
+                    self.clear();
+                    return Err(err);
+                }
+            }
+            context.borrow_mut().clear_kept_objects();
         }
 
         Ok(())

--- a/core/engine/src/script.rs
+++ b/core/engine/src/script.rs
@@ -172,8 +172,6 @@ impl Script {
         let record = context.run();
 
         context.vm.pop_frame();
-        context.clear_kept_objects();
-
         record.consume()
     }
 
@@ -206,8 +204,6 @@ impl Script {
         let record = context.run_async_with_budget(budget).await;
 
         context.vm.pop_frame();
-        context.clear_kept_objects();
-
         record.consume()
     }
 

--- a/examples/src/bin/module_fetch_async.rs
+++ b/examples/src/bin/module_fetch_async.rs
@@ -175,23 +175,21 @@ impl JobExecutor for Queue {
 
     // ...the async flavor won't, which allows concurrent execution with external async tasks.
     async fn run_jobs_async(self: Rc<Self>, context: &RefCell<&mut Context>) -> JsResult<()> {
-        // Early return in case there were no jobs scheduled.
-        if self.promise_jobs.borrow().is_empty()
-            && self.async_jobs.borrow().is_empty()
-            && context.borrow().enqueue_resolved_context_jobs()
-        {
-            return Ok(());
-        }
         let mut group = FutureGroup::new();
         loop {
             for job in std::mem::take(&mut *self.async_jobs.borrow_mut()) {
                 group.insert(job.call(context));
             }
 
-            if group.is_empty() && self.promise_jobs.borrow().is_empty() {
+            if group.is_empty()
+                && self.promise_jobs.borrow().is_empty()
+                && !context.borrow().has_pending_context_jobs()
+            {
                 // Both queues are empty. We can exit.
                 return Ok(());
             }
+
+            context.borrow_mut().enqueue_resolved_context_jobs();
 
             // We have some jobs pending on the microtask queue. Try to poll the pending
             // tasks once to see if any of them finished, and run the pending microtasks

--- a/examples/src/bin/module_fetch_async.rs
+++ b/examples/src/bin/module_fetch_async.rs
@@ -176,7 +176,10 @@ impl JobExecutor for Queue {
     // ...the async flavor won't, which allows concurrent execution with external async tasks.
     async fn run_jobs_async(self: Rc<Self>, context: &RefCell<&mut Context>) -> JsResult<()> {
         // Early return in case there were no jobs scheduled.
-        if self.promise_jobs.borrow().is_empty() && self.async_jobs.borrow().is_empty() {
+        if self.promise_jobs.borrow().is_empty()
+            && self.async_jobs.borrow().is_empty()
+            && context.borrow().enqueue_resolved_context_jobs()
+        {
             return Ok(());
         }
         let mut group = FutureGroup::new();

--- a/examples/src/bin/smol_event_loop.rs
+++ b/examples/src/bin/smol_event_loop.rs
@@ -1,5 +1,5 @@
 use boa_engine::context::time::{JsDuration, JsInstant};
-use boa_engine::job::TimeoutJob;
+use boa_engine::job::{GenericJob, TimeoutJob};
 use boa_engine::{
     Context, JsArgs, JsNativeError, JsResult, JsValue, Script, Source,
     context::ContextBuilder,
@@ -39,6 +39,7 @@ struct Queue {
     async_jobs: RefCell<VecDeque<NativeAsyncJob>>,
     promise_jobs: RefCell<VecDeque<PromiseJob>>,
     timeout_jobs: RefCell<BTreeMap<JsInstant, TimeoutJob>>,
+    generic_jobs: RefCell<VecDeque<GenericJob>>,
 }
 
 impl Queue {
@@ -47,6 +48,7 @@ impl Queue {
             async_jobs: RefCell::default(),
             promise_jobs: RefCell::default(),
             timeout_jobs: RefCell::default(),
+            generic_jobs: RefCell::default(),
         }
     }
 
@@ -69,7 +71,8 @@ impl Queue {
     }
 
     fn drain_jobs(&self, context: &mut Context) {
-        context.enqueue_internal_jobs();
+        context.enqueue_resolved_context_jobs();
+
         // Run the timeout jobs first.
         self.drain_timeout_jobs(context);
 
@@ -78,6 +81,12 @@ impl Queue {
             if let Err(e) = job.call(context) {
                 eprintln!("Uncaught {e}");
             }
+        }
+        let job = self.generic_jobs.borrow_mut().pop_front();
+        if let Some(generic) = job
+            && let Err(err) = generic.call(context)
+        {
+            eprintln!("Uncaught {err}");
         }
         context.clear_kept_objects();
     }
@@ -92,6 +101,7 @@ impl JobExecutor for Queue {
                 let now = context.clock().now();
                 self.timeout_jobs.borrow_mut().insert(now + t.timeout(), t);
             }
+            Job::GenericJob(g) => self.generic_jobs.borrow_mut().push_back(g),
             _ => panic!("unsupported job type"),
         }
     }
@@ -103,13 +113,6 @@ impl JobExecutor for Queue {
 
     // ...the async flavor won't, which allows concurrent execution with external async tasks.
     async fn run_jobs_async(self: Rc<Self>, context: &RefCell<&mut Context>) -> JsResult<()> {
-        // Early return in case there were no jobs scheduled.
-        if self.promise_jobs.borrow().is_empty()
-            && self.async_jobs.borrow().is_empty()
-            && !context.borrow_mut().enqueue_resolved_context_jobs()
-        {
-            return Ok(());
-        }
         let mut group = FutureGroup::new();
         loop {
             for job in std::mem::take(&mut *self.async_jobs.borrow_mut()) {
@@ -117,9 +120,10 @@ impl JobExecutor for Queue {
             }
 
             if group.is_empty()
-                && self.promise_jobs.borrow().is_empty()
+                && self.async_jobs.borrow().is_empty()
                 && self.timeout_jobs.borrow().is_empty()
-                && !context.borrow_mut().enqueue_resolved_context_jobs()
+                && self.generic_jobs.borrow().is_empty()
+                && !context.borrow().has_pending_context_jobs()
             {
                 // All queues are empty. We can exit.
                 return Ok(());

--- a/examples/src/bin/tokio_event_loop.rs
+++ b/examples/src/bin/tokio_event_loop.rs
@@ -78,6 +78,8 @@ impl Queue {
                 eprintln!("Uncaught {e}");
             }
         }
+        context.clear_kept_objects();
+        context.enqueue_internal_jobs();
     }
 }
 
@@ -107,7 +109,10 @@ impl JobExecutor for Queue {
     // ...the async flavor won't, which allows concurrent execution with external async tasks.
     async fn run_jobs_async(self: Rc<Self>, context: &RefCell<&mut Context>) -> JsResult<()> {
         // Early return in case there were no jobs scheduled.
-        if self.promise_jobs.borrow().is_empty() && self.async_jobs.borrow().is_empty() {
+        if self.promise_jobs.borrow().is_empty()
+            && self.async_jobs.borrow().is_empty()
+            && context.borrow_mut().enqueue_resolved_context_jobs()
+        {
             return Ok(());
         }
         let mut group = FutureGroup::new();
@@ -116,8 +121,12 @@ impl JobExecutor for Queue {
                 group.insert(job.call(context));
             }
 
-            if group.is_empty() && self.promise_jobs.borrow().is_empty() {
-                // Both queues are empty. We can exit.
+            if group.is_empty()
+                && self.promise_jobs.borrow().is_empty()
+                && self.timeout_jobs.borrow().is_empty()
+                && !context.borrow_mut().enqueue_resolved_context_jobs()
+            {
+                // All queues are empty. We can exit.
                 return Ok(());
             }
 

--- a/tests/tester/src/exec/mod.rs
+++ b/tests/tester/src/exec/mod.rs
@@ -540,7 +540,7 @@ impl Test {
         register_print_fn(&mut context, async_result.clone());
 
         // add the $262 object.
-        let _js262 = js262::register_js262(handles.clone(), &mut context);
+        let _js262 = js262::register_js262(handles.clone(), console, &mut context);
 
         if console {
             let console = boa_runtime::Console::init(&mut context);


### PR DESCRIPTION
Phew, this was a bit of an adventure.

This implements `Atomics.waitAsync`, which is the last missing synchronization primitive we needed to implement have 100% conformance on that builtin. The implementation is not the most optimal one; we could definitely use some channels to communicate which waiters were notified instead of having to iterate through all of them, but IMO it looks fairly decent for a first pass.