### PR TITLE
Use same cache key for builds and tests

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -16,16 +16,17 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
             binary_extension: ""
-          - target: x86_64-apple-darwin
-            os: macos-13
-            binary_extension: ""
+            arch : X64
           - target: aarch64-apple-darwin
             os: macos-14
+            arch : ARM64
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-24.04-arm
+            arch : ARM64
             binary_extension: ""
           - target: x86_64-pc-windows-msvc
             os: windows-latest
+            arch : X64
             binary_extension: ".exe"
     runs-on: ${{ matrix.os }}
     steps:
@@ -37,6 +38,16 @@ jobs:
         with:
           toolchain: stable
           targets: ${{ matrix.target }}
+
+      - name: Restore cache
+        id: cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ matrix.os }}-${{ matrix.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Build
         run: cargo build --target ${{ matrix.target }} --release --locked --bin boa

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -34,7 +34,7 @@ jobs:
             target
             ~/.cargo/git
             ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - uses: boa-dev/criterion-compare-action@v3.2.4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,23 +82,22 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build: [linux, macos-amd64, macos-arm64, win-msvc]
+        build: [linux, macos-arm64, win-msvc]
         include:
         - build: linux
-          os: ubuntu-20.04
+          os: ubuntu-latest
           target: x86_64-unknown-linux-gnu
-          binary_extension: ""
-        - build: macos-amd64
-          os: macos-13
-          target: x86_64-apple-darwin
+          arch: X64
           binary_extension: ""
         - build: macos-arm64
           os: macos-14
           target: aarch64-apple-darwin
+          arch : ARM64
           binary_extension: ""
         - build: win-msvc
-          os: windows-2019
+          os: windows-latest
           target: x86_64-pc-windows-msvc
+          arch : X64
           binary_extension: ".exe"
     runs-on: ${{ matrix.os }}
     steps:
@@ -110,6 +109,15 @@ jobs:
         with:
           toolchain: stable
           targets: ${{ matrix.target }}
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            target
+            ~/.cargo/git
+            ~/.cargo/registry
+          key: ${{ matrix.os }}-${{ matrix.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Build
         run: cargo build --target ${{ matrix.target }} --verbose --release --locked --bin boa

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,9 +39,15 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - uses: Swatinem/rust-cache@v2
+      - name: Cache cargo
+        uses: actions/cache@v4
         with:
-          key: tarpaulin
+          path: |
+            target
+            ~/.cargo/git
+            ~/.cargo/registry
+          key: ${{ runner.os }}-${{ runner.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
       - name: Install cargo-tarpaulin
         uses: baptiste0928/cargo-install@v3.3.2
         with:
@@ -65,12 +71,15 @@ jobs:
       CARGO_TARGET_X86_64_APPLE_DARWIN_RUSTFLAGS: ${{ (github.ref == 'refs/heads/main' || github.base_ref == 'main') && '-D warnings' || '' }}
       CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU: ${{ (github.ref == 'refs/heads/main' || github.base_ref == 'main') && '-D warnings' || '' }}
     strategy:
-      matrix:
-        os:
-          - macos-13
-          - macos-14
-          - windows-latest
-          - ubuntu-24.04-arm
+       include:
+         - os: macos-14
+           arch: ARM64
+         - os: windows-latest
+           arch: x64
+         - os: ubuntu-24.04-arm
+           arch: ARM64
+         - os: ubuntu-latest
+           arch: X64
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -80,7 +89,15 @@ jobs:
         with:
           toolchain: stable
 
-      - uses: Swatinem/rust-cache@v2
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            target
+            ~/.cargo/git
+            ~/.cargo/registry
+          key: ${{ matrix.os }}-${{ matrix.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
       - name: Build tests
         run: cargo test --no-run --profile ci
       # this order is faster according to rust-analyzer
@@ -157,9 +174,14 @@ jobs:
           toolchain: stable
           components: clippy
 
-      - uses: Swatinem/rust-cache@v2
+      - name: Cache cargo
+        uses: actions/cache@v4
         with:
-          key: clippy
+          path: |
+            target
+            ~/.cargo/git
+            ~/.cargo/registry
+          key: ${{ runner.os }}-${{ runner.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install cargo-workspaces
         run: cargo install cargo-workspaces
@@ -194,9 +216,15 @@ jobs:
         with:
           toolchain: stable
 
-      - uses: Swatinem/rust-cache@v2
+      - name: Cache cargo
+        uses: actions/cache@v4
         with:
-          key: docs
+          path: |
+            target
+            ~/.cargo/git
+            ~/.cargo/registry
+          key: ${{ runner.os }}-${{ runner.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
       - name: Generate documentation
         run: cargo doc -v --document-private-items --all-features
 
@@ -217,9 +245,14 @@ jobs:
         with:
           toolchain: stable
 
-      - uses: Swatinem/rust-cache@v2
+      - name: Cache cargo
+        uses: actions/cache@v4
         with:
-          key: build-fuzz
+          path: |
+            target
+            ~/.cargo/git
+            ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install cargo-fuzz
         run: cargo install cargo-fuzz
@@ -244,9 +277,14 @@ jobs:
         with:
           toolchain: stable
 
-      - uses: Swatinem/rust-cache@v2
+      - name: Cache cargo
+        uses: actions/cache@v4
         with:
-          key: build-run-examples
+          path: |
+            target
+            ~/.cargo/git
+            ~/.cargo/registry
+          key: ${{ runner.os }}-${{ runner.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install cargo-workspaces
         run: cargo install cargo-workspaces

--- a/.github/workflows/test262.yml
+++ b/.github/workflows/test262.yml
@@ -35,7 +35,7 @@ jobs:
             target
             ~/.cargo/git
             ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-test262-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Checkout the data repo
         uses: actions/checkout@v5

--- a/.github/workflows/test262_release.yml
+++ b/.github/workflows/test262_release.yml
@@ -31,7 +31,7 @@ jobs:
             target
             ~/.cargo/git
             ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-test262-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       # Checkout the `data` repository
       - name: Checkout the data repo

--- a/.github/workflows/webassembly.yml
+++ b/.github/workflows/webassembly.yml
@@ -49,11 +49,16 @@ jobs:
         with:
           toolchain: stable
 
-      - uses: Swatinem/rust-cache@v2
-      - name: Install wasm-pack
-        uses: baptiste0928/cargo-install@v3.3.2
+
+      - name: Cache cargo
+        uses: actions/cache@v4
         with:
-          crate: wasm-pack
+          path: |
+            target
+            ~/.cargo/git
+            ~/.cargo/registry
+          key: ${{ runner.os }}-${{ runner.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
       - name: Build Playground
         run: wasm-pack build ./ffi/wasm --verbose
       - name: Test (Chrome)


### PR DESCRIPTION
We've been getting very little cache reuse from our cache keys, and the upstream action we're using doesn't support shared cache keys properly, so its easier to just use the basic cache action.

- Use the same cache key if os, arch and cargo.lock is the same
- Remove macos 13 as that is no longer supported by Rust