### PR TITLE
Various quality of life improvements to the CLI

### DIFF
--- a/core/runtime/src/interval.rs
+++ b/core/runtime/src/interval.rs
@@ -91,7 +91,7 @@ fn handle(
     }
 
     handler_map.borrow_mut().clear_interval(id);
-    Ok(JsValue::undefined())
+    result
 }
 
 /// Set a timeout to call the given function after the given delay.


### PR DESCRIPTION
Allow an expression to be passed from the arguments (using -e). This makes it easier to just run a single expression and returning.

Additionally, if the value returned by a _file_ is undefined, don't show it. It gets confusing to see a list of "undefined" on the command line when running a bunch of modules in batch.

Another change is merging the error printing code so the output is more consistent. As well, I added distinction between an error thrown from a statement versus from a job, so the user can see where it's coming from.

Added support for timeout and generic jobs in the CLI. Now we can use setTimeout or any generic jobs. The CLI will always wait for all jobs to be completed before exiting, which makes setInterval a bit awkward if it has no end conditin.

Finally, fixed a bug in setTimeout where errors were not propagated properly.
