### PR TITLE
fix(regexp): fix the capture group count assert to have the correct upper limit

### DIFF
--- a/core/engine/src/builtins/regexp/mod.rs
+++ b/core/engine/src/builtins/regexp/mod.rs
@@ -1026,8 +1026,7 @@ impl RegExp {
         let n = match_value.captures.len() as u64;
         // 18. Assert: n = R.[[RegExpRecord]].[[CapturingGroupsCount]].
         // 19. Assert: n < 232 - 1.
-        const MAX_CAPTURE_GROUPS: u64 = (1u64 << 32) - 1;
-        debug_assert!(n < MAX_CAPTURE_GROUPS);
+        debug_assert!(n < (1u64 << 32) - 1);
 
 
         // 20. Let A be ! ArrayCreate(n + 1).

--- a/core/engine/src/builtins/regexp/mod.rs
+++ b/core/engine/src/builtins/regexp/mod.rs
@@ -1028,7 +1028,6 @@ impl RegExp {
         // 19. Assert: n < 232 - 1.
         debug_assert!(n < (1u64 << 32) - 1);
 
-
         // 20. Let A be ! ArrayCreate(n + 1).
         // 21. Assert: The mathematical value of A's "length" property is n + 1.
         let a = Array::array_create(n + 1, None, context)?;

--- a/core/engine/src/builtins/regexp/mod.rs
+++ b/core/engine/src/builtins/regexp/mod.rs
@@ -1026,7 +1026,12 @@ impl RegExp {
         let n = match_value.captures.len() as u64;
         // 18. Assert: n = R.[[RegExpRecord]].[[CapturingGroupsCount]].
         // 19. Assert: n < 232 - 1.
-        debug_assert!(n < 23u64.pow(2) - 1);
+        if n >= 23u64.pow(2) - 1 {
+            return Err(JsNativeError::typ()
+                .with_message("Too many capture groups in RegExp")
+                .into());
+        }
+
 
         // 20. Let A be ! ArrayCreate(n + 1).
         // 21. Assert: The mathematical value of A's "length" property is n + 1.

--- a/core/engine/src/builtins/regexp/mod.rs
+++ b/core/engine/src/builtins/regexp/mod.rs
@@ -1026,11 +1026,8 @@ impl RegExp {
         let n = match_value.captures.len() as u64;
         // 18. Assert: n = R.[[RegExpRecord]].[[CapturingGroupsCount]].
         // 19. Assert: n < 232 - 1.
-        if n >= 23u64.pow(2) - 1 {
-            return Err(JsNativeError::typ()
-                .with_message("Too many capture groups in RegExp")
-                .into());
-        }
+        const MAX_CAPTURE_GROUPS: u64 = (1u64 << 32) - 1;
+        debug_assert!(n < MAX_CAPTURE_GROUPS);
 
 
         // 20. Let A be ! ArrayCreate(n + 1).

--- a/core/engine/src/builtins/regexp/tests.rs
+++ b/core/engine/src/builtins/regexp/tests.rs
@@ -225,3 +225,20 @@ fn regular_expression_construction_independant_of_global_reg_exp() {
         TestAction::run(regex),
     ]);
 }
+
+#[test]
+fn regexp_many_captures_should_return_typeerror() {
+    run_test_actions([TestAction::assert_native_error(
+        indoc! {r#"
+            let num_captures = 1000;
+            let regexp_string = "(a)";
+            for (let i = 0; i < num_captures - 1; i++) {
+                regexp_string += "|()";
+            }
+            let regexp = new RegExp(regexp_string);
+            regexp.exec("a");
+        "#},
+        JsNativeErrorKind::Type,
+        "Too many capture groups in RegExp",
+    )]);
+}

--- a/core/engine/src/builtins/regexp/tests.rs
+++ b/core/engine/src/builtins/regexp/tests.rs
@@ -225,20 +225,3 @@ fn regular_expression_construction_independant_of_global_reg_exp() {
         TestAction::run(regex),
     ]);
 }
-
-#[test]
-fn regexp_many_captures_should_return_typeerror() {
-    run_test_actions([TestAction::assert_native_error(
-        indoc! {r#"
-            let num_captures = 1000;
-            let regexp_string = "(a)";
-            for (let i = 0; i < num_captures - 1; i++) {
-                regexp_string += "|()";
-            }
-            let regexp = new RegExp(regexp_string);
-            regexp.exec("a");
-        "#},
-        JsNativeErrorKind::Type,
-        "Too many capture groups in RegExp",
-    )]);
-}


### PR DESCRIPTION
This Pull Request fixes #4399.

It changes the following:

- Raise the limit to what the standard is requiring. It was too low and could be reach easily in real world cases before.