### PR TITLE
Remove alignment of property keys with identation

### DIFF
--- a/core/engine/src/value/display.rs
+++ b/core/engine/src/value/display.rs
@@ -60,7 +60,8 @@ fn print_obj_value_internals(
     let object = obj.borrow();
     if let Some(object) = object.prototype() {
         vec![format!(
-            "{:>width$}: {}",
+            "{:>width$}{}: {}",
+            "",
             "__proto__",
             display_fn(
                 &object.clone().into(),
@@ -72,7 +73,8 @@ fn print_obj_value_internals(
         )]
     } else {
         vec![format!(
-            "{:>width$}: {}",
+            "{:>width$}{}: {}",
+            "",
             "__proto__",
             JsValue::null().display(),
             width = indent,
@@ -104,7 +106,8 @@ fn print_obj_value_props(
         if val.is_data_descriptor() {
             let v = &val.expect_value();
             result.push(format!(
-                "{:>width$}: {}",
+                "{:>width$}{}: {}",
+                "",
                 key,
                 display_fn(v, encounters, indent.wrapping_add(4), print_internals),
                 width = indent,

--- a/core/engine/src/value/mod.rs
+++ b/core/engine/src/value/mod.rs
@@ -81,7 +81,7 @@ static TWO_E_63: LazyLock<BigInt> = LazyLock::new(|| {
 ///     // Comments are allowed inside.
 ///     "key": (js_string!("value"))
 ///   }, context).display().to_string(),
-///   "{\n key: \"value\"\n}",
+///   "{\n    key: \"value\"\n}",
 /// );
 /// ```
 pub use boa_macros::js_object;
@@ -103,7 +103,7 @@ pub use boa_macros::js_object;
 ///
 /// assert_eq!(
 ///     JsValue::from(value).display().to_string(),
-///     "{\n   3: null,\n key: \"value\",\nalsoKey: 1\n}"
+///     "{\n    3: null,\n    key: \"value\",\n    alsoKey: 1\n}"
 /// );
 /// ```
 pub use boa_macros::js_value;

--- a/core/engine/src/value/tests.rs
+++ b/core/engine/src/value/tests.rs
@@ -400,12 +400,28 @@ fn debug_object() {
 fn display_object() {
     const DISPLAY: &str = indoc! {r#"
         {
-           a: "a"
+            a: "a"
         }"#
     };
     run_test_actions([TestAction::assert_with_op("({a: 'a'})", |v, _| {
         v.display().to_string() == DISPLAY
     })]);
+}
+
+/// Ensure indentation is always 4 and that the property key is not right-align with
+/// the brackets.
+#[test]
+fn display_object_indent() {
+    const DISPLAY: &str = indoc! {r#"
+        {
+            a: "a",
+            hello: "world"
+        }"#
+    };
+    run_test_actions([TestAction::assert_with_op(
+        "({a: 'a', hello: 'world'})",
+        |v, _| v.display().to_string() == DISPLAY,
+    )]);
 }
 
 #[test]
@@ -1608,7 +1624,7 @@ mod js_value_macro {
 
         assert_eq!(
             format!("{}", o.display()),
-            "{\nfOne: \"Hello\",\nfield2: 42\n}"
+            "{\n    fOne: \"Hello\",\n    field2: 42\n}"
         );
     }
 }

--- a/core/runtime/src/fetch/tests/response.rs
+++ b/core/runtime/src/fetch/tests/response.rs
@@ -88,7 +88,7 @@ fn response_json() {
             let response = response.as_promise().unwrap().await_blocking(ctx).unwrap();
             assert_eq!(
                 format!("{}", response.display_obj(false)),
-                "{\nhello world: 123\n}"
+                "{\n    hello world: 123\n}"
             );
         }),
     ]);


### PR DESCRIPTION
This fixes some visual issues like alignment of brackets, and also make it more consistent when keys are long (it does not take much, only need to be longer than ident which is 4).

Since most of our tests have single letter keys this never showed up as much of a problem, but in the real world it becomes annoying.

Before:

```
{
hello: "world",
   z: {
       a: 1
    }
}
```

After:

```
{
    hello: "world",
    z: {
        a: 1
    }
}
```