### PR TITLE
Fix documentation for NativeFunction::from_async_fn

### DIFF
--- a/core/engine/src/native_function/mod.rs
+++ b/core/engine/src/native_function/mod.rs
@@ -167,24 +167,21 @@ impl NativeFunction {
     /// Creates a `NativeFunction` from a function returning a [`Future`]-like.
     ///
     /// The returned `NativeFunction` will return an ECMAScript `Promise` that will be fulfilled
-    /// or rejected when the returned [`Future`] completes.
+    /// or rejected when the returned `Future` completes.
     ///
-    /// If you only need to convert a [`Future`]-like into a [`JsPromise`], see
+    /// If you only need to convert a `Future`-like into a [`JsPromise`], see
     /// [`JsPromise::from_future`].
     ///
     ///
-    /// # Caveats
+    /// ## Example
     ///
-    /// Certain async functions need to be desugared for them to be compatible. For example, the
-    /// following won't compile:
-    ///
-    /// ```compile_fail
+    /// ```
     /// # use std::cell::RefCell;
     /// # use boa_engine::{
     /// #   JsValue,
     /// #   Context,
     /// #   JsResult,
-    /// #   NativeFunction
+    /// #   NativeFunction,
     /// #   JsArgs,
     /// # };
     /// async fn test(
@@ -200,92 +197,9 @@ impl NativeFunction {
     /// NativeFunction::from_async_fn(test);
     /// ```
     ///
-    /// Even though `args` is only used before the first await point, Rust's async functions are
-    /// fully lazy, which makes `test` equivalent to something like:
-    ///
-    /// ```
-    /// # use std::cell::RefCell;
-    /// # use std::future::Future;
-    /// # use boa_engine::{JsValue, Context, JsResult, JsArgs};
-    /// fn test<'a, 'b, 'c, 'd>(
-    ///     _this: &'a JsValue,
-    ///     args: &'b [JsValue],
-    ///     context: &'c RefCell<&'d mut Context>,
-    /// ) -> impl Future<Output = JsResult<JsValue>> + use<'a, 'b, 'c, 'd> {
-    ///     async move {
-    ///         let arg = args.get_or_undefined(0).clone();
-    ///         let value = arg.to_u32(&mut context.borrow_mut())?;
-    ///         Ok(JsValue::from(value * 2))
-    ///     }
-    /// }
-    /// ```
-    ///
-    /// Note that all the arguments are captured by the async function, making the returned future not compatible with
-    /// the signature of `from_async_fn`.
-    ///
-    /// In those cases, you can manually restrict the lifetime of the arguments:
-    ///
-    /// ```
-    /// # use std::cell::RefCell;
-    /// # use std::future::Future;
-    /// # use boa_engine::{
-    /// #   JsValue,
-    /// #   Context,
-    /// #   JsResult,
-    /// #   NativeFunction,
-    /// #   JsArgs,
-    /// # };
-    /// fn test<'a, 'b>(
-    ///     _this: &JsValue,
-    ///     args: &[JsValue],
-    ///     context: &'a RefCell<&'b mut Context>,
-    /// ) -> impl Future<Output = JsResult<JsValue>> + use<'a, 'b> {
-    ///     let arg = args.get_or_undefined(0).clone();
-    ///     async move {
-    ///         std::future::ready(()).await;
-    ///         let value = arg.to_u32(&mut context.borrow_mut())?;
-    ///         Ok(JsValue::from(value * 2))
-    ///     }
-    /// }
-    /// NativeFunction::from_async_fn(test);
-    /// ```
-    ///
-    /// And this should always return a valid future.
-    ///
-    /// Keen readers will notice that this caveat doesn't apply to the `context` argument, since
-    /// we captured its lifetime on the previous snippet. This is indeed useful, because it allows
-    /// using the `context` between await points without having to enqueue a separate future job.
-    ///
-    /// ```
-    /// # use std::cell::RefCell;
-    /// # use std::future::Future;
-    /// # use boa_engine::{
-    /// #   JsValue,
-    /// #   Context,
-    /// #   JsResult,
-    /// #   NativeFunction,
-    /// #   JsArgs,
-    /// # };
-    /// fn test<'a, 'b>(
-    ///     _this: &JsValue,
-    ///     args: &[JsValue],
-    ///     context: &'a RefCell<&'b mut Context>,
-    /// ) -> impl Future<Output = JsResult<JsValue>> + use<'a, 'b> {
-    ///     let arg = args.get_or_undefined(0).clone();
-    ///     async move {
-    ///         std::future::ready(()).await;
-    ///         let value = arg.to_u32(&mut context.borrow_mut())?;
-    ///         Ok(JsValue::from(value * 2))
-    ///     }
-    /// }
-    /// NativeFunction::from_async_fn(test);
-    /// ```
-    ///
-    /// [`Future`]: std::future::Future
     pub fn from_async_fn<F>(f: F) -> Self
     where
-        F: for<'a> AsyncFn(&JsValue, &[JsValue], &'a RefCell<&mut Context>) -> JsResult<JsValue>
-            + 'static,
+        F: AsyncFn(&JsValue, &[JsValue], &RefCell<&mut Context>) -> JsResult<JsValue> + 'static,
         F: Copy,
     {
         Self::from_copy_closure(move |this, args, context| {

--- a/core/engine/src/native_function/mod.rs
+++ b/core/engine/src/native_function/mod.rs
@@ -173,7 +173,7 @@ impl NativeFunction {
     /// [`JsPromise::from_future`].
     ///
     ///
-    /// ## Example
+    /// # Examples
     ///
     /// ```
     /// # use std::cell::RefCell;

--- a/core/engine/src/native_function/mod.rs
+++ b/core/engine/src/native_function/mod.rs
@@ -172,7 +172,6 @@ impl NativeFunction {
     /// If you only need to convert a `Future`-like into a [`JsPromise`], see
     /// [`JsPromise::from_future`].
     ///
-    ///
     /// # Examples
     ///
     /// ```


### PR DESCRIPTION
Old documentation was still passing because the imports were missing a comma.

- Removed the caveats section because they don't apply anymore thanks to the new async closures.
- Slightly tweaked the signature of the function. We don't need to use `for<'a>` here because the compiler is smart enough to capture the lifetime of `&RefCell` without capturing the lifetime of `&mut Context`.
