### PR TITLE
Remove `Box` from `Object`'s data member

### DIFF
--- a/core/engine/src/builtins/array_buffer/shared.rs
+++ b/core/engine/src/builtins/array_buffer/shared.rs
@@ -301,7 +301,7 @@ impl SharedArrayBuffer {
         };
 
         // 2. Perform ? RequireInternalSlot(O, [[ArrayBufferMaxByteLength]]).
-        if buf.borrow().data.is_fixed_len() {
+        if buf.borrow().data().is_fixed_len() {
             return Err(JsNativeError::typ()
                 .with_message("SharedArrayBuffer.grow: cannot grow a fixed-length buffer")
                 .into());
@@ -321,7 +321,7 @@ impl SharedArrayBuffer {
         // 10. Let newByteLengthRawBytes be NumericToRawBytes(biguint64, ℤ(newByteLength), isLittleEndian).
 
         let buf = buf.borrow();
-        let buf = &buf.data;
+        let buf = &buf.data();
 
         // d. If newByteLength < currentByteLength or newByteLength > O.[[ArrayBufferMaxByteLength]], throw a RangeError exception.
         // Extracting this condition outside the CAS since throwing early doesn't affect the correct
@@ -395,7 +395,7 @@ impl SharedArrayBuffer {
             })?;
 
         // 4. Let len be ArrayBufferByteLength(O, seq-cst).
-        let len = buf.borrow().data.len(Ordering::SeqCst);
+        let len = buf.borrow().data().len(Ordering::SeqCst);
 
         // 5. Let relativeStart be ? ToIntegerOrInfinity(start).
         // 6. If relativeStart = -∞, let first be 0.
@@ -423,7 +423,7 @@ impl SharedArrayBuffer {
 
         {
             let buf = buf.borrow();
-            let buf = &buf.data;
+            let buf = &buf.data();
             // 16. Perform ? RequireInternalSlot(new, [[ArrayBufferData]]).
             // 17. If IsSharedArrayBuffer(new) is false, throw a TypeError exception.
             let new = new.downcast_ref::<Self>().ok_or_else(|| {

--- a/core/engine/src/builtins/array_buffer/utils.rs
+++ b/core/engine/src/builtins/array_buffer/utils.rs
@@ -160,7 +160,7 @@ impl SliceRef<'_> {
         {
             let mut target_buffer = target_buffer.borrow_mut();
             let target_block = target_buffer
-                .data
+                .data_mut()
                 .bytes_mut()
                 .expect("ArrayBuffer cannot be detached here");
 

--- a/core/engine/src/builtins/intl/number_format/mod.rs
+++ b/core/engine/src/builtins/intl/number_format/mod.rs
@@ -248,7 +248,7 @@ impl BuiltInConstructor for NumberFormat {
                 .objects()
                 .intl()
                 .borrow()
-                .data
+                .data()
                 .fallback_symbol();
 
             // a. Perform ? DefinePropertyOrThrow(this, %Intl%.[[FallbackSymbol]], PropertyDescriptor{ [[Value]]: numberFormat, [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: false }).
@@ -500,7 +500,7 @@ impl NumberFormat {
         let nf_clone = nf.clone();
         let mut nf = nf.borrow_mut();
 
-        let bound_format = if let Some(f) = nf.data.bound_format.clone() {
+        let bound_format = if let Some(f) = nf.data_mut().bound_format.clone() {
             f
         } else {
             // 4. If nf.[[BoundFormat]] is undefined, then
@@ -523,7 +523,7 @@ impl NumberFormat {
                         let mut x = to_intl_mathematical_value(value, context)?;
 
                         // 5. Return FormatNumeric(nf, x).
-                        Ok(js_string!(nf.borrow().data.format(&mut x).to_string()).into())
+                        Ok(js_string!(nf.borrow().data().format(&mut x).to_string()).into())
                     },
                     nf_clone,
                 ),
@@ -531,7 +531,7 @@ impl NumberFormat {
             .length(2)
             .build();
 
-            nf.data.bound_format = Some(bound_format.clone());
+            nf.data_mut().bound_format = Some(bound_format.clone());
             bound_format
         };
 
@@ -558,7 +558,7 @@ impl NumberFormat {
         // 3. Perform ? RequireInternalSlot(nf, [[InitializedNumberFormat]]).
         let nf = unwrap_number_format(this, context)?;
         let nf = nf.borrow();
-        let nf = &nf.data;
+        let nf = nf.data();
 
         // 4. Let options be OrdinaryObjectCreate(%Object.prototype%).
         // 5. For each row of Table 12, except the header row, in table order, do
@@ -753,7 +753,7 @@ fn unwrap_number_format(nf: &JsValue, context: &mut Context) -> JsResult<JsObjec
             .objects()
             .intl()
             .borrow()
-            .data
+            .data()
             .fallback_symbol();
 
         //    a. Return ? Get(nf, %Intl%.[[FallbackSymbol]]).

--- a/core/engine/src/builtins/map/mod.rs
+++ b/core/engine/src/builtins/map/mod.rs
@@ -458,7 +458,7 @@ impl Map {
         // after it has been visited and then re-added before the forEach call completes.
         // Keys that are deleted after the call to forEach begins and before being visited
         // are not visited unless the key is added again before the forEach call completes.
-        let _lock = map.borrow_mut().data.lock(map.clone().upcast());
+        let _lock = map.borrow_mut().data_mut().lock(map.clone().upcast());
 
         // 4. Let entries be the List that is M.[[MapData]].
         // 5. For each Record { [[Key]], [[Value]] } e of entries, do
@@ -466,7 +466,7 @@ impl Map {
         loop {
             let arguments = {
                 let map = map.borrow();
-                let map = &map.data;
+                let map = map.data();
                 if index < map.full_len() {
                     map.get_index(index)
                         .map(|(k, v)| [v.clone(), k.clone(), this.clone()])
@@ -505,13 +505,13 @@ impl Map {
             .and_then(|obj| obj.downcast::<OrderedMap<JsValue>>().ok())
             .ok_or_else(|| JsNativeError::typ().with_message("`this` is not a Map"))?;
 
-        let _lock = map.borrow_mut().data.lock(map.clone().upcast());
+        let _lock = map.borrow_mut().data_mut().lock(map.clone().upcast());
 
         let mut index = 0;
         loop {
             let (k, v) = {
                 let map = map.borrow();
-                let map = &map.data;
+                let map = map.data();
 
                 if index < map.full_len() {
                     if let Some((k, v)) = map.get_index(index) {

--- a/core/engine/src/builtins/regexp/mod.rs
+++ b/core/engine/src/builtins/regexp/mod.rs
@@ -903,7 +903,7 @@ impl RegExp {
         input: &JsString,
         context: &mut Context,
     ) -> JsResult<Option<JsObject>> {
-        let rx = this.borrow().data.clone();
+        let rx = this.borrow().data().clone();
         let this = this.upcast();
 
         // 1. Let length be the length of S.

--- a/core/engine/src/builtins/temporal/mod.rs
+++ b/core/engine/src/builtins/temporal/mod.rs
@@ -173,7 +173,7 @@ pub(crate) fn get_relative_to_option(
         // a. If value has an [[InitializedTemporalZonedDateTime]] internal slot, then
         if let Some(zdt) = object.downcast_ref::<ZonedDateTime>() {
             // i. Return the Record { [[PlainRelativeTo]]: undefined, [[ZonedRelativeTo]]: value }.
-            return Ok(Some(RelativeTo::ZonedDateTime(zdt.inner.clone())));
+            return Ok(Some(RelativeTo::ZonedDateTime(zdt.inner.as_ref().clone())));
         // b. If value has an [[InitializedTemporalDate]] internal slot, then
         } else if let Some(date) = object.downcast_ref::<PlainDate>() {
             // i. Return the Record { [[PlainRelativeTo]]: value, [[ZonedRelativeTo]]: undefined }.

--- a/core/engine/src/builtins/typed_array/builtin.rs
+++ b/core/engine/src/builtins/typed_array/builtin.rs
@@ -371,7 +371,7 @@ impl BuiltinTypedArray {
         let (o, buf_len) = TypedArray::validate(this, Ordering::SeqCst)?;
 
         // 3. Let len be TypedArrayLength(taRecord).
-        let len = o.borrow().data.array_length(buf_len) as i64;
+        let len = o.borrow().data().array_length(buf_len) as i64;
 
         // 4. Let relativeIndex be ? ToIntegerOrInfinity(index).
         let relative_index = args.get_or_undefined(0).to_integer_or_infinity(context)?;
@@ -503,7 +503,7 @@ impl BuiltinTypedArray {
         let (ta, buf_len) = TypedArray::validate(this, Ordering::SeqCst)?;
 
         // 3. Let len be TypedArrayLength(taRecord).
-        let len = ta.borrow().data.array_length(buf_len);
+        let len = ta.borrow().data().array_length(buf_len);
 
         // 4. Let relativeTarget be ? ToIntegerOrInfinity(target).
         // 5. If relativeTarget is -∞, let to be 0.
@@ -532,7 +532,7 @@ impl BuiltinTypedArray {
         // 17. If count > 0, then
         if count > 0 {
             let ta = ta.borrow();
-            let ta = &ta.data;
+            let ta = ta.data();
 
             // a. NOTE: The copying must be performed in a manner that preserves the bit-level encoding of the source data.
             // b. Let buffer be O.[[ViewedArrayBuffer]].
@@ -653,7 +653,7 @@ impl BuiltinTypedArray {
         let (ta, buf_len) = TypedArray::validate(this, Ordering::SeqCst)?;
 
         // 3. Let len be TypedArrayLength(taRecord).
-        let len = ta.borrow().data.array_length(buf_len);
+        let len = ta.borrow().data().array_length(buf_len);
 
         // 4. If IsCallable(callbackfn) is false, throw a TypeError exception.
         let callback_fn = match args.get_or_undefined(0).as_object() {
@@ -710,9 +710,9 @@ impl BuiltinTypedArray {
         let (ta, buf_len) = TypedArray::validate(this, Ordering::SeqCst)?;
 
         // 3. Let len be TypedArrayLength(taRecord).
-        let len = ta.borrow().data.array_length(buf_len);
+        let len = ta.borrow().data().array_length(buf_len);
 
-        let value: JsValue = if ta.borrow().data.kind().content_type() == ContentType::BigInt {
+        let value: JsValue = if ta.borrow().data().kind().content_type() == ContentType::BigInt {
             // 4. If O.[[ContentType]] is BigInt, set value to ? ToBigInt(value).
             args.get_or_undefined(0).to_bigint(context)?.into()
         } else {
@@ -738,11 +738,11 @@ impl BuiltinTypedArray {
             let ta = ta.borrow();
 
             let Some(buf_len) = ta
-                .data
+                .data()
                 .viewed_array_buffer()
                 .as_buffer()
                 .bytes(Ordering::SeqCst)
-                .filter(|b| !ta.data.is_out_of_bounds(b.len()))
+                .filter(|b| !ta.data().is_out_of_bounds(b.len()))
                 .map(|b| b.len())
             else {
                 return Err(JsNativeError::typ()
@@ -751,7 +751,7 @@ impl BuiltinTypedArray {
             };
 
             // 16. Set len to TypedArrayLength(taRecord).
-            ta.data.array_length(buf_len)
+            ta.data().array_length(buf_len)
         };
 
         // 17. Set endIndex to min(endIndex, len).
@@ -790,8 +790,8 @@ impl BuiltinTypedArray {
         let (ta, buf_len) = TypedArray::validate(this, Ordering::SeqCst)?;
 
         // 3. Let len be TypedArrayLength(taRecord).
-        let len = ta.borrow().data.array_length(buf_len);
-        let typed_array_kind = ta.borrow().data.kind();
+        let len = ta.borrow().data().array_length(buf_len);
+        let typed_array_kind = ta.borrow().data().kind();
 
         // 4. If IsCallable(callbackfn) is false, throw a TypeError exception.
         let callback_fn =
@@ -869,7 +869,7 @@ impl BuiltinTypedArray {
         let (ta, buf_len) = TypedArray::validate(this, Ordering::SeqCst)?;
 
         // 3. Let len be TypedArrayLength(taRecord).
-        let len = ta.borrow().data.array_length(buf_len);
+        let len = ta.borrow().data().array_length(buf_len);
 
         let predicate = args.get_or_undefined(0);
         let this_arg = args.get_or_undefined(1);
@@ -905,7 +905,7 @@ impl BuiltinTypedArray {
         let (ta, buf_len) = TypedArray::validate(this, Ordering::SeqCst)?;
 
         // 3. Let len be TypedArrayLength(taRecord).
-        let len = ta.borrow().data.array_length(buf_len);
+        let len = ta.borrow().data().array_length(buf_len);
 
         let predicate = args.get_or_undefined(0);
         let this_arg = args.get_or_undefined(1);
@@ -941,7 +941,7 @@ impl BuiltinTypedArray {
         let (ta, buf_len) = TypedArray::validate(this, Ordering::SeqCst)?;
 
         // 3. Let len be TypedArrayLength(taRecord).
-        let len = ta.borrow().data.array_length(buf_len);
+        let len = ta.borrow().data().array_length(buf_len);
 
         let predicate = args.get_or_undefined(0);
         let this_arg = args.get_or_undefined(1);
@@ -977,7 +977,7 @@ impl BuiltinTypedArray {
         let (ta, buf_len) = TypedArray::validate(this, Ordering::SeqCst)?;
 
         // 3. Let len be TypedArrayLength(taRecord).
-        let len = ta.borrow().data.array_length(buf_len);
+        let len = ta.borrow().data().array_length(buf_len);
 
         let predicate = args.get_or_undefined(0);
         let this_arg = args.get_or_undefined(1);
@@ -1013,7 +1013,7 @@ impl BuiltinTypedArray {
         let (ta, buf_len) = TypedArray::validate(this, Ordering::SeqCst)?;
 
         // 3. Let len be TypedArrayLength(taRecord).
-        let len = ta.borrow().data.array_length(buf_len);
+        let len = ta.borrow().data().array_length(buf_len);
 
         // 4. If IsCallable(callbackfn) is false, throw a TypeError exception.
         let callback_fn =
@@ -1062,7 +1062,7 @@ impl BuiltinTypedArray {
         let (ta, buf_len) = TypedArray::validate(this, Ordering::SeqCst)?;
 
         // 3. Let len be TypedArrayLength(taRecord).
-        let len = ta.borrow().data.array_length(buf_len);
+        let len = ta.borrow().data().array_length(buf_len);
 
         // 4. If len is 0, return false.
         if len == 0 {
@@ -1126,7 +1126,7 @@ impl BuiltinTypedArray {
         let (ta, buf_len) = TypedArray::validate(this, Ordering::SeqCst)?;
 
         // 3. Let len be TypedArrayLength(taRecord).
-        let len = ta.borrow().data.array_length(buf_len);
+        let len = ta.borrow().data().array_length(buf_len);
 
         // 4. If len is 0, return -1𝔽.
         if len == 0 {
@@ -1193,7 +1193,7 @@ impl BuiltinTypedArray {
         let (ta, buf_len) = TypedArray::validate(this, Ordering::SeqCst)?;
 
         // 3. Let len be TypedArrayLength(taRecord).
-        let len = ta.borrow().data.array_length(buf_len);
+        let len = ta.borrow().data().array_length(buf_len);
 
         // 4. If separator is undefined, let sep be the single-element String ",".
         let separator = args.get_or_undefined(0);
@@ -1265,7 +1265,7 @@ impl BuiltinTypedArray {
         let (ta, buf_len) = TypedArray::validate(this, Ordering::SeqCst)?;
 
         // 3. Let len be TypedArrayLength(taRecord).
-        let len = ta.borrow().data.array_length(buf_len);
+        let len = ta.borrow().data().array_length(buf_len);
 
         // 4. If len is 0, return -1𝔽.
         if len == 0 {
@@ -1361,9 +1361,9 @@ impl BuiltinTypedArray {
         let (ta, buf_len) = TypedArray::validate(this, Ordering::SeqCst)?;
 
         // 3. Let len be TypedArrayLength(taRecord).
-        let len = ta.borrow().data.array_length(buf_len);
+        let len = ta.borrow().data().array_length(buf_len);
 
-        let typed_array_kind = ta.borrow().data.kind();
+        let typed_array_kind = ta.borrow().data().kind();
 
         // 4. If IsCallable(callbackfn) is false, throw a TypeError exception.
         let callback_fn = match args.get_or_undefined(0).as_object() {
@@ -1420,7 +1420,7 @@ impl BuiltinTypedArray {
         let (ta, buf_len) = TypedArray::validate(this, Ordering::SeqCst)?;
 
         // 3. Let len be TypedArrayLength(taRecord).
-        let len = ta.borrow().data.array_length(buf_len);
+        let len = ta.borrow().data().array_length(buf_len);
 
         // 4. If IsCallable(callbackfn) is false, throw a TypeError exception.
         let callback_fn =
@@ -1495,7 +1495,7 @@ impl BuiltinTypedArray {
         let (ta, buf_len) = TypedArray::validate(this, Ordering::SeqCst)?;
 
         // 3. Let len be TypedArrayLength(taRecord).
-        let len = ta.borrow().data.array_length(buf_len);
+        let len = ta.borrow().data().array_length(buf_len);
 
         // 4. If IsCallable(callbackfn) is false, throw a TypeError exception.
         let callback_fn = match args.get_or_undefined(0).as_object() {
@@ -1569,7 +1569,7 @@ impl BuiltinTypedArray {
         let (ta, buf_len) = TypedArray::validate(this, Ordering::SeqCst)?;
 
         // 3. Let len be TypedArrayLength(taRecord).
-        let len = ta.borrow().data.array_length(buf_len);
+        let len = ta.borrow().data().array_length(buf_len);
 
         let ta = ta.upcast();
 
@@ -1618,8 +1618,8 @@ impl BuiltinTypedArray {
         let (ta, buf_len) = TypedArray::validate(this, Ordering::SeqCst)?;
 
         // 3. Let len be TypedArrayLength(taRecord).
-        let len = ta.borrow().data.array_length(buf_len);
-        let kind = ta.borrow().data.kind();
+        let len = ta.borrow().data().array_length(buf_len);
+        let kind = ta.borrow().data().kind();
 
         // 4. Let A be ? TypedArrayCreateSameType(O, « 𝔽(length) »).
         let new_array = Self::from_kind_and_length(kind, len, context)?;
@@ -1721,11 +1721,11 @@ impl BuiltinTypedArray {
         // 2. Let targetRecord be MakeTypedArrayWithBufferWitnessRecord(target, seq-cst).
         // 3. If IsTypedArrayOutOfBounds(targetRecord) is true, throw a TypeError exception.
         let target_array = target.borrow();
-        let target_buf_obj = target_array.data.viewed_array_buffer().clone();
+        let target_buf_obj = target_array.data().viewed_array_buffer().clone();
         let Some(target_buf_len) = target_buf_obj
             .as_buffer()
             .bytes(Ordering::SeqCst)
-            .filter(|s| !target_array.data.is_out_of_bounds(s.len()))
+            .filter(|s| !target_array.data().is_out_of_bounds(s.len()))
             .map(|s| s.len())
         else {
             return Err(JsNativeError::typ()
@@ -1734,17 +1734,17 @@ impl BuiltinTypedArray {
         };
 
         // 4. Let targetLength be TypedArrayLength(targetRecord).
-        let target_length = target_array.data.array_length(target_buf_len);
+        let target_length = target_array.data().array_length(target_buf_len);
 
         // 5. Let srcBuffer be source.[[ViewedArrayBuffer]].
         // 6. Let srcRecord be MakeTypedArrayWithBufferWitnessRecord(source, seq-cst).
         // 7. If IsTypedArrayOutOfBounds(srcRecord) is true, throw a TypeError exception.
         let src_array = source.borrow();
-        let mut src_buf_obj = src_array.data.viewed_array_buffer().clone();
+        let mut src_buf_obj = src_array.data().viewed_array_buffer().clone();
         let Some(mut src_buf_len) = src_buf_obj
             .as_buffer()
             .bytes(Ordering::SeqCst)
-            .filter(|s| !src_array.data.is_out_of_bounds(s.len()))
+            .filter(|s| !src_array.data().is_out_of_bounds(s.len()))
             .map(|s| s.len())
         else {
             return Err(JsNativeError::typ()
@@ -1753,28 +1753,28 @@ impl BuiltinTypedArray {
         };
 
         // 8. Let srcLength be TypedArrayLength(srcRecord).
-        let src_length = src_array.data.array_length(src_buf_len);
+        let src_length = src_array.data().array_length(src_buf_len);
 
         // 9. Let targetType be TypedArrayElementType(target).
-        let target_type = target_array.data.kind();
+        let target_type = target_array.data().kind();
 
         // 10. Let targetElementSize be TypedArrayElementSize(target).
         let target_element_size = target_type.element_size();
 
         // 11. Let targetByteOffset be target.[[ByteOffset]].
-        let target_byte_offset = target_array.data.byte_offset();
+        let target_byte_offset = target_array.data().byte_offset();
 
         // 12. Let srcType be TypedArrayElementType(source).
-        let src_type = src_array.data.kind();
+        let src_type = src_array.data().kind();
 
         // 13. Let srcElementSize be TypedArrayElementSize(source).
         let src_element_size = src_type.element_size();
 
         // 14. Let srcByteOffset be source.[[ByteOffset]].
-        let src_byte_offset = src_array.data.byte_offset();
+        let src_byte_offset = src_array.data().byte_offset();
 
         // a. Let srcByteLength be source.[[ByteLength]].
-        let src_byte_length = src_array.data.byte_length(src_buf_len);
+        let src_byte_length = src_array.data().byte_length(src_buf_len);
 
         drop(target_array);
         drop(src_array);
@@ -1933,7 +1933,7 @@ impl BuiltinTypedArray {
         // 3. Let targetLength be TypedArrayLength(targetRecord).
         let target_length = {
             let target = target.borrow();
-            let target = &target.data;
+            let target = target.data();
 
             // 1. Let targetRecord be MakeTypedArrayWithBufferWitnessRecord(target, seq-cst).
             // 2. If IsTypedArrayOutOfBounds(targetRecord) is true, throw a TypeError exception.
@@ -2015,10 +2015,10 @@ impl BuiltinTypedArray {
         let src_borrow = src.borrow();
 
         // 3. Let len be TypedArrayLength(taRecord).
-        let src_len = src_borrow.data.array_length(buf_len);
+        let src_len = src_borrow.data().array_length(buf_len);
 
         // e. Let srcType be TypedArrayElementType(O).
-        let src_type = src_borrow.data.kind();
+        let src_type = src_borrow.data().kind();
 
         drop(src_borrow);
 
@@ -2052,10 +2052,10 @@ impl BuiltinTypedArray {
 
         // a. Set taRecord to MakeTypedArrayWithBufferWitnessRecord(O, seq-cst).
         // b. If IsTypedArrayOutOfBounds(taRecord) is true, throw a TypeError exception.
-        let src_buf_borrow = src_borrow.data.viewed_array_buffer().as_buffer();
+        let src_buf_borrow = src_borrow.data().viewed_array_buffer().as_buffer();
         let Some(src_buf) = src_buf_borrow
             .bytes(Ordering::SeqCst)
-            .filter(|s| !src_borrow.data.is_out_of_bounds(s.len()))
+            .filter(|s| !src_borrow.data().is_out_of_bounds(s.len()))
         else {
             return Err(JsNativeError::typ()
                 .with_message("typed array is outside the bounds of its inner buffer")
@@ -2065,13 +2065,13 @@ impl BuiltinTypedArray {
         let src_buf_len = src_buf.len();
 
         // c. Set endIndex to min(endIndex, TypedArrayLength(taRecord)).
-        let end_index = min(end_index, src_borrow.data.array_length(src_buf_len));
+        let end_index = min(end_index, src_borrow.data().array_length(src_buf_len));
 
         // d. Set countBytes to max(endIndex - startIndex, 0).
         let count = end_index.saturating_sub(start_index) as usize;
 
         // f. Let targetType be TypedArrayElementType(A).
-        let target_type = target_borrow.data.kind();
+        let target_type = target_borrow.data().kind();
 
         if src_type != target_type {
             // h. Else,
@@ -2113,13 +2113,13 @@ impl BuiltinTypedArray {
             let element_size = src_type.element_size();
 
             // v. Let srcByteOffset be O.[[ByteOffset]].
-            let src_byte_offset = src_borrow.data.byte_offset();
+            let src_byte_offset = src_borrow.data().byte_offset();
 
             // vi. Let srcByteIndex be (startIndex × elementSize) + srcByteOffset.
             let src_byte_index = (start_index * element_size + src_byte_offset) as usize;
 
             // vii. Let targetByteIndex be A.[[ByteOffset]].
-            let target_byte_index = target_borrow.data.byte_offset() as usize;
+            let target_byte_index = target_borrow.data().byte_offset() as usize;
 
             // viii. Let endByteIndex be targetByteIndex + (countBytes × elementSize).
             // Not needed by the impl.
@@ -2130,13 +2130,13 @@ impl BuiltinTypedArray {
             //     3. Set srcByteIndex to srcByteIndex + 1.
             //     4. Set targetByteIndex to targetByteIndex + 1.
             if BufferObject::equals(
-                src_borrow.data.viewed_array_buffer(),
-                target_borrow.data.viewed_array_buffer(),
+                src_borrow.data().viewed_array_buffer(),
+                target_borrow.data().viewed_array_buffer(),
             ) {
                 // cannot borrow the target mutably (overlapping bytes), but we can move the data instead.
                 drop(src_buf_borrow);
 
-                let mut src_buf_borrow = src_borrow.data.viewed_array_buffer().as_buffer_mut();
+                let mut src_buf_borrow = src_borrow.data().viewed_array_buffer().as_buffer_mut();
                 let mut src_buf = src_buf_borrow
                     .bytes_with_len(src_buf_len)
                     .expect("already checked that the buffer is not detached");
@@ -2157,7 +2157,7 @@ impl BuiltinTypedArray {
                     );
                 }
             } else {
-                let mut target_buf = target_borrow.data.viewed_array_buffer().as_buffer_mut();
+                let mut target_buf = target_borrow.data().viewed_array_buffer().as_buffer_mut();
                 let mut target_buf = target_buf
                     .bytes(Ordering::SeqCst)
                     .expect("newly created array cannot be detached");
@@ -2200,7 +2200,7 @@ impl BuiltinTypedArray {
         let (ta, buf_len) = TypedArray::validate(this, Ordering::SeqCst)?;
 
         // 3. Let len be TypedArrayLength(taRecord).
-        let len = ta.borrow().data.array_length(buf_len);
+        let len = ta.borrow().data().array_length(buf_len);
 
         // 4. If IsCallable(callbackfn) is false, throw a TypeError exception.
         let callback_fn = match args.get_or_undefined(0).as_object() {
@@ -2267,7 +2267,7 @@ impl BuiltinTypedArray {
         let (ta, buf_len) = TypedArray::validate(this, Ordering::SeqCst)?;
 
         // 4. Let len be TypedArrayLength(taRecord).
-        let len = ta.borrow().data.array_length(buf_len);
+        let len = ta.borrow().data().array_length(buf_len);
 
         // 5. NOTE: The following closure performs a numeric comparison rather than the string comparison used in 23.1.3.30.
         // 6. Let SortCompare be a new Abstract Closure with parameters (x, y) that captures comparefn and performs the following steps when called:
@@ -2319,10 +2319,10 @@ impl BuiltinTypedArray {
         let (ta, buf_len) = TypedArray::validate(this, Ordering::SeqCst)?;
 
         // 4. Let len be TypedArrayLength(taRecord).
-        let len = ta.borrow().data.array_length(buf_len);
+        let len = ta.borrow().data().array_length(buf_len);
 
         // 5. Let A be ? TypedArrayCreateSameType(O, « 𝔽(len) »).
-        let new_array = Self::from_kind_and_length(ta.borrow().data.kind(), len, context)?;
+        let new_array = Self::from_kind_and_length(ta.borrow().data().kind(), len, context)?;
 
         // 6. NOTE: The following closure performs a numeric comparison rather than the string comparison used in 23.1.3.34.
         // 7. Let SortCompare be a new Abstract Closure with parameters (x, y) that captures comparefn and performs the following steps when called:
@@ -2375,7 +2375,7 @@ impl BuiltinTypedArray {
         let src_borrow = src.borrow();
 
         // 4. Let buffer be O.[[ViewedArrayBuffer]].
-        let buffer = src_borrow.data.viewed_array_buffer().clone();
+        let buffer = src_borrow.data().viewed_array_buffer().clone();
 
         // 5. Let srcRecord be MakeTypedArrayWithBufferWitnessRecord(O, seq-cst).
         // 6. If IsTypedArrayOutOfBounds(srcRecord) is true, then
@@ -2383,22 +2383,22 @@ impl BuiltinTypedArray {
         // 7. Else,
         //     a. Let srcLength be TypedArrayLength(srcRecord).
         let src_len = if let Some(buf) = buffer.as_buffer().bytes(Ordering::SeqCst)
-            && !src_borrow.data.is_out_of_bounds(buf.len())
+            && !src_borrow.data().is_out_of_bounds(buf.len())
         {
-            src_borrow.data.array_length(buf.len())
+            src_borrow.data().array_length(buf.len())
         } else {
             0
         };
 
-        let kind = src_borrow.data.kind();
+        let kind = src_borrow.data().kind();
 
         // 12. Let elementSize be TypedArrayElementSize(O).
         let element_size = kind.element_size();
 
         // 13. Let srcByteOffset be O.[[ByteOffset]].
-        let src_byte_offset = src_borrow.data.byte_offset();
+        let src_byte_offset = src_borrow.data().byte_offset();
 
-        let is_auto_length = src_borrow.data.is_auto_length();
+        let is_auto_length = src_borrow.data().is_auto_length();
 
         drop(src_borrow);
 
@@ -2563,8 +2563,8 @@ impl BuiltinTypedArray {
         let (ta, buf_len) = TypedArray::validate(this, Ordering::SeqCst)?;
 
         // 3. Let len be TypedArrayLength(taRecord).
-        let len = ta.borrow().data.array_length(buf_len);
-        let kind = ta.borrow().data.kind();
+        let len = ta.borrow().data().array_length(buf_len);
+        let kind = ta.borrow().data().kind();
 
         // 4. Let relativeIndex be ? ToIntegerOrInfinity(index).
         // triggers any conversion errors before throwing range errors.
@@ -2673,7 +2673,7 @@ impl BuiltinTypedArray {
 
         // 4. Assert: result has [[TypedArrayName]] and [[ContentType]] internal slots.
         // 5. If result.[[ContentType]] ≠ exemplar.[[ContentType]], throw a TypeError exception.
-        if result.borrow().data.kind().content_type() != kind.content_type() {
+        if result.borrow().data().kind().content_type() != kind.content_type() {
             return Err(JsNativeError::typ()
                 .with_message("New typed array has different context type than exemplar")
                 .into());
@@ -2704,7 +2704,7 @@ impl BuiltinTypedArray {
         {
             let new_ta = new_ta.borrow();
             // a. If IsTypedArrayOutOfBounds(taRecord) is true, throw a TypeError exception.
-            if new_ta.data.is_out_of_bounds(buf_len) {
+            if new_ta.data().is_out_of_bounds(buf_len) {
                 return Err(JsNativeError::typ()
                     .with_message("new typed array outside of the bounds of its inner buffer")
                     .into());
@@ -2712,7 +2712,7 @@ impl BuiltinTypedArray {
 
             // b. Let length be TypedArrayLength(taRecord).
             // c. If length < ℝ(argumentList[0]), throw a TypeError exception.
-            if (new_ta.data.array_length(buf_len) as f64) < number {
+            if (new_ta.data().array_length(buf_len) as f64) < number {
                 return Err(JsNativeError::typ()
                     .with_message("new typed array length is smaller than expected")
                     .into());
@@ -2844,7 +2844,7 @@ impl BuiltinTypedArray {
         context: &mut Context,
     ) -> JsResult<JsObject> {
         let src_array = src_array.borrow();
-        let src_array = &src_array.data;
+        let src_array = src_array.data();
 
         // 1. Let srcData be srcArray.[[ViewedArrayBuffer]].
         let src_data = src_array.viewed_array_buffer();
@@ -2903,7 +2903,7 @@ impl BuiltinTypedArray {
             {
                 let mut data = data_obj.borrow_mut();
                 let mut data = SliceRefMut::Slice(
-                    data.data
+                    data.data_mut()
                         .bytes_mut()
                         .expect("a new buffer cannot be detached"),
                 );

--- a/core/engine/src/builtins/typed_array/object.rs
+++ b/core/engine/src/builtins/typed_array/object.rs
@@ -204,13 +204,13 @@ impl TypedArray {
 
         let len = {
             let array = obj.borrow();
-            let buffer = array.data.viewed_array_buffer().as_buffer();
+            let buffer = array.data().viewed_array_buffer().as_buffer();
             // 2. Assert: O has a [[ViewedArrayBuffer]] internal slot.
             // 3. Let taRecord be MakeTypedArrayWithBufferWitnessRecord(O, order).
             // 4. If IsTypedArrayOutOfBounds(taRecord) is true, throw a TypeError exception.
             let Some(buf) = buffer
                 .bytes(order)
-                .filter(|buf| !array.data.is_out_of_bounds(buf.len()))
+                .filter(|buf| !array.data().is_out_of_bounds(buf.len()))
             else {
                 return Err(JsNativeError::typ()
                     .with_message("typed array is outside the bounds of its inner buffer")
@@ -663,7 +663,7 @@ pub(crate) fn typed_array_set_element(
 
     // b. Let arrayTypeName be the String value of O.[[TypedArrayName]].
     // e. Let elementType be the Element Type value in Table 73 for arrayTypeName.
-    let elem_type = obj.borrow().data.kind();
+    let elem_type = obj.borrow().data().kind();
 
     // 1. If O.[[ContentType]] is BigInt, let numValue be ? ToBigInt(value).
     // 2. Otherwise, let numValue be ? ToNumber(value).
@@ -671,16 +671,16 @@ pub(crate) fn typed_array_set_element(
 
     // 3. If IsValidIntegerIndex(O, index) is true, then
     let array = obj.borrow();
-    let mut buffer = array.data.viewed_array_buffer().as_buffer_mut();
+    let mut buffer = array.data().viewed_array_buffer().as_buffer_mut();
     let Some(mut buffer) = buffer.bytes(Ordering::Relaxed) else {
         return Ok(());
     };
-    let Some(index) = array.data.validate_index(index, buffer.len()) else {
+    let Some(index) = array.data().validate_index(index, buffer.len()) else {
         return Ok(());
     };
 
     //     a. Let offset be O.[[ByteOffset]].
-    let offset = array.data.byte_offset();
+    let offset = array.data().byte_offset();
 
     //     b. Let elementSize be TypedArrayElementSize(O).
     let size = elem_type.element_size();

--- a/core/engine/src/object/builtins/jsarraybuffer.rs
+++ b/core/engine/src/object/builtins/jsarraybuffer.rs
@@ -132,7 +132,7 @@ impl JsArrayBuffer {
     pub fn with_max_byte_length(self, max_byte_len: u64) -> Self {
         self.inner
             .borrow_mut()
-            .data
+            .data_mut()
             .set_max_byte_length(max_byte_len);
         self
     }
@@ -176,7 +176,7 @@ impl JsArrayBuffer {
     #[inline]
     #[must_use]
     pub fn byte_length(&self) -> usize {
-        self.inner.borrow().data.len()
+        self.inner.borrow().data().len()
     }
 
     /// Take the inner `ArrayBuffer`'s `array_buffer_data` field and replace it with `None`
@@ -213,7 +213,7 @@ impl JsArrayBuffer {
     pub fn detach(&self, detach_key: &JsValue) -> JsResult<Vec<u8>> {
         self.inner
             .borrow_mut()
-            .data
+            .data_mut()
             .detach(detach_key)?
             .ok_or_else(|| {
                 JsNativeError::typ()
@@ -251,7 +251,7 @@ impl JsArrayBuffer {
     #[inline]
     #[must_use]
     pub fn data(&self) -> Option<GcRef<'_, [u8]>> {
-        GcRef::try_map(self.inner.borrow(), |o| o.data.bytes())
+        GcRef::try_map(self.inner.borrow(), |o| o.data().bytes())
     }
 
     /// Get a mutable reference to the [`JsArrayBuffer`]'s data.
@@ -284,7 +284,7 @@ impl JsArrayBuffer {
     #[inline]
     #[must_use]
     pub fn data_mut(&self) -> Option<GcRefMut<'_, Object<ArrayBuffer>, [u8]>> {
-        GcRefMut::try_map(self.inner.borrow_mut(), |o| o.data.bytes_mut())
+        GcRefMut::try_map(self.inner.borrow_mut(), |o| o.data_mut().bytes_mut())
     }
 }
 

--- a/core/engine/src/object/builtins/jsdataview.rs
+++ b/core/engine/src/object/builtins/jsdataview.rs
@@ -60,7 +60,7 @@ impl JsDataView {
 
         let (buf_byte_len, is_fixed_len) = {
             let buffer = buffer.borrow();
-            let buffer = &buffer.data;
+            let buffer = buffer.data();
 
             // 4. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
             let Some(slice) = buffer.bytes() else {
@@ -109,7 +109,7 @@ impl JsDataView {
 
         // 11. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
         // 12. Set bufferByteLength to ArrayBufferByteLength(buffer, seq-cst).
-        let Some(buf_byte_len) = buffer.borrow().data.bytes().map(|s| s.len() as u64) else {
+        let Some(buf_byte_len) = buffer.borrow().data().bytes().map(|s| s.len() as u64) else {
             return Err(JsNativeError::typ()
                 .with_message("ArrayBuffer is detached")
                 .into());

--- a/core/engine/src/object/builtins/jssharedarraybuffer.rs
+++ b/core/engine/src/object/builtins/jssharedarraybuffer.rs
@@ -81,14 +81,14 @@ impl JsSharedArrayBuffer {
     #[inline]
     #[must_use]
     pub fn byte_length(&self) -> usize {
-        self.borrow().data.len(Ordering::SeqCst)
+        self.borrow().data().len(Ordering::SeqCst)
     }
 
     /// Gets the raw buffer of this `JsSharedArrayBuffer`.
     #[inline]
     #[must_use]
     pub fn inner(&self) -> SharedArrayBuffer {
-        self.borrow().data.as_ref().clone()
+        self.borrow().data().clone()
     }
 }
 

--- a/core/engine/src/object/jsobject.rs
+++ b/core/engine/src/object/jsobject.rs
@@ -3,7 +3,7 @@
 //! The `JsObject` is a garbage collected Object.
 
 use super::{
-    JsPrototype, NativeObject, Object, PrivateName, PropertyMap,
+    JsPrototype, NativeObject, Object, ObjectData, PrivateName, PropertyMap,
     internal_methods::{
         InternalMethodPropertyContext, InternalObjectMethods, ORDINARY_INTERNAL_METHODS,
     },
@@ -165,7 +165,7 @@ impl JsObject {
         let internal_methods = data.internal_methods();
         let inner = Gc::new(VTableObject {
             object: GcRefCell::new(Object {
-                data: Box::new(data),
+                data: ObjectData::new(data),
                 properties: PropertyMap::from_prototype_unique_shape(prototype.into()),
                 extensible: true,
                 private_elements: ThinVec::new(),
@@ -191,7 +191,7 @@ impl JsObject {
         let internal_methods = data.internal_methods();
         let inner = Gc::new(VTableObject {
             object: GcRefCell::new(Object {
-                data: Box::new(data),
+                data: ObjectData::new(data),
                 properties: PropertyMap::from_prototype_with_shared_shape(
                     root_shape,
                     prototype.into(),
@@ -821,7 +821,7 @@ impl<T: NativeObject> JsObject<T> {
         let internal_methods = data.internal_methods();
         let inner = Gc::new(VTableObject {
             object: GcRefCell::new(Object {
-                data: Box::new(data),
+                data: ObjectData::new(data),
                 properties: PropertyMap::from_prototype_with_shared_shape(
                     root_shape,
                     prototype.into(),
@@ -843,7 +843,7 @@ impl<T: NativeObject> JsObject<T> {
         let internal_methods = data.internal_methods();
         let inner = Gc::new(VTableObject {
             object: GcRefCell::new(Object {
-                data: Box::new(data),
+                data: ObjectData::new(data),
                 properties: PropertyMap::from_prototype_unique_shape(prototype.into()),
                 extensible: true,
                 private_elements: ThinVec::new(),
@@ -1016,7 +1016,7 @@ impl<T: NativeObject> Debug for JsObject<T> {
             let ptr: *const _ = self.as_ref();
             let ptr = ptr.cast::<()>();
             let obj = self.borrow();
-            let kind = obj.data.type_name_of_value();
+            let kind = obj.data().type_name_of_value();
             if self.is_callable() {
                 let name_prop = obj
                     .properties()

--- a/core/engine/src/object/shape/shared_shape/template.rs
+++ b/core/engine/src/object/shape/shared_shape/template.rs
@@ -4,7 +4,8 @@ use thin_vec::ThinVec;
 use crate::{
     JsValue,
     object::{
-        IndexedProperties, JsObject, NativeObject, Object, PropertyMap, shape::slot::SlotAttributes,
+        IndexedProperties, JsObject, NativeObject, Object, ObjectData, PropertyMap,
+        shape::slot::SlotAttributes,
     },
     property::{Attribute, PropertyKey},
 };
@@ -110,7 +111,7 @@ impl ObjectTemplate {
         let internal_methods = data.internal_methods();
 
         let mut object = Object {
-            data: Box::new(data),
+            data: ObjectData::new(data),
             extensible: true,
             properties: PropertyMap::new(self.shape.clone().into(), IndexedProperties::default()),
             private_elements: ThinVec::new(),
@@ -133,7 +134,7 @@ impl ObjectTemplate {
     ) -> JsObject {
         let internal_methods = data.internal_methods();
         let mut object = Object {
-            data: Box::new(data),
+            data: ObjectData::new(data),
             extensible: true,
             properties: PropertyMap::new(self.shape.clone().into(), indexed_properties),
             private_elements: ThinVec::new(),

--- a/core/engine/src/vm/opcode/generator/mod.rs
+++ b/core/engine/src/vm/opcode/generator/mod.rs
@@ -127,7 +127,7 @@ impl AsyncGeneratorClose {
         // f. Remove acGenContext from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
 
         // g. Set acGenerator.[[AsyncGeneratorState]] to draining-queue.
-        r#gen.data.state = AsyncGeneratorState::DrainingQueue;
+        r#gen.data_mut().state = AsyncGeneratorState::DrainingQueue;
 
         // h. If result is a normal completion, set result to NormalCompletion(undefined).
         // i. If result is a return completion, set result to NormalCompletion(result.[[Value]]).

--- a/core/engine/src/vm/opcode/generator/yield_stm.rs
+++ b/core/engine/src/vm/opcode/generator/yield_stm.rs
@@ -79,7 +79,7 @@ impl AsyncGeneratorYield {
         // 11. If queue is not empty, then
         //     a. NOTE: Execution continues without suspending the generator.
         //     b. Let toYield be the first element of queue.
-        if let Some(next) = r#gen.data.queue.front() {
+        if let Some(next) = r#gen.data().queue.front() {
             // c. Let resumptionValue be Completion(toYield.[[Completion]]).
             let resume_kind = match next.completion.clone() {
                 CompletionRecord::Normal(val) => {
@@ -106,7 +106,7 @@ impl AsyncGeneratorYield {
         // 12. Else,
 
         //     a. Set generator.[[AsyncGeneratorState]] to suspended-yield.
-        r#gen.data.state = AsyncGeneratorState::SuspendedYield;
+        r#gen.data_mut().state = AsyncGeneratorState::SuspendedYield;
 
         //     TODO: b. Remove genContext from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
         //     TODO: c. Let callerContext be the running execution context.


### PR DESCRIPTION
This PR implements removes the `Box` from `Object`'s data member (by implementing this PR comment https://github.com/boa-dev/boa/pull/4287#issuecomment-2993682209).

The main idea is to limit the alignment, for the min we use a wrapper struct (`ObjectData<T>`) that has an minimum alignment using the `#[align(N)]`, and for the max alignment we use a constant assertion, preventing compilation with a message on how to workaround it.
