### PR TITLE
Implement `Date` and `RegExp` `JsValueStore` from/to

### DIFF
--- a/core/runtime/src/store/from.rs
+++ b/core/runtime/src/store/from.rs
@@ -49,7 +49,7 @@ fn try_from_js_object(
     Ok(new_value)
 }
 
-/// Transfer an object into a store, instead of cloning it. See [mdn].
+/// Transfer an object into a store instead of cloning it. See [mdn].
 ///
 /// Only [transferable objects][to] can be transferred. Anything else will return an
 /// error. Since any object t
@@ -134,6 +134,36 @@ fn clone_typed_array(
     Ok(dolly)
 }
 
+fn clone_date(
+    original: &JsObject,
+    date: &JsDate,
+    seen: &mut SeenMap,
+    context: &mut Context,
+) -> JsResult<JsValueStore> {
+    let msec_since_epoch = date
+        .get_time(context)?
+        .as_number()
+        .ok_or_else(unsupported_type)?;
+
+    let stored = JsValueStore::new(ValueStoreInner::Date(msec_since_epoch));
+    seen.insert(original, stored.clone());
+    Ok(stored)
+}
+
+fn clone_regexp(
+    original: &JsObject,
+    regexp: &JsRegExp,
+    seen: &mut SeenMap,
+    context: &mut Context,
+) -> JsResult<JsValueStore> {
+    let source = regexp.source(context)?;
+    let flags = regexp.flags(context)?;
+
+    let stored = JsValueStore::new(ValueStoreInner::RegExp { source, flags });
+    seen.insert(original, stored.clone());
+    Ok(stored)
+}
+
 fn try_from_map(
     original: &JsObject,
     map: &JsMap,
@@ -207,12 +237,12 @@ fn try_from_js_object_clone(
         return try_from_array_buffer_clone(object, buffer, seen);
     } else if let Ok(ref typed_array) = JsTypedArray::from_object(object.clone()) {
         return clone_typed_array(object, typed_array, transfer, seen, context);
-    } else if let Ok(_date) = JsDate::from_object(object.clone()) {
-        return Err(js_error!(TypeError: "Dates are not supported yet."));
+    } else if let Ok(ref date) = JsDate::from_object(object.clone()) {
+        return clone_date(object, date, seen, context);
     } else if let Ok(_error) = object.clone().downcast::<Error>() {
         return Err(js_error!(TypeError: "Errors are not supported yet."));
-    } else if let Ok(_regexp) = JsRegExp::from_object(object.clone()) {
-        return Err(js_error!(TypeError: "Regular Expressions are not supported yet."));
+    } else if let Ok(ref regexp) = JsRegExp::from_object(object.clone()) {
+        return clone_regexp(object, regexp, seen, context);
     } else if let Ok(_dataview) = JsDataView::from_object(object.clone()) {
         return Err(js_error!(TypeError: "Data views are not supported yet."));
     } else if object.is_callable() {

--- a/core/runtime/src/store/mod.rs
+++ b/core/runtime/src/store/mod.rs
@@ -87,8 +87,7 @@ enum ValueStoreInner {
 
     /// A `Date` object in JavaScript. Although this can be marshaled, it uses
     /// the system's datetime library to be reconstructed and may diverge.
-    #[expect(unused)]
-    Date(std::time::Instant),
+    Date(f64),
 
     /// Allowed error types (see the structured clone algorithm page).
     #[expect(unused)]
@@ -100,9 +99,10 @@ enum ValueStoreInner {
         cause: StringStore,
     },
 
-    /// Regular expression. We store the expression itself.
-    #[expect(unused)]
-    RegExp(StringStore),
+    /// Regular expression. We store the expression and its flags. Everything else
+    /// is reset. These are extracted as `String`, so we don't need to use the
+    /// [`StringStore`] type.
+    RegExp { source: String, flags: String },
 
     /// Array Buffer.
     ArrayBuffer(Vec<u8>),
@@ -111,8 +111,8 @@ enum ValueStoreInner {
     #[expect(unused)]
     DataView {
         buffer: JsValueStore,
-        byte_length: usize,
-        byte_offset: usize,
+        byte_length: u64,
+        byte_offset: u64,
     },
 
     /// Typed Array, including its kind and data.

--- a/core/runtime/src/store/to.rs
+++ b/core/runtime/src/store/to.rs
@@ -2,9 +2,9 @@
 use crate::store::{JsValueStore, StringStore, ValueStoreInner, unsupported_type};
 use boa_engine::builtins::typed_array::TypedArrayKind;
 use boa_engine::object::builtins::{
-    JsArray, JsArrayBuffer, JsMap, JsSet, js_typed_array_from_kind,
+    JsArray, JsArrayBuffer, JsDataView, JsDate, JsMap, JsRegExp, JsSet, js_typed_array_from_kind,
 };
-use boa_engine::{Context, JsBigInt, JsObject, JsResult, JsValue, js_error};
+use boa_engine::{Context, JsBigInt, JsObject, JsResult, JsString, JsValue, js_error};
 use std::collections::HashMap;
 
 #[derive(Default)]
@@ -123,6 +123,51 @@ fn try_into_js_set(
     Ok(JsValue::from(set))
 }
 
+fn try_into_js_date(
+    store: &JsValueStore,
+    msec: f64,
+    seen: &mut ReverseSeenMap,
+    context: &mut Context,
+) -> JsResult<JsValue> {
+    let date = JsDate::new(context);
+    date.set_time(msec, context)?;
+    seen.insert(store, date.clone().into());
+
+    Ok(JsValue::from(date))
+}
+
+fn try_into_regexp(
+    store: &JsValueStore,
+    source: &str,
+    flags: &str,
+    seen: &mut ReverseSeenMap,
+    context: &mut Context,
+) -> JsResult<JsValue> {
+    let re = JsRegExp::new(JsString::from(source), JsString::from(flags), context)?;
+    seen.insert(store, re.clone().into());
+    Ok(JsValue::from(re))
+}
+
+fn try_into_data_view(
+    store: &JsValueStore,
+    buffer: &JsValueStore,
+    byte_length: u64,
+    byte_offset: u64,
+    seen: &mut ReverseSeenMap,
+    context: &mut Context,
+) -> JsResult<JsValue> {
+    let buffer = try_value_into_js(buffer, seen, context)?;
+    let data_view = JsDataView::from_js_array_buffer(
+        JsArrayBuffer::from_object(buffer.as_object().ok_or_else(unsupported_type)?)?,
+        Some(byte_offset),
+        Some(byte_length),
+        context,
+    )?;
+
+    seen.insert(store, data_view.clone().into());
+    Ok(JsValue::from(data_view))
+}
+
 pub(super) fn try_value_into_js(
     store: &JsValueStore,
     seen: &mut ReverseSeenMap,
@@ -147,11 +192,17 @@ pub(super) fn try_value_into_js(
         ValueStoreInner::Map(key_values) => try_into_js_map(store, key_values, seen, context),
         ValueStoreInner::Set(values) => try_into_js_set(store, values, seen, context),
         ValueStoreInner::Array(items) => try_items_into_js_array(store, items, seen, context),
-        ValueStoreInner::Date(_) => Err(js_error!("Not yet implemented.")),
+        ValueStoreInner::Date(msec) => try_into_js_date(store, *msec, seen, context),
         ValueStoreInner::Error { .. } => Err(js_error!("Not yet implemented.")),
-        ValueStoreInner::RegExp(_) => Err(js_error!("Not yet implemented.")),
+        ValueStoreInner::RegExp { source, flags } => {
+            try_into_regexp(store, source, flags, seen, context)
+        }
         ValueStoreInner::ArrayBuffer(data) => try_into_js_array_buffer(store, data, seen, context),
-        ValueStoreInner::DataView { .. } => Err(js_error!("Not yet implemented.")),
+        ValueStoreInner::DataView {
+            buffer,
+            byte_length,
+            byte_offset,
+        } => try_into_data_view(store, buffer, *byte_length, *byte_offset, seen, context),
         ValueStoreInner::TypedArray { kind, buffer } => {
             try_into_js_typed_array(store, *kind, buffer, seen, context)
         }

--- a/core/runtime/tests/clone/complex.js
+++ b/core/runtime/tests/clone/complex.js
@@ -1,78 +1,81 @@
-class SomeClass {
-  constructor() {
-    this.a = 42n;
-    this.x = 1;
-    this.repeat = this;
-    this.repeatArray = [this, this, this];
+// Create a new scope to prevent global namespace poisoning.
+{
+  class SomeClass {
+    constructor() {
+      this.a = 42n;
+      this.x = 1;
+      this.repeat = this;
+      this.repeatArray = [this, this, this];
+    }
   }
+
+  const buffer = new Uint8Array([1, 2, 3, 4]);
+  const buffer2 = new Uint8Array([5, 6, 7, 8]);
+  const buffer3 = new Uint32Array([9, 10, 11, 12]);
+  const buffer4 = new Uint32Array([13, 14, 15, 16]);
+  const arrayBuffer = new ArrayBuffer(16);
+  new DataView(arrayBuffer).setUint32(0, 100);
+  const arrayBuffer2 = new ArrayBuffer(10);
+  new DataView(arrayBuffer2).setUint32(1, 101);
+
+  const original = {
+    some: new SomeClass(),
+    buffer,
+    bufferTArray: [buffer, buffer, buffer, buffer],
+    buffer2,
+    buffer2Array: [buffer2, buffer2, buffer2, buffer2],
+    buffer3,
+    buffer4,
+    arrayBuffer,
+    arrayBuffer2,
+  };
+
+  let dolly = structuredClone(original, {
+    transfer: [buffer.buffer, buffer3.buffer, arrayBuffer2],
+  });
+
+  assertEq(buffer.byteLength, 0);
+  assertEq(buffer2.byteLength, 4);
+  assertEq(buffer3.byteLength, 0);
+  assertThrows(() => {
+    new Uint8Array(buffer);
+  });
+  assertThrows(() => {
+    new Uint32Array(buffer3);
+  });
+
+  assertEq(dolly.buffer.constructor, Uint8Array);
+  assertEq(dolly.buffer.byteLength, 4);
+  assertEq(dolly.buffer2.constructor, Uint8Array);
+  assertEq(dolly.buffer2.byteLength, 4);
+  assertEq(dolly.buffer3.constructor, Uint32Array);
+  assertEq(dolly.buffer3.byteLength, 16);
+  assertEq(dolly.buffer4.constructor, Uint32Array);
+  assertEq(dolly.buffer4.byteLength, 16);
+
+  assertArrayEqual(dolly.buffer, [1, 2, 3, 4]);
+  assertEq(dolly.buffer, dolly.bufferTArray[0]);
+  assertEq(dolly.bufferTArray[0], dolly.bufferTArray[1]);
+  assertEq(dolly.bufferTArray[0], dolly.bufferTArray[2]);
+  assertEq(dolly.bufferTArray[0], dolly.bufferTArray[3]);
+
+  assertArrayEqual(dolly.buffer2, [5, 6, 7, 8]);
+  assertEq(dolly.buffer2Array[0], dolly.buffer2Array[1]);
+  assertEq(dolly.buffer2Array[0], dolly.buffer2Array[2]);
+  assertEq(dolly.buffer2Array[0], dolly.buffer2Array[3]);
+
+  assertArrayEqual(dolly.buffer3, [9, 10, 11, 12]);
+  assertArrayEqual(dolly.buffer4, [13, 14, 15, 16]);
+
+  assertNEq(dolly.some.constructor, SomeClass);
+  assertEq(dolly.some.a, 42n);
+  assertEq(dolly.some.x, 1);
+  assertEq(dolly.some.repeat, dolly.some);
+
+  assertNEq(dolly.arrayBuffer, arrayBuffer);
+  assertEq(dolly.arrayBuffer.byteLength, 16);
+  assertEq(new DataView(dolly.arrayBuffer).getUint32(0), 100);
+  assertNEq(dolly.arrayBuffer2, arrayBuffer2);
+  assertEq(dolly.arrayBuffer2.byteLength, 10);
+  assertEq(new DataView(dolly.arrayBuffer2).getUint32(1), 101);
 }
-
-const buffer = new Uint8Array([1, 2, 3, 4]);
-const buffer2 = new Uint8Array([5, 6, 7, 8]);
-const buffer3 = new Uint32Array([9, 10, 11, 12]);
-const buffer4 = new Uint32Array([13, 14, 15, 16]);
-const arrayBuffer = new ArrayBuffer(16);
-new DataView(arrayBuffer).setUint32(0, 100);
-const arrayBuffer2 = new ArrayBuffer(10);
-new DataView(arrayBuffer2).setUint32(1, 101);
-
-const original = {
-  some: new SomeClass(),
-  buffer,
-  bufferTArray: [buffer, buffer, buffer, buffer],
-  buffer2,
-  buffer2Array: [buffer2, buffer2, buffer2, buffer2],
-  buffer3,
-  buffer4,
-  arrayBuffer,
-  arrayBuffer2,
-};
-
-let dolly = structuredClone(original, {
-  transfer: [buffer.buffer, buffer3.buffer, arrayBuffer2],
-});
-
-assertEq(buffer.byteLength, 0);
-assertEq(buffer2.byteLength, 4);
-assertEq(buffer3.byteLength, 0);
-assertThrows(() => {
-  new Uint8Array(buffer);
-});
-assertThrows(() => {
-  new Uint32Array(buffer3);
-});
-
-assertEq(dolly.buffer.constructor, Uint8Array);
-assertEq(dolly.buffer.byteLength, 4);
-assertEq(dolly.buffer2.constructor, Uint8Array);
-assertEq(dolly.buffer2.byteLength, 4);
-assertEq(dolly.buffer3.constructor, Uint32Array);
-assertEq(dolly.buffer3.byteLength, 16);
-assertEq(dolly.buffer4.constructor, Uint32Array);
-assertEq(dolly.buffer4.byteLength, 16);
-
-assertArrayEqual(dolly.buffer, [1, 2, 3, 4]);
-assertEq(dolly.buffer, dolly.bufferTArray[0]);
-assertEq(dolly.bufferTArray[0], dolly.bufferTArray[1]);
-assertEq(dolly.bufferTArray[0], dolly.bufferTArray[2]);
-assertEq(dolly.bufferTArray[0], dolly.bufferTArray[3]);
-
-assertArrayEqual(dolly.buffer2, [5, 6, 7, 8]);
-assertEq(dolly.buffer2Array[0], dolly.buffer2Array[1]);
-assertEq(dolly.buffer2Array[0], dolly.buffer2Array[2]);
-assertEq(dolly.buffer2Array[0], dolly.buffer2Array[3]);
-
-assertArrayEqual(dolly.buffer3, [9, 10, 11, 12]);
-assertArrayEqual(dolly.buffer4, [13, 14, 15, 16]);
-
-assertNEq(dolly.some.constructor, SomeClass);
-assertEq(dolly.some.a, 42n);
-assertEq(dolly.some.x, 1);
-assertEq(dolly.some.repeat, dolly.some);
-
-assertNEq(dolly.arrayBuffer, arrayBuffer);
-assertEq(dolly.arrayBuffer.byteLength, 16);
-assertEq(new DataView(dolly.arrayBuffer).getUint32(0), 100);
-assertNEq(dolly.arrayBuffer2, arrayBuffer2);
-assertEq(dolly.arrayBuffer2.byteLength, 10);
-assertEq(new DataView(dolly.arrayBuffer2).getUint32(1), 101);

--- a/core/runtime/tests/clone/date.js
+++ b/core/runtime/tests/clone/date.js
@@ -1,0 +1,22 @@
+{
+  const date1 = new Date();
+  const date2 = new Date(date1.getTime());
+
+  // Make sure the world makes sense.
+  assertNEq(date1, date2, "Two different date objects should not be equal");
+
+  const x = {
+    first: date1,
+    second: date1,
+    third: date2,
+  };
+
+  const xx = structuredClone(x);
+
+  assertEq(xx.first, xx.second, "These should be the same object.");
+  assertNEq(
+    xx.second,
+    xx.third,
+    "Second and Third should NOT be the same object.",
+  );
+}

--- a/core/runtime/tests/clone/regexp.js
+++ b/core/runtime/tests/clone/regexp.js
@@ -1,0 +1,31 @@
+{
+  const re1 = new RegExp("abc", "i");
+  const re2 = /abc/i;
+
+  // Make sure the world makes sense.
+  assertNEq(re1, re2, "Two different regexp objects should not be equal");
+
+  const x = {
+    first: re1,
+    second: re1,
+    third: re2,
+    fourth: re2,
+  };
+
+  const xx = structuredClone(x);
+
+  assertEq(xx.first, xx.second, "These should be the same object.");
+  assertNEq(
+    xx.second,
+    xx.third,
+    "Second and Third should NOT be the same object.",
+  );
+  assertEq(xx.third, xx.fourth, "These should be the same object.");
+
+  assert(xx.first.test("def ABC def"));
+  assertEq(
+    Object.getPrototypeOf(xx.first),
+    Object.getPrototypeOf(xx.second),
+    "These should be have the same prototype.",
+  );
+}


### PR DESCRIPTION
`DataView`s are complex as they become invalid when the buffer is transferred, and JsError should be its own thing as it's missing lots of APIs in Boa.
