### PR TITLE
Fix the CLI when it is not attached to a TTY

### DIFF
--- a/cli/src/logger.rs
+++ b/cli/src/logger.rs
@@ -2,6 +2,7 @@ use boa_engine::{Context, Finalize, JsResult, Trace};
 use boa_runtime::{ConsoleState, Logger};
 use rustyline::ExternalPrinter;
 use std::fmt::Debug;
+use std::io::Write;
 use std::sync::{Arc, Mutex};
 
 #[derive(Clone, Trace, Finalize)]
@@ -28,6 +29,8 @@ impl SharedExternalPrinterLogger {
         if let Some(l) = &mut *self.inner.lock().expect("printer lock failed") {
             // Ignore errors, there's nothing we can do at this point.
             drop(l.print(message));
+        } else {
+            drop(std::io::stdout().write_all(message.as_bytes()));
         }
     }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -494,8 +494,9 @@ fn readline_thread_main(
 
     let mut editor =
         Editor::with_config(config).wrap_err("failed to set the editor configuration")?;
-    let printer = editor.create_external_printer()?;
-    printer_out.set(printer);
+    if let Ok(printer) = editor.create_external_printer() {
+        printer_out.set(printer);
+    }
 
     // Check if the history file exists. If it doesn't, create it.
     OpenOptions::new()

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -415,8 +415,6 @@ fn main() -> Result<()> {
     // A channel of expressions to run.
     let (sender, receiver) = std::sync::mpsc::channel::<String>();
     let printer = SharedExternalPrinterLogger::new();
-    // Start the thread early so we can pass the printer to our console logger.
-    let handle = start_readline_thread(sender, printer.clone(), args.vi_mode);
 
     let executor = Rc::new(Executor::new(printer.clone()));
     let loader = Rc::new(SimpleModuleLoader::new(&args.root).map_err(|e| eyre!(e.to_string()))?);
@@ -457,6 +455,8 @@ fn main() -> Result<()> {
         evaluate_expr(expr, &args, &mut context, &printer)?;
         return Ok(());
     }
+
+    let handle = start_readline_thread(sender, printer.clone(), args.vi_mode);
 
     loop {
         match receiver.try_recv() {


### PR DESCRIPTION
This a simple fix when the CLI is not attached to a TTY. In those cases it would print an error `readline thread failed: ENOTTY: Not a typewriter`.

This fixes it by doing three things;
1. by default, if no printers has been set, use stdout normally. This makes sense as if any logging occurs before readline can be initialized, we still want to see it.
2. move back starting the readline loop after args files/expressions are handled.
3. if we cannot build a writer for some reason, don't stop the thread. `readline` still works, but printers won't, so we just show logs on stdout. This can happen if STDIN is a pipe.

