### PR TITLE
Add `repr(C)` on `Object` to prevent field reordering

### DIFF
--- a/core/engine/src/object/mod.rs
+++ b/core/engine/src/object/mod.rs
@@ -165,6 +165,9 @@ impl dyn NativeObject {
 #[derive(Debug, Finalize, Trace)]
 // SAFETY: This does not implement drop, so this is safe.
 #[boa_gc(unsafe_no_drop)]
+// SAFETY: This type must use `#[repr(C)]` to prevent the compiler from reordering fields,
+//         as it is used for casting between types.
+#[repr(C)]
 pub struct Object<T: ?Sized> {
     /// The collection of properties contained in the object
     pub(crate) properties: PropertyMap,


### PR DESCRIPTION
Without `repr(C)`, the compiler may reorder fields, which can lead to undefined behavior during `Gc::cast`-ing.

