### PR TITLE
Allow public access to the full position of a call frame

### DIFF
--- a/core/engine/src/vm/call_frame/mod.rs
+++ b/core/engine/src/vm/call_frame/mod.rs
@@ -3,10 +3,9 @@
 //! This module will provides everything needed to implement the `CallFrame`
 
 use super::ActiveRunnable;
-use crate::vm::source_info::SourcePath;
 use crate::{
     JsValue, builtins::iterable::IteratorRecord, environments::EnvironmentStack, realm::Realm,
-    vm::CodeBlock,
+    vm::CodeBlock, vm::SourcePath,
 };
 use boa_ast::Position;
 use boa_ast::scope::BindingLocator;

--- a/core/engine/src/vm/call_frame/mod.rs
+++ b/core/engine/src/vm/call_frame/mod.rs
@@ -81,7 +81,7 @@ impl CallFrame {
         &self.code_block
     }
 
-    /// Retrieves a tuple of `(`[JsString]`, `[SourcePath]`, `[`Position`]`)` to know the
+    /// Retrieves a tuple of `(`[`JsString`]`, `[`SourcePath`]`, `[`Position`]`)` to know the
     /// location of the call frame.
     #[inline]
     #[must_use]

--- a/core/engine/src/vm/call_frame/mod.rs
+++ b/core/engine/src/vm/call_frame/mod.rs
@@ -2,15 +2,17 @@
 //!
 //! This module will provides everything needed to implement the `CallFrame`
 
+use super::ActiveRunnable;
+use crate::vm::source_info::SourcePath;
 use crate::{
     JsValue, builtins::iterable::IteratorRecord, environments::EnvironmentStack, realm::Realm,
     vm::CodeBlock,
 };
+use boa_ast::Position;
 use boa_ast::scope::BindingLocator;
 use boa_gc::{Finalize, Gc, Trace};
+use boa_string::JsString;
 use thin_vec::ThinVec;
-
-use super::ActiveRunnable;
 
 bitflags::bitflags! {
     /// Flags associated with a [`CallFrame`].
@@ -77,6 +79,19 @@ impl CallFrame {
     #[must_use]
     pub const fn code_block(&self) -> &Gc<CodeBlock> {
         &self.code_block
+    }
+
+    /// Retrieves a tuple of `(`[JsString]`, `[SourcePath]`, `[`Position`]`)` to know the
+    /// location of the call frame.
+    #[inline]
+    #[must_use]
+    pub fn position(&self) -> (JsString, SourcePath, Option<Position>) {
+        let source_info = &self.code_block.source_info;
+        (
+            source_info.function_name().clone(),
+            source_info.map().path().clone(),
+            source_info.map().find(self.pc),
+        )
     }
 }
 

--- a/core/engine/src/vm/call_frame/mod.rs
+++ b/core/engine/src/vm/call_frame/mod.rs
@@ -32,6 +32,13 @@ bitflags::bitflags! {
     }
 }
 
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct CallFrameLocation {
+    pub function_name: JsString,
+    pub path: SourcePath,
+    pub position: Option<Position>,
+}
+
 /// A `CallFrame` holds the state of a function call.
 #[derive(Clone, Debug, Finalize, Trace)]
 pub struct CallFrame {
@@ -84,13 +91,13 @@ impl CallFrame {
     /// location of the call frame.
     #[inline]
     #[must_use]
-    pub fn position(&self) -> (JsString, SourcePath, Option<Position>) {
+    pub fn position(&self) -> CallFrameLocation {
         let source_info = &self.code_block.source_info;
-        (
-            source_info.function_name().clone(),
-            source_info.map().path().clone(),
-            source_info.map().find(self.pc),
-        )
+        CallFrameLocation {
+            function_name: source_info.function_name().clone(),
+            path: source_info.map().path().clone(),
+            position: source_info.map().find(self.pc),
+        }
     }
 }
 

--- a/core/engine/src/vm/code_block.rs
+++ b/core/engine/src/vm/code_block.rs
@@ -185,6 +185,12 @@ impl CodeBlock {
         self.source_info.function_name()
     }
 
+    /// Retrieves the path of this code block.
+    #[must_use]
+    pub fn path(&self) -> &SourcePath {
+        self.source_info.map().path()
+    }
+
     /// Check if the function is traced.
     #[cfg(feature = "trace")]
     pub(crate) fn traceable(&self) -> bool {

--- a/core/engine/src/vm/mod.rs
+++ b/core/engine/src/vm/mod.rs
@@ -38,7 +38,7 @@ pub use runtime_limits::RuntimeLimits;
 pub use {
     call_frame::{CallFrame, GeneratorResumeKind},
     code_block::CodeBlock,
-    source_info::NativeSourceInfo,
+    source_info::{NativeSourceInfo, SourcePath},
 };
 
 mod call_frame;

--- a/core/engine/src/vm/source_info/mod.rs
+++ b/core/engine/src/vm/source_info/mod.rs
@@ -142,7 +142,7 @@ impl Entry {
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
-pub(crate) enum SourcePath {
+pub enum SourcePath {
     #[default]
     None,
     // TODO: Could add more information, like path in which the eval is located.

--- a/core/engine/src/vm/source_info/mod.rs
+++ b/core/engine/src/vm/source_info/mod.rs
@@ -141,7 +141,7 @@ impl Entry {
     }
 }
 
-/// The Path and type of [`Source`]. This applies to functions and objects.
+/// The Path and type of [`boa_engine::Source`]. This applies to functions and objects.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub enum SourcePath {
     /// There was no source associated with this call.

--- a/core/engine/src/vm/source_info/mod.rs
+++ b/core/engine/src/vm/source_info/mod.rs
@@ -141,14 +141,20 @@ impl Entry {
     }
 }
 
+/// The Path and type of [`Source`]. This applies to functions and objects.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub enum SourcePath {
+    /// There was no source associated with this call.
     #[default]
     None,
+    /// The source is from an `eval()` call.
     // TODO: Could add more information, like path in which the eval is located.
     Eval,
+    /// The source is from a `JSON.parse()` call.
     // TODO: Could add more information, like path in which the JSON.parse is located.
     Json,
+    /// The source is from a file or module. This contains the [`Path`] of the
+    /// module (e.g. the absolute file path).
     Path(Rc<Path>),
 }
 

--- a/core/engine/src/vm/tests.rs
+++ b/core/engine/src/vm/tests.rs
@@ -1,4 +1,5 @@
 use crate::vm::CallFrame;
+use crate::vm::call_frame::CallFrameLocation;
 use crate::vm::source_info::SourcePath;
 use crate::{
     Context, JsNativeErrorKind, JsValue, NativeFunction, TestAction, js_string,
@@ -56,35 +57,35 @@ fn position() {
                 assert_eq!(frame.len(), 4);
                 assert_eq!(
                     frame[0].position(),
-                    (
-                        js_string!("myOtherFunction"),
-                        SourcePath::None,
-                        Some(Position::new(2, 16))
-                    )
+                    CallFrameLocation {
+                        function_name: js_string!("myOtherFunction"),
+                        path: SourcePath::None,
+                        position: Some(Position::new(2, 16))
+                    }
                 );
                 assert_eq!(
                     frame[1].position(),
-                    (
-                        js_string!("<eval>"),
-                        SourcePath::Eval,
-                        Some(Position::new(1, 16))
-                    )
+                    CallFrameLocation {
+                        function_name: js_string!("<eval>"),
+                        path: SourcePath::Eval,
+                        position: Some(Position::new(1, 16))
+                    }
                 );
                 assert_eq!(
                     frame[2].position(),
-                    (
-                        js_string!("myFunction"),
-                        SourcePath::None,
-                        Some(Position::new(5, 9))
-                    )
+                    CallFrameLocation {
+                        function_name: js_string!("myFunction"),
+                        path: SourcePath::None,
+                        position: Some(Position::new(5, 9))
+                    }
                 );
                 assert_eq!(
                     frame[3].position(),
-                    (
-                        js_string!("<main>"),
-                        SourcePath::None,
-                        Some(Position::new(8, 11))
-                    )
+                    CallFrameLocation {
+                        function_name: js_string!("<main>"),
+                        path: SourcePath::None,
+                        position: Some(Position::new(8, 11))
+                    }
                 );
                 Ok(JsValue::undefined())
             }),


### PR DESCRIPTION
Prior to this, it was impossible for an application to know the origin of an API call.

My use case is that I want to enable back trace logging on `console.trace()` or when a CLI flag is used.