### PR TITLE
Fix UB on unaligned ArrayBuffers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aligned-vec"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
+dependencies = [
+ "equator",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -345,6 +354,7 @@ dependencies = [
 name = "boa_engine"
 version = "0.20.0"
 dependencies = [
+ "aligned-vec",
  "arrayvec",
  "bitflags 2.9.4",
  "boa_ast",
@@ -1259,6 +1269,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "equator"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
+dependencies = [
+ "equator-macro",
+]
+
+[[package]]
+name = "equator-macro"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,6 +137,7 @@ tokio = { version = "1.47.1", default-features = false }
 futures-concurrency = "7.6.3"
 dynify = "0.1.2"
 futures-channel = "0.3.31"
+aligned-vec = "0.6.4"
 
 # ICU4X
 

--- a/core/engine/Cargo.toml
+++ b/core/engine/Cargo.toml
@@ -113,7 +113,6 @@ fast-float2.workspace = true
 tap.workspace = true
 small_btree.workspace = true
 paste.workspace = true
-
 thiserror.workspace = true
 dashmap.workspace = true
 num_enum.workspace = true
@@ -133,6 +132,7 @@ hashbrown.workspace = true
 either = { workspace = true, optional = true }
 static_assertions.workspace = true
 futures-channel.workspace = true
+aligned-vec.workspace = true
 
 # intl deps
 boa_icu_provider = { workspace = true, features = ["std"], optional = true }

--- a/core/engine/src/builtins/array_buffer/shared.rs
+++ b/core/engine/src/builtins/array_buffer/shared.rs
@@ -607,7 +607,7 @@ pub(crate) fn create_shared_byte_data_block(
     let (data, align, len, _) = buf.into_raw_parts();
 
     // 3. Return db.
-    // SAFETY: `[u8]` must be trasparently castable to `[AtomicU8]`.
+    // SAFETY: `[u8]` must be transparently castable to `[AtomicU8]`.
     Ok(unsafe {
         AlignedBox::from_raw_parts(align, ptr::slice_from_raw_parts_mut(data.cast(), len))
     })

--- a/core/engine/src/builtins/array_buffer/tests.rs
+++ b/core/engine/src/builtins/array_buffer/tests.rs
@@ -1,40 +1,43 @@
 use crate::object::JsArrayBuffer;
-use crate::{Context, TestAction, run_test_actions};
+use crate::{TestAction, run_test_actions};
 
 #[test]
 fn create_byte_data_block() {
-    let context = &mut Context::default();
-    // Sunny day
-    assert!(super::create_byte_data_block(100, None, context).is_ok());
+    run_test_actions([TestAction::inspect_context(|context| {
+        // Sunny day
+        assert!(super::create_byte_data_block(100, None, context).is_ok());
 
-    // Rainy day
-    assert!(super::create_byte_data_block(u64::MAX, None, context).is_err());
+        // Rainy day
+        assert!(super::create_byte_data_block(u64::MAX, None, context).is_err());
+    })]);
 }
 
 #[test]
 fn create_shared_byte_data_block() {
-    let context = &mut Context::default();
-    // Sunny day
-    assert!(super::shared::create_shared_byte_data_block(100, context).is_ok());
+    run_test_actions([TestAction::inspect_context(|context| {
+        // Sunny day
+        assert!(super::shared::create_shared_byte_data_block(100, context).is_ok());
 
-    // Rainy day
-    assert!(super::shared::create_shared_byte_data_block(u64::MAX, context).is_err());
+        // Rainy day
+        assert!(super::shared::create_shared_byte_data_block(u64::MAX, context).is_err());
+    })]);
 }
 
 #[test]
 fn resize() {
-    let context = &mut Context::default();
-    let data_block = super::create_byte_data_block(100, None, context).unwrap();
-    let js_arr = JsArrayBuffer::from_byte_block(data_block, context)
-        .unwrap()
-        .with_max_byte_length(100);
-    let mut arr = js_arr.borrow_mut();
+    run_test_actions([TestAction::inspect_context(|context| {
+        let data_block = super::create_byte_data_block(100, None, context).unwrap();
+        let js_arr = JsArrayBuffer::from_byte_block(data_block, context)
+            .unwrap()
+            .with_max_byte_length(100);
+        let mut arr = js_arr.borrow_mut();
 
-    // Sunny day
-    assert_eq!(arr.data_mut().resize(50), Ok(()));
+        // Sunny day
+        assert_eq!(arr.data_mut().resize(50), Ok(()));
 
-    // Rainy day
-    assert!(arr.data_mut().resize(u64::MAX).is_err());
+        // Rainy day
+        assert!(arr.data_mut().resize(u64::MAX).is_err());
+    })]);
 }
 
 #[test]

--- a/core/engine/src/builtins/atomics/tests.rs
+++ b/core/engine/src/builtins/atomics/tests.rs
@@ -1,9 +1,10 @@
-use std::time::Duration;
+use std::{rc::Rc, time::Duration};
 
 use crate::{
     Context, JsValue,
     builtins::atomics::Atomics,
     js_string,
+    module::IdleModuleLoader,
     object::{JsInt32Array, JsPromise, JsSharedArrayBuffer},
     value::TryFromJs,
 };
@@ -13,7 +14,11 @@ fn waiterlist_block_indexedposition_wake() {
     const NUMAGENT: i32 = 2;
     const RUNNING: i32 = 4;
 
-    let context = &mut Context::builder().can_block(true).build().unwrap();
+    let context = &mut Context::builder()
+        .can_block(true)
+        .module_loader(Rc::new(IdleModuleLoader))
+        .build()
+        .unwrap();
     let buffer = JsSharedArrayBuffer::new(size_of::<i32>() * 5, context).unwrap();
     let inner_buffer = buffer.inner();
     let i32a = JsInt32Array::from_shared_array_buffer(buffer.clone(), context).unwrap();
@@ -23,7 +28,11 @@ fn waiterlist_block_indexedposition_wake() {
         for idx in [2, 0] {
             let buffer = inner_buffer.clone();
             let handle = s.spawn(move || {
-                let context = &mut Context::builder().can_block(true).build().unwrap();
+                let context = &mut Context::builder()
+                    .can_block(true)
+                    .module_loader(Rc::new(IdleModuleLoader))
+                    .build()
+                    .unwrap();
                 let buffer = JsSharedArrayBuffer::from_buffer(buffer, context);
                 let i32a = JsInt32Array::from_shared_array_buffer(buffer, context).unwrap();
 

--- a/core/engine/src/builtins/temporal/plain_month_day/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_month_day/mod.rs
@@ -1,5 +1,4 @@
 //! Boa's implementation of the ECMAScript `Temporal.PlainMonthDay` built-in object.
-//!
 use std::str::FromStr;
 
 use crate::{

--- a/core/engine/src/context/hooks.rs
+++ b/core/engine/src/context/hooks.rs
@@ -19,12 +19,12 @@ use time::{OffsetDateTime, UtcOffset};
 /// need to be redefined:
 ///
 /// ```
-/// use std::rc::Rc;
 /// use boa_engine::{
+///     JsNativeError, JsResult, JsString, Source,
 ///     context::{Context, ContextBuilder, HostHooks},
 ///     realm::Realm,
-///     JsNativeError, JsResult, JsString, Source,
 /// };
+/// use std::rc::Rc;
 ///
 /// struct Hooks;
 ///
@@ -43,7 +43,10 @@ use time::{OffsetDateTime, UtcOffset};
 ///     }
 /// }
 ///
-/// let context = &mut ContextBuilder::new().host_hooks(Rc::new(Hooks)).build().unwrap();
+/// let context = &mut ContextBuilder::new()
+///     .host_hooks(Rc::new(Hooks))
+///     .build()
+///     .unwrap();
 /// let result = context.eval(Source::from_bytes(r#"eval("let a = 5")"#));
 /// assert!(
 ///     result

--- a/core/engine/src/context/mod.rs
+++ b/core/engine/src/context/mod.rs
@@ -57,10 +57,9 @@ thread_local! {
 ///
 /// ```rust
 /// use boa_engine::{
-///     js_string,
+///     Context, Source, js_string,
 ///     object::ObjectInitializer,
 ///     property::{Attribute, PropertyDescriptor},
-///     Context, Source,
 /// };
 ///
 /// let script = r#"
@@ -215,16 +214,19 @@ impl Context {
     /// # Example
     /// ```
     /// use boa_engine::{
-    ///     js_string,
+    ///     Context, js_string,
     ///     object::ObjectInitializer,
     ///     property::{Attribute, PropertyDescriptor},
-    ///     Context,
     /// };
     ///
     /// let mut context = Context::default();
     ///
     /// context
-    ///     .register_global_property(js_string!("myPrimitiveProperty"), 10, Attribute::all())
+    ///     .register_global_property(
+    ///         js_string!("myPrimitiveProperty"),
+    ///         10,
+    ///         Attribute::all(),
+    ///     )
     ///     .expect("property shouldn't exist");
     ///
     /// let object = ObjectInitializer::new(&mut context)
@@ -232,7 +234,11 @@ impl Context {
     ///     .property(js_string!("y"), 1, Attribute::all())
     ///     .build();
     /// context
-    ///     .register_global_property(js_string!("myObjectProperty"), object, Attribute::all())
+    ///     .register_global_property(
+    ///         js_string!("myObjectProperty"),
+    ///         object,
+    ///         Attribute::all(),
+    ///     )
     ///     .expect("property shouldn't exist");
     /// ```
     pub fn register_global_property<K, V>(

--- a/core/engine/src/error.rs
+++ b/core/engine/src/error.rs
@@ -49,15 +49,21 @@ use thiserror::Error;
 ///
 /// ```
 /// # use boa_engine::{js_str, Context, JsValue};
-/// use boa_engine::{js_error};
+/// use boa_engine::js_error;
 /// let context = &mut Context::default();
 ///
 /// let error = js_error!("error!");
 /// assert!(error.as_opaque().is_some());
-/// assert_eq!(error.as_opaque().unwrap().to_string(context).unwrap(), "error!");
+/// assert_eq!(
+///     error.as_opaque().unwrap().to_string(context).unwrap(),
+///     "error!"
+/// );
 ///
 /// let error = js_error!("error: {}", 5);
-/// assert_eq!(error.as_opaque().unwrap().to_string(context).unwrap(), "error: 5");
+/// assert_eq!(
+///     error.as_opaque().unwrap().to_string(context).unwrap(),
+///     "error: 5"
+/// );
 ///
 /// // Non-string literals must be used as an expression.
 /// let error = js_error!({ true });
@@ -360,7 +366,8 @@ impl JsError {
     /// # use boa_engine::{Context, JsError, JsNativeError};
     /// # use boa_engine::builtins::error::Error;
     /// let context = &mut Context::default();
-    /// let error: JsError = JsNativeError::eval().with_message("invalid script").into();
+    /// let error: JsError =
+    ///     JsNativeError::eval().with_message("invalid script").into();
     /// let error_val = error.to_opaque(context);
     ///
     /// assert!(error_val.as_object().unwrap().is::<Error>());
@@ -540,7 +547,8 @@ impl JsError {
     ///
     /// ```rust
     /// # use boa_engine::{JsError, JsNativeError, JsValue};
-    /// let error: JsError = JsNativeError::error().with_message("Unknown error").into();
+    /// let error: JsError =
+    ///     JsNativeError::error().with_message("Unknown error").into();
     ///
     /// assert!(error.as_native().is_some());
     ///

--- a/core/engine/src/interop/into_js_arguments.rs
+++ b/core/engine/src/interop/into_js_arguments.rs
@@ -132,8 +132,10 @@ impl<'a> IntoIterator for JsRest<'a> {
 /// # use boa_engine::{Context, JsValue, IntoJsFunctionCopied};
 /// # use boa_engine::interop::JsAll;
 /// # let mut context = Context::default();
-/// let sums = (|args: JsAll<i32>, context: &mut Context| -> i32 { args.iter().sum() })
-///     .into_js_function_copied(&mut context);
+/// let sums = (|args: JsAll<i32>, context: &mut Context| -> i32 {
+///     args.iter().sum()
+/// })
+/// .into_js_function_copied(&mut context);
 ///
 /// let result = sums
 ///     .call(

--- a/core/engine/src/native_function/mod.rs
+++ b/core/engine/src/native_function/mod.rs
@@ -195,7 +195,6 @@ impl NativeFunction {
     /// }
     /// NativeFunction::from_async_fn(test);
     /// ```
-    ///
     pub fn from_async_fn<F>(f: F) -> Self
     where
         F: AsyncFn(&JsValue, &[JsValue], &RefCell<&mut Context>) -> JsResult<JsValue> + 'static,

--- a/core/engine/src/object/builtins/jsarraybuffer.rs
+++ b/core/engine/src/object/builtins/jsarraybuffer.rs
@@ -1,7 +1,7 @@
 //! A Rust API wrapper for Boa's `ArrayBuffer` Builtin ECMAScript Object
 use crate::{
     Context, JsResult, JsValue,
-    builtins::array_buffer::{AlignedVec, ArrayBuffer},
+    builtins::array_buffer::ArrayBuffer,
     context::intrinsics::StandardConstructors,
     error::JsNativeError,
     object::{JsObject, internal_methods::get_prototype_from_constructor},
@@ -9,6 +9,9 @@ use crate::{
 };
 use boa_gc::{Finalize, GcRef, GcRefMut, Trace};
 use std::ops::Deref;
+
+#[doc(inline)]
+pub use crate::builtins::array_buffer::AlignedVec;
 
 /// `JsArrayBuffer` provides a wrapper for Boa's implementation of the ECMAScript `ArrayBuffer` object
 #[derive(Debug, Clone, Trace, Finalize)]
@@ -46,7 +49,10 @@ impl JsArrayBuffer {
     /// // Creates a blank array buffer of n bytes
     /// let array_buffer = JsArrayBuffer::new(4, context)?;
     ///
-    /// assert_eq!(array_buffer.detach(&JsValue::undefined())?, vec![0_u8; 4]);
+    /// assert_eq!(
+    ///     array_buffer.detach(&JsValue::undefined())?.as_slice(),
+    ///     &[0u8, 0, 0, 0]
+    /// );
     ///
     /// # Ok(())
     /// # }
@@ -76,7 +82,7 @@ impl JsArrayBuffer {
     ///
     /// ```
     /// # use boa_engine::{
-    /// # object::builtins::JsArrayBuffer,
+    /// # object::builtins::{JsArrayBuffer, AlignedVec},
     /// # Context, JsResult, JsValue,
     /// # };
     /// # fn main() -> JsResult<()> {
@@ -84,12 +90,12 @@ impl JsArrayBuffer {
     /// # let context = &mut Context::default();
     ///
     /// // Create a buffer from a chunk of data
-    /// let data_block: Vec<u8> = (0..5).collect();
+    /// let data_block = AlignedVec::from_iter(0, 0..5);
     /// let array_buffer = JsArrayBuffer::from_byte_block(data_block, context)?;
     ///
     /// assert_eq!(
-    ///     array_buffer.detach(&JsValue::undefined())?,
-    ///     (0..5).collect::<Vec<u8>>()
+    ///     array_buffer.detach(&JsValue::undefined())?.as_slice(),
+    ///     &[0u8, 1, 2, 3, 4]
     /// );
     /// # Ok(())
     /// # }
@@ -156,14 +162,14 @@ impl JsArrayBuffer {
     ///
     /// ```
     /// # use boa_engine::{
-    /// # object::builtins::JsArrayBuffer,
+    /// # object::builtins::{JsArrayBuffer, AlignedVec},
     /// # Context, JsResult,
     /// # };
     /// # fn main() -> JsResult<()> {
     /// # // Initialize context
     /// # let context = &mut Context::default();
     /// // Create a buffer from a chunk of data
-    /// let data_block: Vec<u8> = (0..5).collect();
+    /// let data_block = AlignedVec::from_iter(0, 0..5);
     /// let array_buffer = JsArrayBuffer::from_byte_block(data_block, context)?;
     ///
     /// // Take the inner buffer
@@ -188,20 +194,20 @@ impl JsArrayBuffer {
     ///
     /// ```
     /// # use boa_engine::{
-    /// # object::builtins::JsArrayBuffer,
+    /// # object::builtins::{JsArrayBuffer, AlignedVec},
     /// # Context, JsResult, JsValue
     /// # };
     /// # fn main() -> JsResult<()> {
     /// # // Initialize context
     /// # let context = &mut Context::default();
     /// // Create a buffer from a chunk of data
-    /// let data_block: Vec<u8> = (0..5).collect();
+    /// let data_block = AlignedVec::from_iter(0, 0..5);
     /// let array_buffer = JsArrayBuffer::from_byte_block(data_block, context)?;
     ///
     /// // Take the inner buffer
     /// let internal_buffer = array_buffer.detach(&JsValue::undefined())?;
     ///
-    /// assert_eq!(internal_buffer, (0..5).collect::<Vec<u8>>());
+    /// assert_eq!(internal_buffer.as_slice(), &[0u8, 1, 2, 3, 4]);
     ///
     /// // Anymore interaction with the buffer will return an error
     /// let detached_err = array_buffer.detach(&JsValue::undefined());
@@ -228,23 +234,20 @@ impl JsArrayBuffer {
     ///
     /// ```
     /// # use boa_engine::{
-    /// # object::builtins::JsArrayBuffer,
-    /// # Context, JsResult, JsValue
+    /// # object::builtins::{JsArrayBuffer, AlignedVec},
+    /// # Context, JsResult, JsValue,
     /// # };
     /// # fn main() -> JsResult<()> {
     /// # // Initialize context
     /// # let context = &mut Context::default();
     /// // Create a buffer from a chunk of data
-    /// let data_block: Vec<u8> = (0..5).collect();
+    /// let data_block = AlignedVec::from_iter(0, 0..5);
     /// let array_buffer = JsArrayBuffer::from_byte_block(data_block, context)?;
     ///
     /// // Get a reference to the data.
     /// let internal_buffer = array_buffer.data();
     ///
-    /// assert_eq!(
-    ///     internal_buffer.as_deref(),
-    ///     Some((0..5).collect::<Vec<u8>>().as_slice())
-    /// );
+    /// assert_eq!(internal_buffer.as_deref(), Some(&[0u8, 1, 2, 3, 4][..]));
     /// # Ok(())
     /// # }
     /// ```
@@ -260,14 +263,14 @@ impl JsArrayBuffer {
     ///
     /// ```
     /// # use boa_engine::{
-    /// # object::builtins::JsArrayBuffer,
+    /// # object::builtins::{JsArrayBuffer, AlignedVec},
     /// # Context, JsResult, JsValue
     /// # };
     /// # fn main() -> JsResult<()> {
     /// # // Initialize context
     /// # let context = &mut Context::default();
     /// // Create a buffer from a chunk of data
-    /// let data_block: Vec<u8> = (0..5).collect();
+    /// let data_block = AlignedVec::from_iter(0, 0..5);
     /// let array_buffer = JsArrayBuffer::from_byte_block(data_block, context)?;
     ///
     /// // Get a reference to the data.
@@ -277,7 +280,7 @@ impl JsArrayBuffer {
     ///
     /// internal_buffer.fill(10);
     ///
-    /// assert_eq!(&*internal_buffer, vec![10u8; 5].as_slice());
+    /// assert_eq!(&*internal_buffer, &[10u8, 10, 10, 10, 10]);
     /// # Ok(())
     /// # }
     /// ```

--- a/core/engine/src/object/builtins/jsarraybuffer.rs
+++ b/core/engine/src/object/builtins/jsarraybuffer.rs
@@ -1,7 +1,7 @@
 //! A Rust API wrapper for Boa's `ArrayBuffer` Builtin ECMAScript Object
 use crate::{
     Context, JsResult, JsValue,
-    builtins::array_buffer::ArrayBuffer,
+    builtins::array_buffer::{AlignedVec, ArrayBuffer},
     context::intrinsics::StandardConstructors,
     error::JsNativeError,
     object::{JsObject, internal_methods::get_prototype_from_constructor},
@@ -94,7 +94,7 @@ impl JsArrayBuffer {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn from_byte_block(byte_block: Vec<u8>, context: &mut Context) -> JsResult<Self> {
+    pub fn from_byte_block(byte_block: AlignedVec<u8>, context: &mut Context) -> JsResult<Self> {
         let constructor = context
             .intrinsics()
             .constructors()
@@ -210,7 +210,7 @@ impl JsArrayBuffer {
     /// # }
     /// ```
     #[inline]
-    pub fn detach(&self, detach_key: &JsValue) -> JsResult<Vec<u8>> {
+    pub fn detach(&self, detach_key: &JsValue) -> JsResult<AlignedVec<u8>> {
         self.inner
             .borrow_mut()
             .data_mut()

--- a/core/engine/src/object/builtins/jsdataview.rs
+++ b/core/engine/src/object/builtins/jsdataview.rs
@@ -23,7 +23,8 @@ use std::ops::Deref;
 /// let array_buffer = JsArrayBuffer::new(4, context)?;
 ///
 /// // Create a new Dataview from pre-existing ArrayBuffer
-/// let data_view = JsDataView::from_js_array_buffer(array_buffer, None, None, context)?;
+/// let data_view =
+///     JsDataView::from_js_array_buffer(array_buffer, None, None, context)?;
 ///
 /// # Ok(())
 /// # }

--- a/core/engine/src/object/builtins/jsdate.rs
+++ b/core/engine/src/object/builtins/jsdate.rs
@@ -14,7 +14,9 @@ use time::{OffsetDateTime, format_description::well_known::Rfc3339};
 /// Create a `JsDate` object and set date to December 4 1995
 ///
 /// ```
-/// use boa_engine::{js_string, object::builtins::JsDate, Context, JsResult, JsValue};
+/// use boa_engine::{
+///     Context, JsResult, JsValue, js_string, object::builtins::JsDate,
+/// };
 ///
 /// fn main() -> JsResult<()> {
 ///     // JS mutable Context

--- a/core/engine/src/object/builtins/jsmap.rs
+++ b/core/engine/src/object/builtins/jsmap.rs
@@ -235,7 +235,10 @@ impl JsMap {
     /// js_map.set(js_string!("foo"), js_string!("bar"), context)?;
     /// js_map.set(2, 4, context)?;
     ///
-    /// assert_eq!(js_map.get(js_string!("foo"), context)?, js_string!("bar").into());
+    /// assert_eq!(
+    ///     js_map.get(js_string!("foo"), context)?,
+    ///     js_string!("bar").into()
+    /// );
     /// assert_eq!(js_map.get(2, context)?, 4.into());
     /// # Ok(())
     /// # }
@@ -296,7 +299,10 @@ impl JsMap {
     /// js_map.delete(js_string!("foo"), context)?;
     ///
     /// assert_eq!(js_map.get_size(context)?, 1.into());
-    /// assert_eq!(js_map.get(js_string!("foo"), context)?, JsValue::undefined());
+    /// assert_eq!(
+    ///     js_map.get(js_string!("foo"), context)?,
+    ///     JsValue::undefined()
+    /// );
     /// # Ok(())
     /// # }
     /// ```

--- a/core/engine/src/object/builtins/jspromise.rs
+++ b/core/engine/src/object/builtins/jspromise.rs
@@ -35,14 +35,20 @@ use std::{future::Future, pin::Pin, task};
 /// # fn main() -> Result<(), Box<dyn Error>> {
 /// let context = &mut Context::default();
 ///
-/// context.register_global_property(js_string!("finally"), false, Attribute::all());
+/// context.register_global_property(
+///     js_string!("finally"),
+///     false,
+///     Attribute::all(),
+/// );
 ///
 /// let promise = JsPromise::new(
 ///     |resolvers, context| {
 ///         let result = js_string!("hello world!").into();
-///         resolvers
-///             .resolve
-///             .call(&JsValue::undefined(), &[result], context)?;
+///         resolvers.resolve.call(
+///             &JsValue::undefined(),
+///             &[result],
+///             context,
+///         )?;
 ///         Ok(JsValue::undefined())
 ///     },
 ///     context,
@@ -52,7 +58,8 @@ use std::{future::Future, pin::Pin, task};
 ///     .then(
 ///         Some(
 ///             NativeFunction::from_fn_ptr(|_, args, _| {
-///                 Err(JsError::from_opaque(args.get_or_undefined(0).clone()).into())
+///                 Err(JsError::from_opaque(args.get_or_undefined(0).clone())
+///                     .into())
 ///             })
 ///             .to_js_function(context.realm()),
 ///         ),
@@ -60,8 +67,10 @@ use std::{future::Future, pin::Pin, task};
 ///         context,
 ///     )
 ///     .catch(
-///         NativeFunction::from_fn_ptr(|_, args, _| Ok(args.get_or_undefined(0).clone()))
-///             .to_js_function(context.realm()),
+///         NativeFunction::from_fn_ptr(|_, args, _| {
+///             Ok(args.get_or_undefined(0).clone())
+///         })
+///         .to_js_function(context.realm()),
 ///         context,
 ///     )
 ///     .finally(
@@ -132,9 +141,11 @@ impl JsPromise {
     /// let promise = JsPromise::new(
     ///     |resolvers, context| {
     ///         let result = js_string!("hello world").into();
-    ///         resolvers
-    ///             .resolve
-    ///             .call(&JsValue::undefined(), &[result], context)?;
+    ///         resolvers.resolve.call(
+    ///             &JsValue::undefined(),
+    ///             &[result],
+    ///             context,
+    ///         )?;
     ///         Ok(JsValue::undefined())
     ///     },
     ///     context,
@@ -329,7 +340,9 @@ impl JsPromise {
     /// let context = &mut Context::default();
     ///
     /// fn do_thing(success: bool) -> JsResult<JsString> {
-    ///     success.then(|| js_string!("resolved!")).ok_or(js_error!("rejected!"))
+    ///     success
+    ///         .then(|| js_string!("resolved!"))
+    ///         .ok_or(js_error!("rejected!"))
     /// }
     ///
     /// let promise = JsPromise::from_result(do_thing(true), context);
@@ -411,7 +424,10 @@ impl JsPromise {
     /// # };
     /// let context = &mut Context::default();
     ///
-    /// let promise = JsPromise::reject(JsError::from_opaque(js_string!("oops!").into()), context);
+    /// let promise = JsPromise::reject(
+    ///     JsError::from_opaque(js_string!("oops!").into()),
+    ///     context,
+    /// );
     ///
     /// assert_eq!(
     ///     promise.state(),
@@ -496,9 +512,11 @@ impl JsPromise {
     ///
     /// let promise = JsPromise::new(
     ///     |resolvers, context| {
-    ///         resolvers
-    ///             .resolve
-    ///             .call(&JsValue::undefined(), &[255.255.into()], context)?;
+    ///         resolvers.resolve.call(
+    ///             &JsValue::undefined(),
+    ///             &[255.255.into()],
+    ///             context,
+    ///         )?;
     ///         Ok(JsValue::undefined())
     ///     },
     ///     context,
@@ -561,9 +579,11 @@ impl JsPromise {
     ///     |resolvers, context| {
     ///         let error = JsNativeError::typ().with_message("thrown");
     ///         let error = error.to_opaque(context);
-    ///         resolvers
-    ///             .reject
-    ///             .call(&JsValue::undefined(), &[error.into()], context)?;
+    ///         resolvers.reject.call(
+    ///             &JsValue::undefined(),
+    ///             &[error.into()],
+    ///             context,
+    ///         )?;
     ///         Ok(JsValue::undefined())
     ///     },
     ///     context,
@@ -617,15 +637,21 @@ impl JsPromise {
     /// # fn main() -> Result<(), Box<dyn Error>> {
     /// let context = &mut Context::default();
     ///
-    /// context.register_global_property(js_string!("finally"), false, Attribute::all())?;
+    /// context.register_global_property(
+    ///     js_string!("finally"),
+    ///     false,
+    ///     Attribute::all(),
+    /// )?;
     ///
     /// let promise = JsPromise::new(
     ///     |resolvers, context| {
     ///         let error = JsNativeError::typ().with_message("thrown");
     ///         let error = error.to_opaque(context);
-    ///         resolvers
-    ///             .reject
-    ///             .call(&JsValue::undefined(), &[error.into()], context)?;
+    ///         resolvers.reject.call(
+    ///             &JsValue::undefined(),
+    ///             &[error.into()],
+    ///             context,
+    ///         )?;
     ///         Ok(JsValue::undefined())
     ///     },
     ///     context,
@@ -1101,9 +1127,13 @@ impl JsPromise {
     /// # use boa_engine::object::builtins::{JsFunction, JsPromise};
     /// let context = &mut Context::default();
     ///
-    /// let p1 = JsPromise::new(|fns, context| {
-    ///     fns.resolve.call(&JsValue::undefined(), &[JsValue::new(1)], context)
-    /// }, context);
+    /// let p1 = JsPromise::new(
+    ///     |fns, context| {
+    ///         fns.resolve
+    ///             .call(&JsValue::undefined(), &[JsValue::new(1)], context)
+    ///     },
+    ///     context,
+    /// );
     /// let p2 = p1.then(
     ///     Some(
     ///         NativeFunction::from_fn_ptr(|_, args, context| {
@@ -1113,7 +1143,8 @@ impl JsPromise {
     ///         .to_js_function(context.realm()),
     ///     ),
     ///     None,
-    ///     context,);
+    ///     context,
+    /// );
     ///
     /// assert_eq!(p2.await_blocking(context), Ok(JsValue::new(2)));
     /// ```
@@ -1124,19 +1155,20 @@ impl JsPromise {
     /// # use boa_engine::object::builtins::JsPromise;
     ///
     /// let context = &mut Context::default();
-    /// let p1 = JsPromise::new(|fns, context| {
-    ///     fns.resolve.call(&JsValue::undefined(), &[], context)
-    /// }, context)
-    ///     .then(
-    ///         Some(
-    ///             NativeFunction::from_fn_ptr(|_, _, _| {
-    ///                 panic!("This will not happen.");
-    ///             })
-    ///             .to_js_function(context.realm())
-    ///         ),
-    ///         None,
-    ///         context,
-    ///     );
+    /// let p1 = JsPromise::new(
+    ///     |fns, context| fns.resolve.call(&JsValue::undefined(), &[], context),
+    ///     context,
+    /// )
+    /// .then(
+    ///     Some(
+    ///         NativeFunction::from_fn_ptr(|_, _, _| {
+    ///             panic!("This will not happen.");
+    ///         })
+    ///         .to_js_function(context.realm()),
+    ///     ),
+    ///     None,
+    ///     context,
+    /// );
     /// let p2 = JsPromise::resolve(1, context);
     ///
     /// assert_eq!(p2.await_blocking(context), Ok(JsValue::new(1)));

--- a/core/engine/src/object/builtins/jstypedarray.rs
+++ b/core/engine/src/object/builtins/jstypedarray.rs
@@ -3,6 +3,7 @@ use crate::{
     Context, JsResult, JsString, JsValue,
     builtins::{
         BuiltInConstructor,
+        array_buffer::AlignedVec,
         typed_array::{BuiltinTypedArray, TypedArray, TypedArrayKind},
     },
     error::JsNativeError,
@@ -1028,10 +1029,12 @@ macro_rules! JsTypedArrayType {
             where
                 I: IntoIterator<Item = $element>,
             {
-                let bytes: Vec<_> = elements
+                let bytes = AlignedVec::from_iter(
+                    0,
+                    elements
                     .into_iter()
                     .flat_map(<$element>::to_ne_bytes)
-                    .collect();
+                );
                 let array_buffer = JsArrayBuffer::from_byte_block(bytes, context)?;
                 let new_target = context
                     .intrinsics()

--- a/core/engine/src/object/datatypes.rs
+++ b/core/engine/src/object/datatypes.rs
@@ -33,7 +33,8 @@ use super::internal_methods::{InternalObjectMethods, ORDINARY_INTERNAL_METHODS};
 ///     counter: usize,
 /// }
 ///
-/// let object = JsObject::from_proto_and_data(None, CustomStruct { counter: 5 });
+/// let object =
+///     JsObject::from_proto_and_data(None, CustomStruct { counter: 5 });
 ///
 /// assert_eq!(object.downcast_ref::<CustomStruct>().unwrap().counter, 5);
 /// ```

--- a/core/engine/src/value/conversions/convert.rs
+++ b/core/engine/src/value/conversions/convert.rs
@@ -22,7 +22,8 @@ use crate::{Context, JsData, JsResult, JsString, JsValue};
 /// # use boa_engine::value::{Convert, TryFromJs};
 /// # let mut context = Context::default();
 /// let value = JsValue::from(js_string!("42"));
-/// let Convert(converted): Convert<i32> = Convert::try_from_js(&value, &mut context).unwrap();
+/// let Convert(converted): Convert<i32> =
+///     Convert::try_from_js(&value, &mut context).unwrap();
 ///
 /// assert_eq!(converted, 42);
 /// ```

--- a/core/engine/src/value/conversions/nullable/mod.rs
+++ b/core/engine/src/value/conversions/nullable/mod.rs
@@ -66,7 +66,8 @@ mod tests;
 /// # use boa_engine::{Context, JsResult, JsValue};
 /// # use boa_engine::value::Nullable;
 /// # let context = &mut Context::default();
-/// let mut v: JsResult<Nullable<Option<u8>>> = JsValue::undefined().try_js_into(context);
+/// let mut v: JsResult<Nullable<Option<u8>>> =
+///     JsValue::undefined().try_js_into(context);
 /// assert_eq!(v, Ok(Nullable::NonNull(None)));
 ///
 /// v = JsValue::null().try_js_into(context);

--- a/core/engine/src/value/mod.rs
+++ b/core/engine/src/value/mod.rs
@@ -1056,19 +1056,24 @@ impl JsValue {
     /// # Example
     ///
     /// ```
-    /// use boa_engine::{JsValue, Context};
+    /// use boa_engine::{Context, JsValue};
     ///
     /// let mut context = Context::default();
     ///
     /// let defined_value = JsValue::from(5);
     /// let undefined = JsValue::undefined();
     ///
-    /// let defined_result = defined_value.map(|v| v.add(&JsValue::from(5), &mut context)).transpose().unwrap();
-    /// let undefined_result = undefined.map(|v| v.add(&JsValue::from(5), &mut context)).transpose().unwrap();
+    /// let defined_result = defined_value
+    ///     .map(|v| v.add(&JsValue::from(5), &mut context))
+    ///     .transpose()
+    ///     .unwrap();
+    /// let undefined_result = undefined
+    ///     .map(|v| v.add(&JsValue::from(5), &mut context))
+    ///     .transpose()
+    ///     .unwrap();
     ///
     /// assert_eq!(defined_result, Some(JsValue::from(10u8)));
     /// assert_eq!(undefined_result, None);
-    ///
     /// ```
     #[inline]
     #[must_use]
@@ -1089,7 +1094,7 @@ impl JsValue {
     /// # Example
     ///
     /// ```
-    /// use boa_engine::{JsValue, Context};
+    /// use boa_engine::{Context, JsValue};
     ///
     /// let mut context = Context::default();
     ///
@@ -1097,15 +1102,18 @@ impl JsValue {
     /// let undefined = JsValue::undefined();
     ///
     /// let defined_result = defined_value
-    ///     .map_or(Ok(JsValue::new(true)), |v| v.add(&JsValue::from(5), &mut context))
+    ///     .map_or(Ok(JsValue::new(true)), |v| {
+    ///         v.add(&JsValue::from(5), &mut context)
+    ///     })
     ///     .unwrap();
     /// let undefined_result = undefined
-    ///     .map_or(Ok(JsValue::new(true)), |v| v.add(&JsValue::from(5), &mut context))
+    ///     .map_or(Ok(JsValue::new(true)), |v| {
+    ///         v.add(&JsValue::from(5), &mut context)
+    ///     })
     ///     .unwrap();
     ///
     /// assert_eq!(defined_result, JsValue::new(10));
     /// assert_eq!(undefined_result, JsValue::new(true));
-    ///
     /// ```
     #[inline]
     #[must_use]

--- a/core/engine/src/vm/call_frame/mod.rs
+++ b/core/engine/src/vm/call_frame/mod.rs
@@ -45,7 +45,6 @@ pub struct CallFrame {
     pub(crate) code_block: Gc<CodeBlock>,
     pub(crate) pc: u32,
     /// The register pointer, points to the first register in the stack.
-    ///
     // TODO: Check if storing the frame pointer instead of argument count and computing the
     //       argument count based on the pointers would be better for accessing the arguments
     //       and the elements before the register pointer.

--- a/core/parser/src/source/mod.rs
+++ b/core/parser/src/source/mod.rs
@@ -51,7 +51,8 @@ impl<'input> Source<'static, UTF16Input<'input>> {
     ///
     /// ```
     /// # use boa_parser::Source;
-    /// let utf16: Vec<u16> = "var array = [5, 4, 3, 2, 1];".encode_utf16().collect();
+    /// let utf16: Vec<u16> =
+    ///     "var array = [5, 4, 3, 2, 1];".encode_utf16().collect();
     /// let source = Source::from_utf16(&utf16);
     /// ```
     ///

--- a/core/runtime/src/store/from.rs
+++ b/core/runtime/src/store/from.rs
@@ -1,7 +1,7 @@
 //! All methods for serializing a [`JsValue`] into a [`JsValueStore`].
 
 use crate::store::{JsValueStore, StringStore, ValueStoreInner, unsupported_type};
-use boa_engine::builtins::array_buffer::ArrayBuffer;
+use boa_engine::builtins::array_buffer::{AlignedVec, ArrayBuffer};
 use boa_engine::builtins::error::Error;
 use boa_engine::object::builtins::{
     JsArray, JsArrayBuffer, JsDataView, JsDate, JsMap, JsRegExp, JsSet, JsTypedArray,
@@ -112,7 +112,7 @@ fn try_from_array_buffer_clone(
     seen: &mut SeenMap,
 ) -> JsResult<JsValueStore> {
     let data = buffer.data().ok_or_else(unsupported_type)?;
-    let data = data.to_vec();
+    let data = AlignedVec::from_slice(0, &data);
     let new_value = JsValueStore::new(ValueStoreInner::ArrayBuffer(data));
     seen.insert(original, new_value.clone());
 

--- a/core/runtime/src/store/mod.rs
+++ b/core/runtime/src/store/mod.rs
@@ -1,5 +1,6 @@
 //! Module containing the types related to the [`JsValueStore`].
 use boa_engine::bigint::RawBigInt;
+use boa_engine::builtins::array_buffer::AlignedVec;
 use boa_engine::builtins::error::ErrorKind;
 use boa_engine::builtins::typed_array::TypedArrayKind;
 use boa_engine::value::TryIntoJs;
@@ -105,7 +106,7 @@ enum ValueStoreInner {
     RegExp { source: String, flags: String },
 
     /// Array Buffer.
-    ArrayBuffer(Vec<u8>),
+    ArrayBuffer(AlignedVec<u8>),
 
     /// Dataview.
     #[expect(unused)]

--- a/core/runtime/src/store/to.rs
+++ b/core/runtime/src/store/to.rs
@@ -1,5 +1,6 @@
 //! All methods for deserializing a [`JsValueStore`] into a [`JsValue`].
 use crate::store::{JsValueStore, StringStore, ValueStoreInner, unsupported_type};
+use boa_engine::builtins::array_buffer::AlignedVec;
 use boa_engine::builtins::typed_array::TypedArrayKind;
 use boa_engine::object::builtins::{
     JsArray, JsArrayBuffer, JsDataView, JsDate, JsMap, JsRegExp, JsSet, js_typed_array_from_kind,
@@ -65,7 +66,7 @@ fn try_into_js_array_buffer(
     seen: &mut ReverseSeenMap,
     context: &mut Context,
 ) -> JsResult<JsValue> {
-    let buffer = JsArrayBuffer::from_byte_block(data.to_vec(), context)?;
+    let buffer = JsArrayBuffer::from_byte_block(AlignedVec::from_slice(0, data), context)?;
     let obj = JsObject::from(buffer);
     seen.insert(store, obj.clone());
     Ok(JsValue::from(obj))

--- a/core/string/src/builder.rs
+++ b/core/string/src/builder.rs
@@ -10,7 +10,6 @@ use std::{
 };
 
 /// A mutable builder to create instance of `JsString`.
-///
 #[derive(Debug)]
 pub struct JsStringBuilder<D: Copy> {
     cap: usize,
@@ -54,7 +53,6 @@ impl<D: Copy> JsStringBuilder<D> {
     ///
     /// - `new_len` must be less than or equal to `capacity()`.
     /// - The elements at `old_len..new_len` must be initialized.
-    ///
     #[inline]
     pub const unsafe fn set_len(&mut self, new_len: usize) {
         debug_assert!(new_len <= self.capacity());
@@ -581,7 +579,7 @@ impl Latin1JsStringBuilder {
 /// let mut s = Utf16JsStringBuilder::new();
 /// s.push(b'x' as u16);
 /// s.extend_from_slice(&[b'1', b'2', b'3'].map(u16::from));
-/// s.extend([0xD83C, 0xDFB9, 0xD83C, 0xDFB6, 0xD83C, 0xDFB5,]); // 🎹🎶🎵
+/// s.extend([0xD83C, 0xDFB9, 0xD83C, 0xDFB6, 0xD83C, 0xDFB5]); // 🎹🎶🎵
 /// let js_string = s.build();
 /// ```
 pub type Utf16JsStringBuilder = JsStringBuilder<u16>;

--- a/examples/src/bin/jsarraybuffer.rs
+++ b/examples/src/bin/jsarraybuffer.rs
@@ -1,7 +1,9 @@
 // This example shows how to manipulate a Javascript array using Rust code.
 
 use boa_engine::{
-    Context, JsResult, JsValue, js_string,
+    Context, JsResult, JsValue,
+    builtins::array_buffer::AlignedVec,
+    js_string,
     object::builtins::{JsArrayBuffer, JsDataView, JsUint8Array, JsUint32Array},
     property::Attribute,
 };
@@ -24,7 +26,7 @@ fn main() -> JsResult<()> {
     // We can also create array buffers from a user defined block of data.
     //
     // NOTE: The block data will not be cloned.
-    let blob_of_data: Vec<u8> = (0..=255).collect();
+    let blob_of_data = AlignedVec::from_iter(0, 0..=255);
     let array_buffer = JsArrayBuffer::from_byte_block(blob_of_data, context)?;
 
     // This the byte length of the new array buffer will be the length of block of data.
@@ -60,12 +62,15 @@ fn main() -> JsResult<()> {
         .unwrap();
 
     // We can also take the inner data from a JsArrayBuffer
-    let data_block: Vec<u8> = (0..5).collect();
+    let data_block = AlignedVec::from_iter(0, 0..5);
     let array_buffer = JsArrayBuffer::from_byte_block(data_block, context)?;
 
     let internal_buffer = array_buffer.detach(&JsValue::undefined())?;
 
-    assert_eq!(internal_buffer, (0..5).collect::<Vec<u8>>());
+    assert_eq!(
+        internal_buffer.as_slice(),
+        (0..5).collect::<Vec<u8>>().as_slice()
+    );
     let detached_err = array_buffer.detach(&JsValue::undefined());
     assert!(detached_err.is_err());
 


### PR DESCRIPTION
Our implementation of `ArrayBuffer` assumes all array allocations would be aligned to at least 64 bits. This works for amd64, but for other architectures it could be a wrong assumption to make, causing UB. This PR adds the `aligned-vec` crate to always allocate buffers at 64 bit boundaries, which solves the issue.

For an easy test, just run `cargo +nightly miri test array_buffer -p boa_engine`.