### PR TITLE
Fix UB in implementation of `NanBoxedValue`

### DIFF
--- a/core/engine/src/builtins/bigint/mod.rs
+++ b/core/engine/src/builtins/bigint/mod.rs
@@ -139,7 +139,6 @@ impl BigInt {
         value
             // 1. If Type(value) is BigInt, return value.
             .as_bigint()
-            .cloned()
             // 2. If Type(value) is Object and value has a [[BigIntData]] internal slot, then
             //    a. Assert: Type(value.[[BigIntData]]) is BigInt.
             //    b. Return value.[[BigIntData]].

--- a/core/engine/src/builtins/string/mod.rs
+++ b/core/engine/src/builtins/string/mod.rs
@@ -714,7 +714,10 @@ impl String {
         // 3. Let n be ? ToIntegerOrInfinity(count).
         match args.get_or_undefined(0).to_integer_or_infinity(context)? {
             IntegerOrInfinity::Integer(n)
-                if n > 0 && (n as usize) * len <= Self::MAX_STRING_LENGTH =>
+                if u64::try_from(n)
+                    .ok()
+                    .and_then(|n| n.checked_mul(len as u64))
+                    .is_some_and(|total_len| total_len <= (Self::MAX_STRING_LENGTH as u64)) =>
             {
                 if string.is_empty() {
                     return Ok(js_string!().into());

--- a/core/engine/src/builtins/typed_array/builtin.rs
+++ b/core/engine/src/builtins/typed_array/builtin.rs
@@ -3175,7 +3175,7 @@ fn compare_typed_array_elements(
             // 6. If x < y, return -1𝔽.
             // 7. If x > y, return 1𝔽.
             // 10. Return +0𝔽.
-            Ok(x.cmp(y))
+            Ok(x.cmp(&y))
         }
         (JsVariant::Integer32(x), JsVariant::Integer32(y)) => {
             // Note: Other steps are not relevant for integers.

--- a/core/engine/src/value/equality.rs
+++ b/core/engine/src/value/equality.rs
@@ -39,7 +39,7 @@ impl JsValue {
         match (self.variant(), other.variant()) {
             // 2. If Type(x) is Number or BigInt, then
             //    a. Return ! Type(x)::equal(x, y).
-            (JsVariant::BigInt(x), JsVariant::BigInt(y)) => JsBigInt::equal(x, y),
+            (JsVariant::BigInt(x), JsVariant::BigInt(y)) => JsBigInt::equal(&x, &y),
             (JsVariant::Float64(x), JsVariant::Float64(y)) => Number::equal(x, y),
             (JsVariant::Float64(x), JsVariant::Integer32(y)) => Number::equal(x, f64::from(y)),
             (JsVariant::Integer32(x), JsVariant::Float64(y)) => Number::equal(f64::from(x), y),
@@ -93,14 +93,10 @@ impl JsValue {
             //    a. Let n be ! StringToBigInt(y).
             //    b. If n is NaN, return false.
             //    c. Return the result of the comparison x == n.
-            (JsVariant::BigInt(a), JsVariant::String(b)) => {
-                JsBigInt::from_js_string(&b).as_ref() == Some(a)
-            }
+            (JsVariant::BigInt(a), JsVariant::String(b)) => JsBigInt::from_js_string(&b) == Some(a),
 
             // 7. If Type(x) is String and Type(y) is BigInt, return the result of the comparison y == x.
-            (JsVariant::String(a), JsVariant::BigInt(b)) => {
-                JsBigInt::from_js_string(&a).as_ref() == Some(b)
-            }
+            (JsVariant::String(a), JsVariant::BigInt(b)) => JsBigInt::from_js_string(&a) == Some(b),
 
             // 8. If Type(x) is Boolean, return the result of the comparison ! ToNumber(x) == y.
             (JsVariant::Boolean(x), _) => {
@@ -145,10 +141,10 @@ impl JsValue {
             // 12. If Type(x) is BigInt and Type(y) is Number, or if Type(x) is Number and Type(y) is BigInt, then
             //    a. If x or y are any of NaN, +∞, or -∞, return false.
             //    b. If the mathematical value of x is equal to the mathematical value of y, return true; otherwise return false.
-            (JsVariant::BigInt(a), JsVariant::Float64(ref b)) => a == b,
-            (JsVariant::Float64(ref a), JsVariant::BigInt(b)) => a == b,
-            (JsVariant::BigInt(a), JsVariant::Integer32(ref b)) => a == b,
-            (JsVariant::Integer32(ref a), JsVariant::BigInt(b)) => a == b,
+            (JsVariant::BigInt(a), JsVariant::Float64(b)) => a == b,
+            (JsVariant::Float64(a), JsVariant::BigInt(b)) => a == b,
+            (JsVariant::BigInt(a), JsVariant::Integer32(b)) => a == b,
+            (JsVariant::Integer32(a), JsVariant::BigInt(b)) => a == b,
 
             // 13. Return false.
             _ => false,
@@ -172,7 +168,7 @@ impl JsValue {
         match (x.variant(), y.variant()) {
             // 2. If Type(x) is Number or BigInt, then
             //    a. Return ! Type(x)::SameValue(x, y).
-            (JsVariant::BigInt(x), JsVariant::BigInt(y)) => JsBigInt::same_value(x, y),
+            (JsVariant::BigInt(x), JsVariant::BigInt(y)) => JsBigInt::same_value(&x, &y),
             (JsVariant::Float64(x), JsVariant::Float64(y)) => Number::same_value(x, y),
             (JsVariant::Float64(x), JsVariant::Integer32(y)) => Number::same_value(x, f64::from(y)),
             (JsVariant::Integer32(x), JsVariant::Float64(y)) => Number::same_value(f64::from(x), y),
@@ -201,7 +197,7 @@ impl JsValue {
         match (x.variant(), y.variant()) {
             // 2. If Type(x) is Number or BigInt, then
             //    a. Return ! Type(x)::SameValueZero(x, y).
-            (JsVariant::BigInt(x), JsVariant::BigInt(y)) => JsBigInt::same_value_zero(x, y),
+            (JsVariant::BigInt(x), JsVariant::BigInt(y)) => JsBigInt::same_value_zero(&x, &y),
 
             (JsVariant::Float64(x), JsVariant::Float64(y)) => Number::same_value_zero(x, y),
             (JsVariant::Float64(x), JsVariant::Integer32(y)) => {

--- a/core/engine/src/value/hash.rs
+++ b/core/engine/src/value/hash.rs
@@ -45,7 +45,7 @@ impl Hash for JsValue {
             JsVariant::Integer32(integer) => RationalHashable(f64::from(integer)).hash(state),
             JsVariant::BigInt(bigint) => bigint.hash(state),
             JsVariant::Float64(rational) => RationalHashable(rational).hash(state),
-            JsVariant::Symbol(symbol) => Hash::hash(symbol, state),
+            JsVariant::Symbol(symbol) => Hash::hash(&symbol, state),
             JsVariant::Object(object) => object.hash(state),
         }
     }

--- a/core/engine/src/value/inner/legacy.rs
+++ b/core/engine/src/value/inner/legacy.rs
@@ -198,9 +198,9 @@ impl EnumBasedValue {
     /// Returns the value as a boxed `[JsBigInt]`.
     #[must_use]
     #[inline]
-    pub(crate) const fn as_bigint(&self) -> Option<&JsBigInt> {
+    pub(crate) fn as_bigint(&self) -> Option<JsBigInt> {
         match self {
-            Self::BigInt(value) => Some(value),
+            Self::BigInt(value) => Some(value.clone()),
             _ => None,
         }
     }
@@ -218,9 +218,9 @@ impl EnumBasedValue {
     /// Returns the value as a boxed `[JsSymbol]`.
     #[must_use]
     #[inline]
-    pub(crate) const fn as_symbol(&self) -> Option<&JsSymbol> {
+    pub(crate) fn as_symbol(&self) -> Option<JsSymbol> {
         match self {
-            Self::Symbol(value) => Some(value),
+            Self::Symbol(value) => Some(value.clone()),
             _ => None,
         }
     }
@@ -238,16 +238,16 @@ impl EnumBasedValue {
     /// Returns the `[JsVariant]` of this inner value.
     #[must_use]
     #[inline]
-    pub(crate) fn as_variant(&self) -> JsVariant<'_> {
+    pub(crate) fn as_variant(&self) -> JsVariant {
         match self {
             Self::Undefined => JsVariant::Undefined,
             Self::Null => JsVariant::Null,
             Self::Boolean(v) => JsVariant::Boolean(*v),
             Self::Integer32(v) => JsVariant::Integer32(*v),
             Self::Float64(v) => JsVariant::Float64(*v),
-            Self::BigInt(v) => JsVariant::BigInt(v),
+            Self::BigInt(v) => JsVariant::BigInt(v.clone()),
             Self::Object(v) => JsVariant::Object(v.clone()),
-            Self::Symbol(v) => JsVariant::Symbol(v),
+            Self::Symbol(v) => JsVariant::Symbol(v.clone()),
             Self::String(v) => JsVariant::String(v.clone()),
         }
     }

--- a/core/engine/src/value/inner/nan_boxed.rs
+++ b/core/engine/src/value/inner/nan_boxed.rs
@@ -1,6 +1,6 @@
 //! A NaN-boxed inner value for JavaScript values.
 //!
-//! This `[JsValue]` is a float using `NaN` values to represent inner
+//! This [`JsValue`] is a float using `NaN` values to represent inner
 //! JavaScript value.
 //!
 //! # Assumptions
@@ -48,7 +48,7 @@
 //!
 //! # Design
 //!
-//! This `[JsValue]` inner type is a NaN-boxed value, which is a 64-bits value
+//! This [`JsValue`] inner type is a NaN-boxed value, which is a 64-bits value
 //! that can represent any JavaScript value. If the integer is a non-NaN value,
 //! it will be stored as a 64-bits float. If it is a `f64::NAN` value, it will
 //! be stored as a quiet `NaN` value. Subnormal numbers are regular float.
@@ -106,27 +106,39 @@
 //! with regular NAN should happen.
 #![allow(clippy::inline_always)]
 
-use crate::{JsBigInt, JsObject, JsSymbol, JsVariant};
-use boa_gc::{Finalize, Trace, custom_trace};
-use boa_string::JsString;
+use crate::{
+    JsBigInt, JsObject, JsSymbol, JsVariant, bigint::RawBigInt, object::ErasedVTableObject,
+    symbol::RawJsSymbol,
+};
+use boa_gc::{Finalize, GcBox, Trace, custom_trace};
+use boa_string::{JsString, RawJsString};
 use core::fmt;
 use static_assertions::const_assert;
+use std::{
+    mem::ManuallyDrop,
+    ptr::{self, NonNull},
+};
 
-// We cannot NaN-box pointers larger than 64 bits.
-const_assert!(size_of::<usize>() <= size_of::<u64>());
+const _NAN_BOX_COMPAT_CHECK: () = const {
+    // We can only NaN-box pointers that are 32 or 64 bits.
+    assert!(
+        size_of::<usize>() == size_of::<u64>() || size_of::<usize>() == size_of::<u32>(),
+        "this platform is not compatible with a nan-boxed `JsValueInner`\n\
+        enable the `jsvalue-enum` feature to use the enum-based `JsValueInner`"
+    );
 
-// We cannot NaN-box pointers that are not 4-bytes aligned.
-const_assert!(align_of::<*mut ()>() >= 4);
+    // We cannot NaN-box pointers that are not 4-bytes aligned.
+    assert!(
+        align_of::<*mut ()>() >= 4,
+        "this platform is not compatible with a nan-boxed `JsValueInner`\n\
+        enable the `jsvalue-enum` feature to use the enum-based `JsValueInner`"
+    );
+};
 
 /// Internal module for bit masks and constants.
 ///
 /// All bit magic is done here.
 mod bits {
-    use crate::object::ErasedVTableObject;
-    use boa_engine::{JsBigInt, JsObject, JsSymbol};
-    use boa_gc::GcBox;
-    use boa_string::{JsString, RawJsString};
-    use std::ptr::NonNull;
 
     /// The mask for the bits that indicate if the value is a NaN-value.
     const MASK_NAN: u64 = 0x7FF0_0000_0000_0000;
@@ -183,18 +195,6 @@ mod bits {
         (value & MASK_NAN != MASK_NAN)
             || (value & MASK_KIND) == (MASK_NAN | TAG_INF)
             || (value & MASK_KIND) == (MASK_NAN | TAG_NAN)
-    }
-
-    /// Checks that a value is a valid undefined.
-    #[inline(always)]
-    pub(super) const fn is_undefined(value: u64) -> bool {
-        value == VALUE_UNDEFINED
-    }
-
-    /// Checks that a value is a valid null.
-    #[inline(always)]
-    pub(super) const fn is_null(value: u64) -> bool {
-        value == VALUE_NULL
     }
 
     /// Checks that a value is a valid integer32.
@@ -262,181 +262,56 @@ mod bits {
         value & MASK_BOOLEAN_VALUE != 0
     }
 
-    /// Returns a tagged u64 of a boxed `[JsBigInt]`.
-    ///
-    /// # Safety
-    /// The pointer must be 4-bits aligned and cannot exceed 51-bits. This will
-    /// result in a panic. Also, the object is not checked for validity.
-    ///
-    /// The box is forgotten after this operation. It must be dropped separately,
-    /// by calling `[Self::drop_pointer]`.
+    fn tag_pointer(value: *mut ()) -> u64 {
+        let value = value.addr() as u64;
+        let value_masked: u64 = value & MASK_POINTER_VALUE;
+
+        // Assert alignment and location of the pointer.
+        assert_eq!(
+            value_masked, value,
+            "this platform is not compatible with a nan-boxed `JsValueInner`\n\
+            enable the `jsvalue-enum` feature to use the enum-based `JsValueInner`"
+        );
+
+        // Cannot have a null pointer.
+        assert_ne!(value_masked, 0, "pointer is null");
+
+        value_masked
+    }
+
+    /// Returns a tagged u64 of a boxed [`JsBigInt`].
     #[inline(always)]
     #[allow(clippy::identity_op)]
-    pub(super) unsafe fn tag_bigint(value: Box<JsBigInt>) -> u64 {
-        let value = Box::into_raw(value) as u64;
-        let value_masked: u64 = value & MASK_POINTER_VALUE;
-
-        // Assert alignment and location of the pointer.
-        assert_eq!(
-            value_masked, value,
-            "Pointer is not 4-bits aligned or over 51-bits."
-        );
-        // Cannot have a null pointer for bigint.
-        assert_ne!(value_masked, 0, "Pointer is NULL.");
-
+    pub(super) fn tag_bigint(value: *mut ()) -> u64 {
         // Simply cast for bits.
-        value_masked | MASK_BIGINT
+        tag_pointer(value) | MASK_BIGINT
     }
 
-    /// Returns a tagged u64 of a boxed `[JsObject]`.
-    ///
-    /// # Safety
-    /// The pointer must be 4-bits aligned and cannot exceed 51-bits. This will
-    /// result in a panic. Also, the object is not checked for validity.
-    ///
-    /// The box is forgotten after this operation. It must be dropped separately,
-    /// by calling `[Self::drop_pointer]`.
+    /// Returns a tagged u64 of a boxed [`JsObject`].
     #[inline(always)]
-    pub(super) unsafe fn tag_object(value: JsObject) -> u64 {
-        let value = value.into_raw().as_ptr() as u64;
-        let value_masked: u64 = value & MASK_POINTER_VALUE;
-
-        // Assert alignment and location of the pointer.
-        assert_eq!(
-            value_masked, value,
-            "Pointer is not 4-bits aligned or over 51-bits."
-        );
-        // Cannot have a null pointer for bigint.
-        assert_ne!(value_masked, 0, "Pointer is NULL.");
-
+    pub(super) fn tag_object(value: *mut ()) -> u64 {
         // Simply cast for bits.
-        value_masked | MASK_OBJECT
+        tag_pointer(value) | MASK_OBJECT
     }
 
-    /// Returns an owned `JsObject` from a tagged value.
-    ///
-    /// # Safety
-    /// * The pointer must be a valid pointer to a `GcBox<ErasedVTableObject>`.
-    pub(super) unsafe fn untag_object_owned(value: u64) -> JsObject {
-        // This is safe since we already checked the pointer is not null as this point.
-        unsafe {
-            JsObject::from_raw(NonNull::new_unchecked(
-                (value & MASK_POINTER_VALUE) as *mut GcBox<ErasedVTableObject>,
-            ))
-        }
-    }
-
-    /// Returns a tagged u64 of a boxed `[JsSymbol]`.
-    ///
-    /// # Safety
-    /// The pointer must be 4-bits aligned and cannot exceed 51-bits. This will
-    /// result in a panic. Also, the object is not checked for validity.
-    ///
-    /// The box is forgotten after this operation. It must be dropped separately,
-    /// by calling `[Self::drop_pointer]`.
+    /// Returns a tagged u64 of a boxed [`JsSymbol`].
     #[inline(always)]
-    pub(super) unsafe fn tag_symbol(value: Box<JsSymbol>) -> u64 {
-        let value = Box::into_raw(value) as u64;
-        let value_masked: u64 = value & MASK_POINTER_VALUE;
-
-        // Assert alignment and location of the pointer.
-        assert_eq!(
-            value_masked, value,
-            "Pointer is not 4-bits aligned or over 51-bits."
-        );
-        // Cannot have a null pointer for bigint.
-        assert_ne!(value_masked, 0, "Pointer is NULL.");
-
+    pub(super) fn tag_symbol(value: *mut ()) -> u64 {
         // Simply cast for bits.
-        value_masked | MASK_SYMBOL
+        tag_pointer(value) | MASK_SYMBOL
     }
 
-    /// Returns a tagged u64 of a boxed `[JsString]`.
-    ///
-    /// # Safety
-    /// The pointer must be 4-bits aligned and cannot exceed 51-bits. This will
-    /// result in a panic. Also, the object is not checked for validity.
-    ///
-    /// The box is forgotten after this operation. It must be dropped separately,
-    /// by calling `[Self::drop_pointer]`.
+    /// Returns a tagged u64 of a boxed [`JsString`].
     #[inline(always)]
-    pub(super) unsafe fn tag_string(value: JsString) -> u64 {
-        let value = JsString::into_raw(value).addr().get() as u64;
-        let value_masked: u64 = value & MASK_POINTER_VALUE;
-
-        // Assert alignment and location of the pointer.
-        assert_eq!(
-            value_masked, value,
-            "Pointer is not 4-bits aligned or over 51-bits."
-        );
-        // Cannot have a null pointer for bigint.
-        assert_ne!(value_masked, 0, "Pointer is NULL.");
-
+    pub(super) fn tag_string(value: *mut ()) -> u64 {
         // Simply cast for bits.
-        value_masked | MASK_STRING
+        tag_pointer(value) | MASK_STRING
     }
 
-    /// Returns a reference to T from a tagged value.
-    ///
-    /// # Safety
-    /// The pointer must be a valid pointer to a T on the heap, otherwise this
-    /// will result in undefined behavior.
+    /// Returns the pointer address of the inner value.
     #[inline(always)]
-    pub(super) const unsafe fn untag_pointer<'a, T>(value: u64) -> &'a T {
-        // This is safe since we already checked the pointer is not null as this point.
-        unsafe { NonNull::new_unchecked((value & MASK_POINTER_VALUE) as *mut T).as_ref() }
-    }
-
-    /// Returns a clone of a [`JsString`] from a tagged value.
-    ///
-    /// # Safety
-    ///
-    /// The pointer must be a valid pointer to a [`JsString`], otherwise this
-    /// will result in undefined behavior.
-    #[inline(always)]
-    pub(super) unsafe fn untag_string_pointer(value: u64) -> JsString {
-        let value = (value & MASK_POINTER_VALUE) as *mut RawJsString;
-
-        // SAFETY: JsValue always holds a valid, non-null JsString, so this is safe.
-        let ptr = unsafe { NonNull::new_unchecked(value) };
-
-        // SAFETY: The caller must guarantee that the JsValue is of type JsString, which is always valid.
-        let this = unsafe { JsString::from_raw(ptr) };
-
-        let result = this.clone();
-
-        // SAFETY: Dropping the `this` would result in a use-after-free if all reference are dropped.
-        std::mem::forget(this);
-
-        result
-    }
-
-    /// Returns a boxed T from a tagged value.
-    ///
-    /// # Safety
-    ///
-    /// The pointer must be a valid pointer to a T on the heap, otherwise this
-    /// will result in undefined behavior.
-    #[allow(clippy::unnecessary_box_returns)]
-    pub(super) unsafe fn untag_pointer_owned<T>(value: u64) -> Box<T> {
-        // This is safe since we already checked the pointer is not null as this point.
-        unsafe { Box::from_raw((value & MASK_POINTER_VALUE) as *mut T) }
-    }
-
-    /// Returns the inner [`JsString`] from a tagged value.
-    ///
-    /// # Safety
-    ///
-    /// The pointer must be a valid pointer to a [`JsString`], otherwise this
-    /// will result in undefined behavior.
-    pub(super) unsafe fn untag_string_owned(value: u64) -> JsString {
-        let value = (value & MASK_POINTER_VALUE) as *mut RawJsString;
-
-        // SAFETY: JsValue always holds a valid, non-null JsString, so this is safe.
-        let ptr = unsafe { NonNull::new_unchecked(value) };
-
-        // SAFETY: The caller must guarantee that the JsValue is of type JsString, which is always valid.
-        unsafe { JsString::from_raw(ptr) }
+    pub(super) const fn untag_pointer(value: u64) -> usize {
+        (value & MASK_POINTER_VALUE) as usize
     }
 }
 
@@ -453,8 +328,12 @@ const_assert!(f64::from_bits(bits::MASK_STRING).is_nan());
 const_assert!(f64::from_bits(bits::MASK_SYMBOL).is_nan());
 const_assert!(f64::from_bits(bits::MASK_BIGINT).is_nan());
 
-/// A NaN-boxed `[JsValue]`'s inner.
-pub(crate) struct NanBoxedValue(pub u64);
+/// A NaN-boxed [`JsValue`]'s inner.
+pub(crate) struct NanBoxedValue {
+    #[cfg(target_pointer_width = "32")]
+    half: u32,
+    ptr: *mut (),
+}
 
 impl fmt::Debug for NanBoxedValue {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -501,18 +380,37 @@ impl Clone for NanBoxedValue {
         } else if let Some(s) = self.as_symbol() {
             Self::symbol(s.clone())
         } else {
-            Self(self.0)
+            Self {
+                #[cfg(target_pointer_width = "32")]
+                half: self.half,
+                ptr: self.ptr,
+            }
         }
     }
 }
 
 impl NanBoxedValue {
-    /// Creates a new `InnerValue` from an u64 value without checking the validity
+    /// Creates a new `NanBoxedValue` from an u64 value without checking the validity
     /// of the value.
     #[must_use]
     #[inline(always)]
     const fn from_inner_unchecked(inner: u64) -> Self {
-        Self(inner)
+        Self {
+            #[cfg(target_pointer_width = "32")]
+            half: (inner >> 32) as u32,
+            ptr: ptr::without_provenance_mut(inner as usize),
+        }
+    }
+
+    #[must_use]
+    #[inline(always)]
+    fn value(&self) -> u64 {
+        let value = self.ptr.addr() as u64;
+
+        #[cfg(target_pointer_width = "32")]
+        let value = ((self.half as u64) << 32) | value;
+
+        value
     }
 
     /// Returns a `InnerValue` from a Null.
@@ -551,103 +449,128 @@ impl NanBoxedValue {
         Self::from_inner_unchecked(bits::tag_bool(value))
     }
 
-    /// Returns a `InnerValue` from a boxed `[JsBigInt]`.
+    /// Returns a `InnerValue` from a boxed [`JsBigInt`].
     #[must_use]
     #[inline(always)]
     pub(crate) fn bigint(value: JsBigInt) -> Self {
-        Self::from_inner_unchecked(unsafe { bits::tag_bigint(Box::new(value)) })
+        let value = value.into_raw().cast::<()>().cast_mut();
+        let addr = bits::tag_bigint(value);
+        Self {
+            #[cfg(target_pointer_width = "32")]
+            half: (addr >> 32) as u32,
+            ptr: value.with_addr(addr as usize),
+        }
     }
 
-    /// Returns a `InnerValue` from a boxed `[JsObject]`.
+    /// Returns a `InnerValue` from a boxed [`JsObject`].
     #[must_use]
     #[inline(always)]
     pub(crate) fn object(value: JsObject) -> Self {
-        Self::from_inner_unchecked(unsafe { bits::tag_object(value) })
+        let value = value.into_raw().as_ptr().cast::<()>();
+        let addr = bits::tag_object(value);
+
+        Self {
+            #[cfg(target_pointer_width = "32")]
+            half: (addr >> 32) as u32,
+            ptr: value.with_addr(addr as usize),
+        }
     }
 
-    /// Returns a `InnerValue` from a boxed `[JsSymbol]`.
+    /// Returns a `InnerValue` from a boxed [`JsSymbol`].
     #[must_use]
     #[inline(always)]
     pub(crate) fn symbol(value: JsSymbol) -> Self {
-        Self::from_inner_unchecked(unsafe { bits::tag_symbol(Box::new(value)) })
+        let value = value.into_raw().as_ptr().cast::<()>();
+        let addr = bits::tag_symbol(value);
+        Self {
+            #[cfg(target_pointer_width = "32")]
+            half: (addr >> 32) as u32,
+            ptr: value.with_addr(addr as usize),
+        }
     }
 
-    /// Returns a `InnerValue` from a boxed `[JsString]`.
+    /// Returns a `InnerValue` from a boxed [`JsString`].
     #[must_use]
     #[inline(always)]
     pub(crate) fn string(value: JsString) -> Self {
-        Self::from_inner_unchecked(unsafe { bits::tag_string(value) })
+        let value = value.into_raw().as_ptr().cast::<()>();
+        let addr = bits::tag_string(value);
+        Self {
+            #[cfg(target_pointer_width = "32")]
+            half: (addr >> 32) as u32,
+            ptr: value.with_addr(addr as usize),
+        }
     }
 
     /// Returns true if a value is undefined.
     #[must_use]
     #[inline(always)]
-    pub(crate) const fn is_undefined(&self) -> bool {
-        bits::is_undefined(self.0)
+    pub(crate) fn is_undefined(&self) -> bool {
+        self.value() == bits::VALUE_UNDEFINED
     }
 
     /// Returns true if a value is null.
     #[must_use]
     #[inline(always)]
-    pub(crate) const fn is_null(&self) -> bool {
-        bits::is_null(self.0)
+    pub(crate) fn is_null(&self) -> bool {
+        self.value() == bits::VALUE_NULL
     }
 
     /// Returns true if a value is a boolean.
     #[must_use]
     #[inline(always)]
-    pub(crate) const fn is_bool(&self) -> bool {
-        bits::is_bool(self.0)
+    pub(crate) fn is_bool(&self) -> bool {
+        bits::is_bool(self.value())
     }
 
     /// Returns true if a value is a 64-bits float.
     #[must_use]
     #[inline(always)]
-    pub(crate) const fn is_float64(&self) -> bool {
-        bits::is_float(self.0)
+    pub(crate) fn is_float64(&self) -> bool {
+        bits::is_float(self.value())
     }
 
     /// Returns true if a value is a 32-bits integer.
     #[must_use]
     #[inline(always)]
-    pub(crate) const fn is_integer32(&self) -> bool {
-        bits::is_integer32(self.0)
+    pub(crate) fn is_integer32(&self) -> bool {
+        bits::is_integer32(self.value())
     }
 
-    /// Returns true if a value is a `[JsBigInt]`. A `NaN` will not match here.
+    /// Returns true if a value is a [`JsBigInt`]. A `NaN` will not match here.
     #[must_use]
     #[inline(always)]
-    pub(crate) const fn is_bigint(&self) -> bool {
-        bits::is_bigint(self.0)
+    pub(crate) fn is_bigint(&self) -> bool {
+        bits::is_bigint(self.value())
     }
 
     /// Returns true if a value is a boxed Object.
     #[must_use]
     #[inline(always)]
-    pub(crate) const fn is_object(&self) -> bool {
-        bits::is_object(self.0)
+    pub(crate) fn is_object(&self) -> bool {
+        bits::is_object(self.value())
     }
 
     /// Returns true if a value is a boxed Symbol.
     #[must_use]
     #[inline(always)]
-    pub(crate) const fn is_symbol(&self) -> bool {
-        bits::is_symbol(self.0)
+    pub(crate) fn is_symbol(&self) -> bool {
+        bits::is_symbol(self.value())
     }
 
     /// Returns true if a value is a boxed String.
     #[must_use]
     #[inline(always)]
-    pub(crate) const fn is_string(&self) -> bool {
-        bits::is_string(self.0)
+    pub(crate) fn is_string(&self) -> bool {
+        bits::is_string(self.value())
     }
 
     /// Returns the value as a f64 if it is a float.
     #[must_use]
     #[inline(always)]
-    pub(crate) const fn as_float64(&self) -> Option<f64> {
+    pub(crate) fn as_float64(&self) -> Option<f64> {
         if self.is_float64() {
-            Some(f64::from_bits(self.0))
+            Some(f64::from_bits(self.value()))
         } else {
             None
         }
@@ -656,9 +579,9 @@ impl NanBoxedValue {
     /// Returns the value as an i32 if it is an integer.
     #[must_use]
     #[inline(always)]
-    pub(crate) const fn as_integer32(&self) -> Option<i32> {
+    pub(crate) fn as_integer32(&self) -> Option<i32> {
         if self.is_integer32() {
-            Some(bits::untag_i32(self.0))
+            Some(bits::untag_i32(self.value()))
         } else {
             None
         }
@@ -667,82 +590,154 @@ impl NanBoxedValue {
     /// Returns the value as a boolean if it is a boolean.
     #[must_use]
     #[inline(always)]
-    pub(crate) const fn as_bool(&self) -> Option<bool> {
-        match self.0 {
+    pub(crate) fn as_bool(&self) -> Option<bool> {
+        match self.value() {
             bits::VALUE_FALSE => Some(false),
             bits::VALUE_TRUE => Some(true),
             _ => None,
         }
     }
 
-    /// Returns the value as a boxed `[JsBigInt]`.
+    /// Returns the value as a boxed [`JsBigInt`].
     #[must_use]
     #[inline(always)]
-    pub(crate) const fn as_bigint(&self) -> Option<&JsBigInt> {
+    pub(crate) fn as_bigint(&self) -> Option<JsBigInt> {
         if self.is_bigint() {
-            Some(unsafe { bits::untag_pointer::<'_, JsBigInt>(self.0) })
+            // SAFETY: the inner address must hold a valid, non-null JsBigInt.
+            unsafe { Some((*self.as_bigint_unchecked()).clone()) }
         } else {
             None
         }
     }
 
-    /// Returns the value as a boxed `[JsObject]`.
+    /// Returns the value as a [`JsBigInt`] without checking the inner tag.
+    ///
+    /// # Safety
+    ///
+    /// The inner value must be a valid `JsBigInt`.
+    #[must_use]
+    #[inline(always)]
+    unsafe fn as_bigint_unchecked(&self) -> ManuallyDrop<JsBigInt> {
+        let addr = bits::untag_pointer(self.value());
+        // SAFETY: This is guaranteed by the caller.
+        unsafe {
+            ManuallyDrop::new(JsBigInt::from_raw(
+                self.ptr.with_addr(addr).cast::<RawBigInt>().cast_const(),
+            ))
+        }
+    }
+
+    /// Returns the value as a boxed [`JsObject`].
     #[must_use]
     #[inline(always)]
     pub(crate) fn as_object(&self) -> Option<JsObject> {
         if self.is_object() {
-            let obj = unsafe { bits::untag_object_owned(self.0) };
-            let o = obj.clone();
-            core::mem::forget(obj); // Prevent double drop.
-            Some(o)
+            // SAFETY: the inner address must hold a valid, non-null JsObject.
+            unsafe { Some((*self.as_object_unchecked()).clone()) }
         } else {
             None
         }
     }
 
-    /// Returns the value as a boxed `[JsSymbol]`.
+    /// Returns the value as a boxed [`JsObject`] without checking the inner tag.
+    ///
+    /// # Safety
+    ///
+    /// The inner value must be a valid `JsObject`.
     #[must_use]
     #[inline(always)]
-    pub(crate) const fn as_symbol(&self) -> Option<&JsSymbol> {
+    unsafe fn as_object_unchecked(&self) -> ManuallyDrop<JsObject> {
+        let addr = bits::untag_pointer(self.value());
+        // SAFETY: This is guaranteed by the caller.
+        unsafe {
+            ManuallyDrop::new(JsObject::from_raw(NonNull::new_unchecked(
+                self.ptr.with_addr(addr).cast::<GcBox<ErasedVTableObject>>(),
+            )))
+        }
+    }
+
+    /// Returns the value as a [`JsSymbol`].
+    #[must_use]
+    #[inline(always)]
+    pub(crate) fn as_symbol(&self) -> Option<JsSymbol> {
         if self.is_symbol() {
-            Some(unsafe { bits::untag_pointer::<'_, JsSymbol>(self.0) })
+            // SAFETY: the inner address must hold a valid, non-null JsSymbol.
+            unsafe { Some((*self.as_symbol_unchecked()).clone()) }
         } else {
             None
         }
     }
 
-    /// Returns the value as a boxed `[JsString]`.
+    /// Returns the value as a [`JsSymbol`] without checking the inner tag.
+    ///
+    /// # Safety
+    ///
+    /// The inner value must be a valid `JsSymbol`.
+    #[must_use]
+    #[inline(always)]
+    unsafe fn as_symbol_unchecked(&self) -> ManuallyDrop<JsSymbol> {
+        let addr = bits::untag_pointer(self.value());
+        // SAFETY: This is guaranteed by the caller.
+        unsafe {
+            ManuallyDrop::new(JsSymbol::from_raw(NonNull::new_unchecked(
+                self.ptr.with_addr(addr).cast::<RawJsSymbol>(),
+            )))
+        }
+    }
+
+    /// Returns the value as a boxed [`JsString`].
     #[must_use]
     #[inline(always)]
     pub(crate) fn as_string(&self) -> Option<JsString> {
         if self.is_string() {
-            Some(unsafe { bits::untag_string_pointer(self.0) })
+            // SAFETY: the inner address must hold a valid, non-null JsString.
+            unsafe { Some((*self.as_string_unchecked()).clone()) }
         } else {
             None
         }
     }
 
-    /// Returns the `[JsVariant]` of this inner value.
+    /// Returns the value as a [`JsString`] without checking the inner tag.
+    ///
+    /// # Safety
+    ///
+    /// The inner value must be a valid `JsString`.
     #[must_use]
     #[inline(always)]
-    pub(crate) fn as_variant(&self) -> JsVariant<'_> {
-        match self.0 & bits::MASK_KIND {
+    unsafe fn as_string_unchecked(&self) -> ManuallyDrop<JsString> {
+        let addr = bits::untag_pointer(self.value());
+        // SAFETY: the inner address must hold a valid, non-null JsString.
+        unsafe {
+            ManuallyDrop::new(JsString::from_raw(NonNull::new_unchecked(
+                self.ptr.with_addr(addr).cast::<RawJsString>(),
+            )))
+        }
+    }
+
+    /// Returns the [`JsVariant`] of this inner value.
+    #[must_use]
+    #[inline(always)]
+    pub(crate) fn as_variant(&self) -> JsVariant {
+        match self.value() & bits::MASK_KIND {
             bits::MASK_OBJECT => {
-                let obj = unsafe { bits::untag_object_owned(self.0) };
-                let o = obj.clone();
-                core::mem::forget(obj); // Prevent double drop.
-                JsVariant::Object(o)
+                JsVariant::Object(unsafe { (*self.as_object_unchecked()).clone() })
             }
-            bits::MASK_STRING => JsVariant::String(unsafe { bits::untag_string_pointer(self.0) }),
-            bits::MASK_SYMBOL => JsVariant::Symbol(unsafe { bits::untag_pointer(self.0) }),
-            bits::MASK_BIGINT => JsVariant::BigInt(unsafe { bits::untag_pointer(self.0) }),
-            bits::MASK_INT32 => JsVariant::Integer32(bits::untag_i32(self.0)),
-            bits::MASK_BOOLEAN => JsVariant::Boolean(bits::untag_bool(self.0)),
-            bits::MASK_OTHER => match self.0 {
+            bits::MASK_STRING => {
+                JsVariant::String(unsafe { (*self.as_string_unchecked()).clone() })
+            }
+            bits::MASK_SYMBOL => {
+                JsVariant::Symbol(unsafe { (*self.as_symbol_unchecked()).clone() })
+            }
+            bits::MASK_BIGINT => {
+                JsVariant::BigInt(unsafe { (*self.as_bigint_unchecked()).clone() })
+            }
+            bits::MASK_INT32 => JsVariant::Integer32(bits::untag_i32(self.value())),
+            bits::MASK_BOOLEAN => JsVariant::Boolean(bits::untag_bool(self.value())),
+            bits::MASK_OTHER => match self.value() {
                 bits::VALUE_NULL => JsVariant::Null,
                 _ => JsVariant::Undefined,
             },
-            _ => JsVariant::Float64(f64::from_bits(self.0)),
+            _ => JsVariant::Float64(f64::from_bits(self.value())),
         }
     }
 }
@@ -750,11 +745,19 @@ impl NanBoxedValue {
 impl Drop for NanBoxedValue {
     #[inline(always)]
     fn drop(&mut self) {
-        match self.0 & bits::MASK_KIND {
-            bits::MASK_OBJECT => drop(unsafe { bits::untag_object_owned(self.0) }),
-            bits::MASK_STRING => drop(unsafe { bits::untag_string_owned(self.0) }),
-            bits::MASK_SYMBOL => drop(unsafe { bits::untag_pointer_owned::<JsSymbol>(self.0) }),
-            bits::MASK_BIGINT => drop(unsafe { bits::untag_pointer_owned::<JsBigInt>(self.0) }),
+        match self.value() & bits::MASK_KIND {
+            bits::MASK_OBJECT => {
+                drop(unsafe { ManuallyDrop::into_inner(self.as_object_unchecked()) })
+            }
+            bits::MASK_STRING => {
+                drop(unsafe { ManuallyDrop::into_inner(self.as_string_unchecked()) })
+            }
+            bits::MASK_SYMBOL => {
+                drop(unsafe { ManuallyDrop::into_inner(self.as_symbol_unchecked()) })
+            }
+            bits::MASK_BIGINT => {
+                drop(unsafe { ManuallyDrop::into_inner(self.as_bigint_unchecked()) })
+            }
             _ => {}
         }
     }
@@ -837,8 +840,8 @@ macro_rules! assert_type {
     ($value: ident is bigint($scalar: ident)) => {
         assert_type!(@@is $value, 0, 0, 0, 0, 0, 1, 0, 0, 0);
         assert_type!(@@as $value, 0, 0, 0, 0, 0, 1, 0, 0, 0);
-        assert_eq!(Some(&$scalar), $value.as_bigint());
-        assert_eq!($value.as_variant(), JsVariant::BigInt(&$scalar));
+        assert_eq!(Some(&$scalar), $value.as_bigint().as_ref());
+        assert_eq!($value.as_variant(), JsVariant::BigInt($scalar));
     };
     ($value: ident is object($scalar: ident)) => {
         assert_type!(@@is $value, 0, 0, 0, 0, 0, 0, 0, 1, 0);
@@ -849,8 +852,8 @@ macro_rules! assert_type {
     ($value: ident is symbol($scalar: ident)) => {
         assert_type!(@@is $value, 0, 0, 0, 0, 0, 0, 0, 0, 1);
         assert_type!(@@as $value, 0, 0, 0, 0, 0, 0, 0, 0, 1);
-        assert_eq!(Some(&$scalar), $value.as_symbol());
-        assert_eq!($value.as_variant(), JsVariant::Symbol(&$scalar));
+        assert_eq!(Some(&$scalar), $value.as_symbol().as_ref());
+        assert_eq!($value.as_variant(), JsVariant::Symbol($scalar));
     };
     ($value: ident is string($scalar: ident)) => {
         assert_type!(@@is $value, 0, 0, 0, 0, 0, 0, 1, 0, 0);

--- a/core/engine/src/value/mod.rs
+++ b/core/engine/src/value/mod.rs
@@ -143,7 +143,7 @@ impl JsValue {
     /// Return the variant of this value.
     #[inline]
     #[must_use]
-    pub fn variant(&self) -> JsVariant<'_> {
+    pub fn variant(&self) -> JsVariant {
         self.0.as_variant()
     }
 
@@ -192,7 +192,7 @@ impl JsValue {
     /// Returns true if the value is an object.
     #[inline]
     #[must_use]
-    pub const fn is_object(&self) -> bool {
+    pub fn is_object(&self) -> bool {
         self.0.is_object()
     }
 
@@ -294,7 +294,7 @@ impl JsValue {
     /// Returns true if the value is a symbol.
     #[inline]
     #[must_use]
-    pub const fn is_symbol(&self) -> bool {
+    pub fn is_symbol(&self) -> bool {
         self.0.is_symbol()
     }
 
@@ -302,27 +302,27 @@ impl JsValue {
     #[inline]
     #[must_use]
     pub fn as_symbol(&self) -> Option<JsSymbol> {
-        self.0.as_symbol().cloned()
+        self.0.as_symbol()
     }
 
     /// Returns true if the value is undefined.
     #[inline]
     #[must_use]
-    pub const fn is_undefined(&self) -> bool {
+    pub fn is_undefined(&self) -> bool {
         self.0.is_undefined()
     }
 
     /// Returns true if the value is null.
     #[inline]
     #[must_use]
-    pub const fn is_null(&self) -> bool {
+    pub fn is_null(&self) -> bool {
         self.0.is_null()
     }
 
     /// Returns true if the value is null or undefined.
     #[inline]
     #[must_use]
-    pub const fn is_null_or_undefined(&self) -> bool {
+    pub fn is_null_or_undefined(&self) -> bool {
         self.is_undefined() || self.is_null()
     }
 
@@ -335,12 +335,11 @@ impl JsValue {
     #[inline]
     #[must_use]
     #[allow(clippy::float_cmp)]
-    pub const fn as_i32(&self) -> Option<i32> {
+    pub fn as_i32(&self) -> Option<i32> {
         if let Some(integer) = self.0.as_integer32() {
             Some(integer)
         } else if let Some(rational) = self.0.as_float64() {
-            // Use this poor-man's check as `[f64::fract]` isn't const.
-            if rational == ((rational as i32) as f64) {
+            if rational == f64::from(rational as i32) {
                 Some(rational as i32)
             } else {
                 None
@@ -353,7 +352,7 @@ impl JsValue {
     /// Returns true if the value is a number.
     #[inline]
     #[must_use]
-    pub const fn is_number(&self) -> bool {
+    pub fn is_number(&self) -> bool {
         self.0.is_integer32() || self.0.is_float64()
     }
 
@@ -371,7 +370,7 @@ impl JsValue {
     /// Returns true if the value is a string.
     #[inline]
     #[must_use]
-    pub const fn is_string(&self) -> bool {
+    pub fn is_string(&self) -> bool {
         self.0.is_string()
     }
 
@@ -385,28 +384,28 @@ impl JsValue {
     /// Returns true if the value is a boolean.
     #[inline]
     #[must_use]
-    pub const fn is_boolean(&self) -> bool {
+    pub fn is_boolean(&self) -> bool {
         self.0.is_bool()
     }
 
     /// Returns the boolean if the value is a boolean, otherwise `None`.
     #[inline]
     #[must_use]
-    pub const fn as_boolean(&self) -> Option<bool> {
+    pub fn as_boolean(&self) -> Option<bool> {
         self.0.as_bool()
     }
 
     /// Returns true if the value is a bigint.
     #[inline]
     #[must_use]
-    pub const fn is_bigint(&self) -> bool {
+    pub fn is_bigint(&self) -> bool {
         self.0.is_bigint()
     }
 
-    /// Returns an optional reference to a `BigInt` if the value is a `BigInt` primitive.
+    /// Returns a `BigInt` if the value is a `BigInt` primitive.
     #[inline]
     #[must_use]
-    pub const fn as_bigint(&self) -> Option<&JsBigInt> {
+    pub fn as_bigint(&self) -> Option<JsBigInt> {
         self.0.as_bigint()
     }
 

--- a/core/engine/src/value/operations.rs
+++ b/core/engine/src/value/operations.rs
@@ -21,7 +21,7 @@ impl JsValue {
             (JsVariant::Float64(x), JsVariant::Float64(y)) => Self::new(x + y),
             (JsVariant::Integer32(x), JsVariant::Float64(y)) => Self::new(f64::from(x) + y),
             (JsVariant::Float64(x), JsVariant::Integer32(y)) => Self::new(x + f64::from(y)),
-            (JsVariant::BigInt(x), JsVariant::BigInt(y)) => Self::new(JsBigInt::add(x, y)),
+            (JsVariant::BigInt(x), JsVariant::BigInt(y)) => Self::new(JsBigInt::add(&x, &y)),
 
             // String concat
             (JsVariant::String(x), JsVariant::String(y)) => Self::from(js_string!(&x, &y)),
@@ -62,7 +62,7 @@ impl JsValue {
             (JsVariant::Integer32(x), JsVariant::Float64(y)) => Self::new(f64::from(x) - y),
             (JsVariant::Float64(x), JsVariant::Integer32(y)) => Self::new(x - f64::from(y)),
 
-            (JsVariant::BigInt(x), JsVariant::BigInt(y)) => Self::new(JsBigInt::sub(x, y)),
+            (JsVariant::BigInt(x), JsVariant::BigInt(y)) => Self::new(JsBigInt::sub(&x, &y)),
 
             // Slow path:
             (_, _) => match (self.to_numeric(context)?, other.to_numeric(context)?) {
@@ -90,7 +90,7 @@ impl JsValue {
             (JsVariant::Integer32(x), JsVariant::Float64(y)) => Self::new(f64::from(x) * y),
             (JsVariant::Float64(x), JsVariant::Integer32(y)) => Self::new(x * f64::from(y)),
 
-            (JsVariant::BigInt(x), JsVariant::BigInt(y)) => Self::new(JsBigInt::mul(x, y)),
+            (JsVariant::BigInt(x), JsVariant::BigInt(y)) => Self::new(JsBigInt::mul(&x, &y)),
 
             // Slow path:
             (_, _) => match (self.to_numeric(context)?, other.to_numeric(context)?) {
@@ -123,7 +123,7 @@ impl JsValue {
                         .with_message("BigInt division by zero")
                         .into());
                 }
-                Self::new(JsBigInt::div(x, y))
+                Self::new(JsBigInt::div(&x, &y))
             }
 
             // Slow path:
@@ -176,7 +176,7 @@ impl JsValue {
                         .with_message("BigInt division by zero")
                         .into());
                 }
-                Self::new(JsBigInt::rem(x, y))
+                Self::new(JsBigInt::rem(&x, &y))
             }
 
             // Slow path:
@@ -224,7 +224,7 @@ impl JsValue {
                 }
             }
             (JsVariant::Float64(x), JsVariant::Integer32(y)) => Self::new(x.powi(y)),
-            (JsVariant::BigInt(a), JsVariant::BigInt(b)) => Self::new(JsBigInt::pow(a, b)?),
+            (JsVariant::BigInt(a), JsVariant::BigInt(b)) => Self::new(JsBigInt::pow(&a, &b)?),
 
             // Slow path:
             (_, _) => match (self.to_numeric(context)?, other.to_numeric(context)?) {
@@ -256,7 +256,7 @@ impl JsValue {
             (JsVariant::Integer32(x), JsVariant::Float64(y)) => Self::new(x & f64_to_int32(y)),
             (JsVariant::Float64(x), JsVariant::Integer32(y)) => Self::new(f64_to_int32(x) & y),
 
-            (JsVariant::BigInt(x), JsVariant::BigInt(y)) => Self::new(JsBigInt::bitand(x, y)),
+            (JsVariant::BigInt(x), JsVariant::BigInt(y)) => Self::new(JsBigInt::bitand(&x, &y)),
 
             // Slow path:
             (_, _) => match (self.to_numeric(context)?, other.to_numeric(context)?) {
@@ -286,7 +286,7 @@ impl JsValue {
             (JsVariant::Integer32(x), JsVariant::Float64(y)) => Self::new(x | f64_to_int32(y)),
             (JsVariant::Float64(x), JsVariant::Integer32(y)) => Self::new(f64_to_int32(x) | y),
 
-            (JsVariant::BigInt(x), JsVariant::BigInt(y)) => Self::new(JsBigInt::bitor(x, y)),
+            (JsVariant::BigInt(x), JsVariant::BigInt(y)) => Self::new(JsBigInt::bitor(&x, &y)),
 
             // Slow path:
             (_, _) => match (self.to_numeric(context)?, other.to_numeric(context)?) {
@@ -316,7 +316,7 @@ impl JsValue {
             (JsVariant::Integer32(x), JsVariant::Float64(y)) => Self::new(x ^ f64_to_int32(y)),
             (JsVariant::Float64(x), JsVariant::Integer32(y)) => Self::new(f64_to_int32(x) ^ y),
 
-            (JsVariant::BigInt(x), JsVariant::BigInt(y)) => Self::new(JsBigInt::bitxor(x, y)),
+            (JsVariant::BigInt(x), JsVariant::BigInt(y)) => Self::new(JsBigInt::bitxor(&x, &y)),
 
             // Slow path:
             (_, _) => match (self.to_numeric(context)?, other.to_numeric(context)?) {
@@ -352,7 +352,9 @@ impl JsValue {
                 Self::new(f64_to_int32(x).wrapping_shl(y as u32))
             }
 
-            (JsVariant::BigInt(a), JsVariant::BigInt(b)) => Self::new(JsBigInt::shift_left(a, b)?),
+            (JsVariant::BigInt(a), JsVariant::BigInt(b)) => {
+                Self::new(JsBigInt::shift_left(&a, &b)?)
+            }
 
             // Slow path:
             (_, _) => match (self.to_numeric(context)?, other.to_numeric(context)?) {
@@ -388,7 +390,9 @@ impl JsValue {
                 Self::new(f64_to_int32(x).wrapping_shr(y as u32))
             }
 
-            (JsVariant::BigInt(a), JsVariant::BigInt(b)) => Self::new(JsBigInt::shift_right(a, b)?),
+            (JsVariant::BigInt(a), JsVariant::BigInt(b)) => {
+                Self::new(JsBigInt::shift_right(&a, &b)?)
+            }
 
             // Slow path:
             (_, _) => match (self.to_numeric(context)?, other.to_numeric(context)?) {
@@ -497,7 +501,7 @@ impl JsValue {
             }
             JsVariant::Integer32(num) => Self::new(-num),
             JsVariant::Boolean(true) => Self::new(-1),
-            JsVariant::BigInt(x) => Self::new(JsBigInt::neg(x)),
+            JsVariant::BigInt(x) => Self::new(JsBigInt::neg(&x)),
         })
     }
 
@@ -554,9 +558,9 @@ impl JsValue {
                 match (px.variant(), py.variant()) {
                     (JsVariant::String(x), JsVariant::String(y)) => (x < y).into(),
                     (JsVariant::BigInt(x), JsVariant::String(y)) => JsBigInt::from_js_string(&y)
-                        .map_or(AbstractRelation::Undefined, |ref y| (x < y).into()),
+                        .map_or(AbstractRelation::Undefined, |y| (x < y).into()),
                     (JsVariant::String(x), JsVariant::BigInt(y)) => JsBigInt::from_js_string(&x)
-                        .map_or(AbstractRelation::Undefined, |ref x| (x < y).into()),
+                        .map_or(AbstractRelation::Undefined, |x| (x < y).into()),
                     (_, _) => match (px.to_numeric(context)?, py.to_numeric(context)?) {
                         (Numeric::Number(x), Numeric::Number(y)) => Number::less_than(x, y),
                         (Numeric::BigInt(ref x), Numeric::BigInt(ref y)) => (x < y).into(),

--- a/core/engine/src/value/variant.rs
+++ b/core/engine/src/value/variant.rs
@@ -6,7 +6,7 @@ use boa_string::JsString;
 /// Represents either a primitive value ([`bool`], [`f64`], [`i32`]) or a reference
 /// to a heap allocated value ([`JsString`], [`JsSymbol`]).
 #[derive(Debug, PartialEq)]
-pub enum JsVariant<'a> {
+pub enum JsVariant {
     /// `null` - A null value, for when a value doesn't exist.
     Null,
     /// `undefined` - An undefined value, for when a field or index doesn't exist.
@@ -22,30 +22,30 @@ pub enum JsVariant<'a> {
     /// `Number` - A 32-bit integer, such as `42`.
     Integer32(i32),
     /// `BigInt` - holds any arbitrary large signed integer.
-    BigInt(&'a JsBigInt),
+    BigInt(JsBigInt),
     /// `Object` - An object, such as `Math`, represented by a binary tree of string keys to Javascript values.
     Object(JsObject),
     /// `Symbol` - A Symbol Primitive type.
-    Symbol(&'a JsSymbol),
+    Symbol(JsSymbol),
 }
 
-impl<'a> From<JsVariant<'a>> for JsValue {
-    fn from(value: JsVariant<'a>) -> Self {
+impl From<JsVariant> for JsValue {
+    fn from(value: JsVariant) -> Self {
         match value {
             JsVariant::Null => JsValue::null(),
             JsVariant::Undefined => JsValue::undefined(),
             JsVariant::Boolean(b) => JsValue::new(b),
-            JsVariant::String(s) => JsValue::new(s.clone()),
+            JsVariant::String(s) => JsValue::new(s),
             JsVariant::Float64(f) => JsValue::new(f),
             JsVariant::Integer32(i) => JsValue::new(i),
-            JsVariant::BigInt(b) => JsValue::new(b.clone()),
-            JsVariant::Object(o) => JsValue::new(o.clone()),
-            JsVariant::Symbol(s) => JsValue::new(s.clone()),
+            JsVariant::BigInt(b) => JsValue::new(b),
+            JsVariant::Object(o) => JsValue::new(o),
+            JsVariant::Symbol(s) => JsValue::new(s),
         }
     }
 }
 
-impl JsVariant<'_> {
+impl JsVariant {
     /// Check if the variant is an `undefined` value.
     #[inline]
     #[must_use]

--- a/utils/tag_ptr/src/lib.rs
+++ b/utils/tag_ptr/src/lib.rs
@@ -66,11 +66,7 @@ impl<T> Tagged<T> {
         unsafe { Self(NonNull::new_unchecked(ptr)) }
     }
 
-    /// Creates a new `Tagged` pointer from a `NonNull` pointer.
-    ///
-    /// # Requirements
-    ///
-    /// - `ptr` must have an alignment of at least 2.
+    /// Creates a new `Tagged` pointer from a (possibly tagged) `NonNull` pointer.
     #[inline]
     #[must_use]
     pub const fn from_non_null(ptr: NonNull<T>) -> Self {


### PR DESCRIPTION
- Changes the representation of `NanBoxedValue` to be a `*const ()` (plus an extra `u32` for 32-bit platforms).
- Removes usages of `Box` in `NanBoxedValue` for `JsSymbol` and `JsBigInt`.

The previous implementation technically was UB, because we didn't carry the provenance of the nan-boxed pointers.