### PR TITLE
Propagate AST errors to the user

### DIFF
--- a/core/ast/src/function/ordinary_function.rs
+++ b/core/ast/src/function/ordinary_function.rs
@@ -271,6 +271,9 @@ impl FunctionExpression {
     }
 
     /// Analyze the scope of the function expression.
+    ///
+    /// # Errors
+    /// Any scope or binding errors that happened during the analysis.
     pub fn analyze_scope(
         &mut self,
         strict: bool,

--- a/core/ast/src/function/ordinary_function.rs
+++ b/core/ast/src/function/ordinary_function.rs
@@ -271,10 +271,13 @@ impl FunctionExpression {
     }
 
     /// Analyze the scope of the function expression.
-    pub fn analyze_scope(&mut self, strict: bool, scope: &Scope, interner: &Interner) -> bool {
-        if !collect_bindings(self, strict, false, scope, interner) {
-            return false;
-        }
+    pub fn analyze_scope(
+        &mut self,
+        strict: bool,
+        scope: &Scope,
+        interner: &Interner,
+    ) -> Result<(), &'static str> {
+        collect_bindings(self, strict, false, scope, interner)?;
         analyze_binding_escapes(self, false, scope.clone(), interner)
     }
 }

--- a/core/ast/src/scope_analyzer.rs
+++ b/core/ast/src/scope_analyzer.rs
@@ -41,7 +41,7 @@ pub(crate) fn collect_bindings<'a, N>(
     eval: bool,
     scope: &Scope,
     interner: &Interner,
-) -> bool
+) -> Result<(), &'static str>
 where
     &'a mut N: Into<NodeRefMut<'a>>,
 {
@@ -52,7 +52,10 @@ where
         scope: scope.clone(),
         interner,
     };
-    !visitor.visit(node).is_break()
+    match visitor.visit(node) {
+        ControlFlow::Continue(()) => Ok(()),
+        ControlFlow::Break(reason) => Err(reason),
+    }
 }
 
 /// Analyze if bindings escape their function scopes.
@@ -62,7 +65,7 @@ pub(crate) fn analyze_binding_escapes<'a, N>(
     in_eval: bool,
     scope: Scope,
     interner: &Interner,
-) -> bool
+) -> Result<(), &'static str>
 where
     &'a mut N: Into<NodeRefMut<'a>>,
 {
@@ -72,7 +75,11 @@ where
         with: false,
         interner,
     };
-    !visitor.visit(node.into()).is_break()
+
+    match visitor.visit(node.into()) {
+        ControlFlow::Continue(()) => Ok(()),
+        ControlFlow::Break(reason) => Err(reason),
+    }
 }
 
 struct BindingEscapeAnalyzer<'interner> {

--- a/core/ast/src/scope_analyzer.rs
+++ b/core/ast/src/scope_analyzer.rs
@@ -34,7 +34,9 @@ use rustc_hash::FxHashMap;
 use std::ops::ControlFlow;
 
 /// Collect bindings and fill the scopes with them.
-#[must_use]
+///
+/// # Errors
+/// Any break in the control flow that happened during the collection.
 pub(crate) fn collect_bindings<'a, N>(
     node: &'a mut N,
     strict: bool,
@@ -59,7 +61,9 @@ where
 }
 
 /// Analyze if bindings escape their function scopes.
-#[must_use]
+///
+/// # Errors
+/// Any break in the control flow that happened during the analysis.
 pub(crate) fn analyze_binding_escapes<'a, N>(
     node: &'a mut N,
     in_eval: bool,

--- a/core/ast/tests/scope.rs
+++ b/core/ast/tests/scope.rs
@@ -18,7 +18,7 @@ use boa_string::JsString;
 fn empty_script_is_ok() {
     let scope = &Scope::new_global();
     let mut script = Script::default();
-    let ok = script.analyze_scope(scope, &Interner::new());
+    let ok = script.analyze_scope(scope, &Interner::new()).is_ok();
     assert!(ok);
     assert_eq!(scope.num_bindings(), 0);
 }
@@ -41,7 +41,7 @@ fn script_global_let() {
         LinearPosition::default(),
         false,
     ));
-    let ok = script.analyze_scope(&scope, &interner);
+    let ok = script.analyze_scope(&scope, &interner).is_ok();
     assert!(ok);
     assert_eq!(scope.num_bindings(), 1);
     let a = scope.get_binding_reference(&JsString::from("a")).unwrap();
@@ -68,7 +68,7 @@ fn script_global_const() {
         LinearPosition::default(),
         false,
     ));
-    let ok = script.analyze_scope(&scope, &interner);
+    let ok = script.analyze_scope(&scope, &interner).is_ok();
     assert!(ok);
     assert_eq!(scope.num_bindings(), 1);
     let a = scope.get_binding_reference(&JsString::from("a")).unwrap();
@@ -101,7 +101,7 @@ fn script_block_let() {
         LinearPosition::default(),
         false,
     ));
-    let ok = script.analyze_scope(&scope, &interner);
+    let ok = script.analyze_scope(&scope, &interner).is_ok();
     assert!(ok);
     assert_eq!(scope.num_bindings(), 0);
     let StatementListItem::Statement(statement) = script.statements().first().unwrap() else {
@@ -153,7 +153,7 @@ fn script_function_mapped_arguments_not_accessed() {
         LinearPosition::default(),
         false,
     ));
-    let ok = script.analyze_scope(&scope, &interner);
+    let ok = script.analyze_scope(&scope, &interner).is_ok();
     assert!(ok);
     assert_eq!(scope.num_bindings(), 0);
 
@@ -239,7 +239,7 @@ fn script_function_mapped_arguments_accessed() {
         LinearPosition::default(),
         false,
     ));
-    let ok = script.analyze_scope(&scope, &interner);
+    let ok = script.analyze_scope(&scope, &interner).is_ok();
     assert!(ok);
     assert_eq!(scope.num_bindings(), 0);
     let StatementListItem::Declaration(declaration) = script.statements().first().unwrap() else {

--- a/core/engine/src/builtins/function/mod.rs
+++ b/core/engine/src/builtins/function/mod.rs
@@ -20,7 +20,7 @@ use crate::{
     context::intrinsics::{Intrinsics, StandardConstructor, StandardConstructors},
     environments::{EnvironmentStack, FunctionSlots, PrivateEnvironment, ThisBindingStatus},
     error::JsNativeError,
-    js_string,
+    js_error, js_string,
     native_function::NativeFunctionObject,
     object::{
         JsData, JsFunction, JsObject, PrivateElement, PrivateName,
@@ -647,10 +647,10 @@ impl BuiltInFunctionObject {
             false,
             Span::new(function_span_start, function_span_end),
         );
-        if !function.analyze_scope(strict, context.realm().scope(), context.interner()) {
-            return Err(JsNativeError::syntax()
-                .with_message("failed to analyze function scope")
-                .into());
+        if let Err(reason) =
+            function.analyze_scope(strict, context.realm().scope(), context.interner())
+        {
+            return Err(js_error!(SyntaxError: "failed to analyze function scope: {}", reason));
         }
 
         let in_with = context.vm.environments.has_object_environment();

--- a/core/parser/src/parser/mod.rs
+++ b/core/parser/src/parser/mod.rs
@@ -165,9 +165,9 @@ impl<'a, R: ReadChar> Parser<'a, R> {
     ) -> ParseResult<ScriptParseOutput> {
         self.cursor.set_goal(InputElement::HashbangOrRegExp);
         let (mut ast, source) = ScriptParser::new(false).parse(&mut self.cursor, interner)?;
-        if !ast.analyze_scope(scope, interner) {
+        if let Err(reason) = ast.analyze_scope(scope, interner) {
             return Err(Error::general(
-                "invalid scope analysis",
+                format!("invalid scope analysis: {reason}"),
                 Position::new(1, 1),
             ));
         }
@@ -211,9 +211,9 @@ impl<'a, R: ReadChar> Parser<'a, R> {
     {
         self.cursor.set_goal(InputElement::HashbangOrRegExp);
         let (mut module, source) = ModuleParser.parse(&mut self.cursor, interner)?;
-        if !module.analyze_scope(scope, interner) {
+        if let Err(reason) = module.analyze_scope(scope, interner) {
             return Err(Error::general(
-                "invalid scope analysis",
+                format!("invalid scope analysis: {reason}"),
                 Position::new(1, 1),
             ));
         }

--- a/core/parser/src/parser/tests/mod.rs
+++ b/core/parser/src/parser/tests/mod.rs
@@ -42,7 +42,9 @@ where
 {
     let mut script = Script::new(StatementList::from((expr.into(), PSEUDO_LINEAR_POS)));
     let scope = Scope::new_global();
-    script.analyze_scope(&scope, interner);
+    script
+        .analyze_scope(&scope, interner)
+        .expect("failed to analyze script");
     assert_eq!(
         Parser::new(Source::from_bytes(js))
             .parse_script(&Scope::new_global(), interner)
@@ -59,7 +61,9 @@ where
 {
     let mut module = Module::new(ModuleItemList::from(expr.into()));
     let scope = Scope::new_global();
-    module.analyze_scope(&scope, interner);
+    module
+        .analyze_scope(&scope, interner)
+        .expect("failed to analyze");
     assert_eq!(
         Parser::new(Source::from_bytes(js))
             .parse_module(&Scope::new_global(), interner)


### PR DESCRIPTION
This gives better error messages:

<img width="1677" height="278" alt="CleanShot 2025-09-04 at 11 44 05@2x" src="https://github.com/user-attachments/assets/045f5c96-3008-47bd-991b-f5a28f60ccdf" />

Prior to this PR, the message would simply say "invalid scope analysis" without any further reason.