### PR TITLE
Implement `Math.sumPrecise`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -410,6 +410,7 @@ dependencies = [
  "tinystr",
  "web-time",
  "writeable",
+ "xsum",
  "yoke",
  "zerofrom",
 ]
@@ -5321,6 +5322,12 @@ checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
 dependencies = [
  "either",
 ]
+
+[[package]]
+name = "xsum"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "294a1cb991f5548a829039857b4908933f58f898f55fb2f1d50286260e3a371f"
 
 [[package]]
 name = "yoke"

--- a/core/engine/Cargo.toml
+++ b/core/engine/Cargo.toml
@@ -12,7 +12,8 @@ repository.workspace = true
 rust-version.workspace = true
 
 [features]
-default = ["float16"]
+default = ["float16", "xsum"]
+
 
 # Replace the NaN-boxing implementation of `JsValueInner` with an
 # enum-based implementation. This implementation is less performant
@@ -77,6 +78,9 @@ js = ["dep:web-time", "dep:getrandom"]
 # Enable support for Float16 typed arrays
 float16 = ["dep:float16"]
 
+# Enable support for `Math.prototype.sumPrecise`
+xsum = ["dep:xsum"]
+
 # Native Backtraces
 native-backtrace = []
 
@@ -91,6 +95,7 @@ boa_string.workspace = true
 cow-utils.workspace = true
 futures-lite.workspace = true
 float16 = { version = "0.1", optional = true }
+xsum = { version = "0.1.1", optional = true }
 serde = { workspace = true, features = ["derive", "rc"] }
 serde_json.workspace = true
 rand.workspace = true


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This PR implements [Math.sumPrecise](https://tc39.es/ecma262/#sec-math.sumprecise) functionality.

This uses the `xsum` crate for the implementation, so that crate has been added behind a feature flag for the dependency and the dependency has been added to `boa_engine`'s defaults.