### PR TITLE
Add an empty EmbeddedModuleLoader default

### DIFF
--- a/core/interop/src/loaders/embedded.rs
+++ b/core/interop/src/loaders/embedded.rs
@@ -97,7 +97,7 @@ impl TryFrom<&str> for CompressType {
 }
 
 /// The resulting type of creating an embedded module loader.
-#[derive(Debug, Clone)]
+#[derive(Debug, Default, Clone)]
 #[allow(clippy::module_name_repetitions)]
 pub struct EmbeddedModuleLoader {
     map: HashMap<JsString, RefCell<EmbeddedModuleEntry>>,


### PR DESCRIPTION
Useful in some `else` cases. Right now the best way is to do `EmbeddedModuleLoader::from_iter(vec![])`.