### PR TITLE
Unblock Context::run_jobs when no timeouts need to be run

### DIFF
--- a/cli/src/logger.rs
+++ b/cli/src/logger.rs
@@ -1,0 +1,65 @@
+use boa_engine::{Context, Finalize, JsResult, Trace};
+use boa_runtime::{ConsoleState, Logger};
+use rustyline::ExternalPrinter;
+use std::fmt::Debug;
+use std::sync::{Arc, Mutex};
+
+#[derive(Clone, Trace, Finalize)]
+pub(crate) struct SharedExternalPrinterLogger {
+    #[unsafe_ignore_trace]
+    inner: Arc<Mutex<Option<Box<dyn ExternalPrinter + Send>>>>,
+}
+
+impl SharedExternalPrinterLogger {
+    pub(crate) fn new() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    pub(crate) fn set<T: ExternalPrinter + Send + 'static>(&self, inner: T) {
+        self.inner
+            .lock()
+            .expect("printer lock failed")
+            .replace(Box::new(inner));
+    }
+
+    pub(crate) fn print(&self, message: String) {
+        if let Some(l) = &mut *self.inner.lock().expect("printer lock failed") {
+            // Ignore errors, there's nothing we can do at this point.
+            drop(l.print(message));
+        }
+    }
+}
+
+impl Debug for SharedExternalPrinterLogger {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SharedExternalPrinterLogger").finish()
+    }
+}
+
+impl Logger for SharedExternalPrinterLogger {
+    #[inline]
+    fn log(&self, msg: String, state: &ConsoleState, _context: &mut Context) -> JsResult<()> {
+        let indent = state.indent();
+        self.print(format!("{msg:>indent$}\n"));
+        Ok(())
+    }
+
+    #[inline]
+    fn info(&self, msg: String, state: &ConsoleState, context: &mut Context) -> JsResult<()> {
+        self.log(msg, state, context)
+    }
+
+    #[inline]
+    fn warn(&self, msg: String, state: &ConsoleState, context: &mut Context) -> JsResult<()> {
+        self.log(msg, state, context)
+    }
+
+    #[inline]
+    fn error(&self, msg: String, state: &ConsoleState, _context: &mut Context) -> JsResult<()> {
+        let indent = state.indent();
+        self.print(format!("{msg:>indent$}\n"));
+        Ok(())
+    }
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -9,7 +9,9 @@
 
 mod debug;
 mod helper;
+mod logger;
 
+use crate::logger::SharedExternalPrinterLogger;
 use boa_engine::context::time::JsInstant;
 use boa_engine::job::{GenericJob, TimeoutJob};
 use boa_engine::{
@@ -32,6 +34,8 @@ use colored::Colorize;
 use debug::init_boa_debug_object;
 use rustyline::{EditMode, Editor, config::Config, error::ReadlineError};
 use std::collections::BTreeMap;
+use std::sync::mpsc::{Sender, TryRecvError};
+use std::time::Duration;
 use std::{
     cell::RefCell,
     collections::VecDeque,
@@ -41,7 +45,10 @@ use std::{
     path::{Path, PathBuf},
     println,
     rc::Rc,
+    thread,
 };
+
+// ----
 
 #[cfg(all(
     target_arch = "x86_64",
@@ -276,19 +283,26 @@ fn generate_flowgraph<R: ReadChar>(
     Ok(result)
 }
 
-fn uncaught_error(error: &JsError) {
-    eprintln!("{}: {}", "Uncaught".red(), error.to_string().red());
+#[must_use]
+fn uncaught_error(error: &JsError) -> String {
+    format!("{}: {}\n", "Uncaught".red(), error.to_string().red())
 }
 
-fn uncaught_job_error(error: &JsError) {
-    eprintln!(
-        "{}: {}",
+#[must_use]
+fn uncaught_job_error(error: &JsError) -> String {
+    format!(
+        "{}: {}\n",
         "Uncaught error (during job evaluation)".red(),
         error.to_string().red()
-    );
+    )
 }
 
-fn evaluate_expr(line: &str, args: &Opt, context: &mut Context) -> Result<()> {
+fn evaluate_expr(
+    line: &str,
+    args: &Opt,
+    context: &mut Context,
+    printer: &SharedExternalPrinterLogger,
+) -> Result<()> {
     if args.has_dump_flag() {
         dump(Source::from_bytes(&line), args, context)?;
     } else if let Some(flowgraph) = args.flowgraph {
@@ -303,11 +317,8 @@ fn evaluate_expr(line: &str, args: &Opt, context: &mut Context) -> Result<()> {
         }
     } else {
         match context.eval(Source::from_bytes(line)) {
-            Ok(v) => println!("{}", v.display()),
-            Err(ref v) => uncaught_error(v),
-        }
-        if let Err(err) = context.run_jobs() {
-            eprintln!("{err}");
+            Ok(v) => printer.print(format!("{}\n", v.display())),
+            Err(ref v) => printer.print(uncaught_error(v)),
         }
     }
 
@@ -319,6 +330,7 @@ fn evaluate_file(
     args: &Opt,
     context: &mut Context,
     loader: &SimpleModuleLoader,
+    printer: &SharedExternalPrinterLogger,
 ) -> Result<()> {
     if args.has_dump_flag() {
         return dump(Source::from_filepath(file)?, args, context);
@@ -366,7 +378,7 @@ fn evaluate_file(
                 println!("{}", v.display());
             }
         }
-        Err(v) => uncaught_error(&v),
+        Err(v) => printer.print(uncaught_error(&v)),
     }
 
     context
@@ -374,9 +386,14 @@ fn evaluate_file(
         .map_err(|err| err.into_erased(context).into())
 }
 
-fn evaluate_files(args: &Opt, context: &mut Context, loader: &SimpleModuleLoader) -> Result<()> {
+fn evaluate_files(
+    args: &Opt,
+    context: &mut Context,
+    loader: &SimpleModuleLoader,
+    printer: &SharedExternalPrinterLogger,
+) -> Result<()> {
     for file in &args.files {
-        evaluate_file(file, args, context, loader)?;
+        evaluate_file(file, args, context, loader, printer)?;
     }
     Ok(())
 }
@@ -392,7 +409,13 @@ fn main() -> Result<()> {
 
     let args = Opt::parse();
 
-    let executor = Rc::new(Executor::default());
+    // A channel of expressions to run.
+    let (sender, receiver) = std::sync::mpsc::channel::<String>();
+    let printer = SharedExternalPrinterLogger::new();
+    // Start the thread early so we can pass the printer to our console logger.
+    let handle = start_readline_thread(sender, printer.clone(), args.vi_mode);
+
+    let executor = Rc::new(Executor::new(printer.clone()));
     let loader = Rc::new(SimpleModuleLoader::new(&args.root).map_err(|e| eyre!(e.to_string()))?);
     let mut context = ContextBuilder::new()
         .job_executor(executor)
@@ -404,7 +427,7 @@ fn main() -> Result<()> {
     context.strict(args.strict);
 
     // Add `console`.
-    add_runtime(&mut context);
+    add_runtime(printer.clone(), &mut context);
 
     // Trace Output
     context.set_trace(args.trace);
@@ -420,21 +443,52 @@ fn main() -> Result<()> {
     context.set_optimizer_options(optimizer_options);
 
     if !args.files.is_empty() {
-        evaluate_files(&args, &mut context, &loader)?;
+        evaluate_files(&args, &mut context, &loader, &printer)?;
 
         if let Some(ref expr) = args.expression {
-            evaluate_expr(expr, &args, &mut context)?;
+            evaluate_expr(expr, &args, &mut context, &printer)?;
         }
 
         return Ok(());
     } else if let Some(ref expr) = args.expression {
-        evaluate_expr(expr, &args, &mut context)?;
+        evaluate_expr(expr, &args, &mut context, &printer)?;
         return Ok(());
     }
 
+    loop {
+        match receiver.try_recv() {
+            Ok(line) => {
+                if let Err(err) = context.run_jobs() {
+                    printer.print(uncaught_job_error(&err));
+                }
+
+                evaluate_expr(&line, &args, &mut context, &printer)?;
+            }
+            Err(TryRecvError::Empty) => {
+                thread::sleep(Duration::from_millis(10));
+                if let Err(err) = context.run_jobs() {
+                    printer.print(uncaught_job_error(&err));
+                }
+            }
+            Err(_err) => {
+                break;
+            }
+        }
+    }
+
+    handle.join().expect("failed to join thread");
+
+    Ok(())
+}
+
+fn readline_thread_main(
+    sender: &Sender<String>,
+    printer_out: &SharedExternalPrinterLogger,
+    vi_mode: bool,
+) -> Result<()> {
     let config = Config::builder()
         .keyseq_timeout(Some(1))
-        .edit_mode(if args.vi_mode {
+        .edit_mode(if vi_mode {
             EditMode::Vi
         } else {
             EditMode::Emacs
@@ -443,6 +497,9 @@ fn main() -> Result<()> {
 
     let mut editor =
         Editor::with_config(config).wrap_err("failed to set the editor configuration")?;
+    let printer = editor.create_external_printer()?;
+    printer_out.set(printer);
+
     // Check if the history file exists. If it doesn't, create it.
     OpenOptions::new()
         .read(true)
@@ -463,10 +520,9 @@ fn main() -> Result<()> {
 
             Ok(line) => {
                 let line = line.trim_end();
-
                 editor.add_history_entry(line).map_err(io::Error::other)?;
-
-                evaluate_expr(line, &args, &mut context)?;
+                sender.send(line.to_string())?;
+                thread::sleep(Duration::from_millis(10));
             }
 
             Err(err) => {
@@ -486,11 +542,25 @@ fn main() -> Result<()> {
     Ok(())
 }
 
+/// Create the readline thread which sends lines from stdin back to the main thread.
+fn start_readline_thread(
+    sender: Sender<String>,
+    printer_out: SharedExternalPrinterLogger,
+    vi_mode: bool,
+) -> thread::JoinHandle<()> {
+    thread::spawn(
+        move || match readline_thread_main(&sender, &printer_out, vi_mode) {
+            Ok(()) => {}
+            Err(e) => eprintln!("readline thread failed: {e}"),
+        },
+    )
+}
+
 /// Adds the CLI runtime to the context with default options.
-fn add_runtime(context: &mut Context) {
+fn add_runtime(printer: SharedExternalPrinterLogger, context: &mut Context) {
     boa_runtime::register(
         (
-            boa_runtime::extensions::ConsoleExtension::default(),
+            boa_runtime::extensions::ConsoleExtension(printer),
             #[cfg(feature = "fetch")]
             boa_runtime::extensions::FetchExtension(
                 boa_runtime::fetch::BlockingReqwestFetcher::default(),
@@ -503,15 +573,26 @@ fn add_runtime(context: &mut Context) {
 }
 
 #[allow(clippy::struct_field_names)]
-#[derive(Default)]
 struct Executor {
     promise_jobs: RefCell<VecDeque<PromiseJob>>,
     async_jobs: RefCell<VecDeque<NativeAsyncJob>>,
     timeout_jobs: RefCell<BTreeMap<JsInstant, TimeoutJob>>,
     generic_jobs: RefCell<VecDeque<GenericJob>>,
+
+    printer: SharedExternalPrinterLogger,
 }
 
 impl Executor {
+    fn new(printer: SharedExternalPrinterLogger) -> Self {
+        Self {
+            promise_jobs: RefCell::default(),
+            async_jobs: RefCell::default(),
+            timeout_jobs: RefCell::default(),
+            generic_jobs: RefCell::default(),
+            printer,
+        }
+    }
+
     fn is_empty(&self, context: &mut Context) -> bool {
         let now = context.clock().now();
 
@@ -534,7 +615,7 @@ impl Executor {
 
         for job in jobs_to_run.into_values() {
             if let Err(e) = job.call(context) {
-                uncaught_job_error(&e);
+                self.printer.print(uncaught_job_error(&e));
             }
         }
     }
@@ -544,7 +625,7 @@ impl Executor {
         if let Some(generic) = job
             && let Err(err) = generic.call(context)
         {
-            uncaught_job_error(&err);
+            self.printer.print(uncaught_job_error(&err));
         }
     }
 }
@@ -561,7 +642,7 @@ impl JobExecutor for Executor {
                     .insert(now + job.timeout(), job);
             }
             Job::GenericJob(job) => self.generic_jobs.borrow_mut().push_back(job),
-            job => eprintln!("unsupported job type {job:?}"),
+            job => self.printer.print(format!("unsupported job type {job:?}")),
         }
     }
 
@@ -579,19 +660,19 @@ impl JobExecutor for Executor {
             let jobs = std::mem::take(&mut *self.promise_jobs.borrow_mut());
             for job in jobs {
                 if let Err(e) = job.call(context) {
-                    uncaught_job_error(&e);
+                    self.printer.print(uncaught_job_error(&e));
                 }
             }
 
             let async_jobs = std::mem::take(&mut *self.async_jobs.borrow_mut());
             for async_job in async_jobs {
                 if let Err(e) = pollster::block_on(async_job.call(&RefCell::new(context))) {
-                    uncaught_job_error(&e);
+                    self.printer.print(uncaught_job_error(&e));
                 }
                 let jobs = std::mem::take(&mut *self.promise_jobs.borrow_mut());
                 for job in jobs {
                     if let Err(e) = job.call(context) {
-                        uncaught_job_error(&e);
+                        self.printer.print(uncaught_job_error(&e));
                     }
                 }
             }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -513,10 +513,13 @@ struct Executor {
 
 impl Executor {
     fn is_empty(&self, context: &mut Context) -> bool {
+        let now = context.clock().now();
+
         !context.has_pending_context_jobs()
             && self.promise_jobs.borrow().is_empty()
             && self.async_jobs.borrow().is_empty()
-            && self.timeout_jobs.borrow().is_empty()
+            // The timeout jobs queue is empty IIF there are no jobs to execute right now.
+            && !self.timeout_jobs.borrow().iter().any(|(t, _)| &now >= t)
             && self.generic_jobs.borrow().is_empty()
     }
 

--- a/core/engine/src/job.rs
+++ b/core/engine/src/job.rs
@@ -695,7 +695,6 @@ impl JobExecutor for SimpleJobExecutor {
                 && self.async_jobs.borrow().is_empty()
                 && self.generic_jobs.borrow().is_empty()
                 && no_timeout_jobs_to_run
-                && self.timeout_jobs.borrow().is_empty()
                 && group.is_empty()
             {
                 break;

--- a/core/engine/src/job.rs
+++ b/core/engine/src/job.rs
@@ -157,6 +157,10 @@ pub struct TimeoutJob {
     job: NativeJob,
     /// Signals if the timeout job was cancelled.
     cancelled: OnceFlag,
+    /// Signals that this job is recurring. A recurring job shouldn't be
+    /// awaited for when considering whether a run of the event loop is
+    /// done.
+    recurring: bool,
 }
 
 impl TimeoutJob {
@@ -167,6 +171,18 @@ impl TimeoutJob {
             timeout: JsDuration::from_millis(timeout_in_millis),
             job,
             cancelled: OnceFlag::new(),
+            recurring: false,
+        }
+    }
+
+    /// Create a new `TimeoutJob` that is marked as recurring.
+    #[must_use]
+    pub fn recurring(job: NativeJob, timeout_in_millis: u64) -> Self {
+        Self {
+            timeout: JsDuration::from_millis(timeout_in_millis),
+            job,
+            cancelled: OnceFlag::new(),
+            recurring: true,
         }
     }
 
@@ -215,6 +231,12 @@ impl TimeoutJob {
     /// Returns the `OnceFlag` to cancel this timeout job.
     pub(crate) fn cancelled_flag(&self) -> OnceFlag {
         self.cancelled.clone()
+    }
+
+    /// Returns `true` if the job is recurring (meaning it happens regularly).
+    #[must_use]
+    pub fn is_recurring(&self) -> bool {
+        self.recurring
     }
 }
 
@@ -656,10 +678,16 @@ impl JobExecutor for SimpleJobExecutor {
         Self: Sized,
     {
         loop {
+            // There are no timeout jobs to run IIF there are no jobs to execute right now.
+            let no_timeout_jobs_to_run = {
+                let now = context.borrow().clock().now();
+                !self.timeout_jobs.borrow().iter().any(|(t, _)| &now >= t)
+            };
+
             if self.promise_jobs.borrow().is_empty()
                 && self.async_jobs.borrow().is_empty()
                 && self.generic_jobs.borrow().is_empty()
-                && self.timeout_jobs.borrow().is_empty()
+                && no_timeout_jobs_to_run
                 && !context.borrow().has_pending_context_jobs()
             {
                 break;

--- a/core/runtime/src/interval.rs
+++ b/core/runtime/src/interval.rs
@@ -79,7 +79,7 @@ fn handle(
     let result = function_ref.call(&JsValue::undefined(), &args, context);
     if let Some(delay) = reschedule {
         if handler_map.borrow().is_interval_valid(id) {
-            let job = TimeoutJob::new(
+            let job = TimeoutJob::recurring(
                 NativeJob::new(move |context| {
                     handle(handler_map, id, function_ref, args, reschedule, context)
                 }),


### PR DESCRIPTION
Prior to this PR, `run_jobs()` would block as long as there would be timeout jobs, even if they were in the future. A good example is using `setInterval` would run an infinite loop in `run_jobs()`.

This PR unblock `run_jobs()` when the jobs do not need to be run right now.

The new tests would infinite loop prior to this PR.

This PR also moved the code for the CLI prompt to a separate thread so the JavaScript code isn't waiting on prompts before executing tasks. This means that intervals/timeouts/promises/etc return immediately and will output their logs and move the prompt without interupting the user.