### PR TITLE
Regex optimization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -518,6 +518,7 @@ dependencies = [
 name = "boa_parser"
 version = "0.20.0"
 dependencies = [
+ "arrayvec",
  "bitflags 2.9.1",
  "boa_ast",
  "boa_interner",

--- a/core/parser/Cargo.toml
+++ b/core/parser/Cargo.toml
@@ -21,6 +21,7 @@ bitflags.workspace = true
 num-bigint.workspace = true
 regress.workspace = true
 icu_properties.workspace = true
+arrayvec.workspace = true
 
 [dev-dependencies]
 indoc.workspace = true


### PR DESCRIPTION
This Pull Request fixes/closes #4305

It changes the following:

- Use an ArrayVec instead of a regular Vec for processing regular expression flags, avoiding an unnecessary heap allocation and memory usage especially in the case of complex nested regexps. 
- Refactors the processing of regexps to avoid deeply nested and potentially error prone match structure
- Properly shows syntax errors in cases where more than 8 regex flags are provided (disallowed by the spec).
