### PR TITLE
Update to temporal_rs to 0.1 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4201,9 +4201,9 @@ dependencies = [
 
 [[package]]
 name = "temporal_rs"
-version = "0.0.16"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67f9a1bf14704be6400d37f5ec9c10f139e563adae37dee83c4477178818486"
+checksum = "7305090e19b67670330fde1365b7c2c8a3b5a5ef6c92efc238b3b964a8c395fd"
 dependencies = [
  "core_maths",
  "icu_calendar",
@@ -4345,9 +4345,9 @@ dependencies = [
 
 [[package]]
 name = "timezone_provider"
-version = "0.0.16"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14fab21f70d8ca989ca76d399d26f4487747ac2def3816d93eaa966f8dfa2ea7"
+checksum = "071d5533454ed925a1f4841f7128d1d248f3465d6a18e9afe298212916cc3269"
 dependencies = [
  "combine",
  "jiff-tzdb",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,8 +124,8 @@ intrusive-collections = "0.9.7"
 cfg-if = "1.0.1"
 either = "1.15.0"
 sys-locale = "0.3.2"
-timezone_provider = { version = "0.0.16" }
-temporal_rs = { version = "0.0.16", default-features = false }
+timezone_provider = { version = "0.1.0" }
+temporal_rs = { version = "0.1.0", default-features = false }
 web-time = "1.1.0"
 criterion = "0.5.1"
 float-cmp = "0.10.0"

--- a/core/engine/src/builtins/temporal/instant/mod.rs
+++ b/core/engine/src/builtins/temporal/instant/mod.rs
@@ -647,7 +647,7 @@ impl Instant {
         };
 
         let ixdtf = instant.inner.to_ixdtf_string_with_provider(
-            timezone.as_ref(),
+            timezone,
             options,
             context.tz_provider(),
         )?;

--- a/core/engine/src/builtins/temporal/plain_date/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_date/mod.rs
@@ -989,7 +989,7 @@ impl PlainDate {
         // 3. Let calendar be ? ToTemporalCalendarIdentifier(calendarLike).
         let calendar = to_temporal_calendar_identifier(args.get_or_undefined(0))?;
         // 4. Return ! CreateTemporalDate(plainDate.[[ISODate]], calendar).
-        let resolved_date = date.inner.with_calendar(calendar)?;
+        let resolved_date = date.inner.with_calendar(calendar);
         create_temporal_date(resolved_date, None, context).map(Into::into)
     }
 
@@ -1337,7 +1337,7 @@ pub(crate) fn to_temporal_date(
             // ii. Let instant be ! CreateTemporalInstant(item.[[Nanoseconds]]).
             // iii. Let plainDateTime be ? GetPlainDateTimeFor(item.[[TimeZone]], instant, item.[[Calendar]]).
             // iv. Return ! CreateTemporalDate(plainDateTime.[[ISOYear]], plainDateTime.[[ISOMonth]], plainDateTime.[[ISODay]], plainDateTime.[[Calendar]]).
-            return zdt.inner.to_plain_date().map_err(Into::into);
+            return Ok(zdt.inner.to_plain_date());
         // c. If item has an [[InitializedTemporalDateTime]] internal slot, then
         } else if let Some(dt) = object.downcast_ref::<PlainDateTime>() {
             let options_obj = get_options_object(&options)?;

--- a/core/engine/src/builtins/temporal/plain_year_month/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_year_month/mod.rs
@@ -306,8 +306,8 @@ impl PlainYearMonth {
             })?;
         let inner = &year_month.inner;
         match field {
-            DateTimeValues::Year => Ok(inner.iso_year().into()),
-            DateTimeValues::Month => Ok(inner.iso_month().into()),
+            DateTimeValues::Year => Ok(inner.year().into()),
+            DateTimeValues::Month => Ok(inner.month().into()),
             DateTimeValues::MonthCode => {
                 Ok(JsString::from(InnerYearMonth::month_code(inner).as_str()).into())
             }

--- a/core/engine/src/builtins/temporal/zoneddatetime/mod.rs
+++ b/core/engine/src/builtins/temporal/zoneddatetime/mod.rs
@@ -452,8 +452,8 @@ impl BuiltInConstructor for ZonedDateTime {
 
         let inner = ZonedDateTimeInner::try_new_with_provider(
             epoch_nanos.to_i128(),
-            calendar,
             timezone,
+            calendar,
             context.tz_provider(),
         )?;
 
@@ -510,7 +510,7 @@ impl ZonedDateTime {
 
         Ok(JsString::from(
             zdt.inner
-                .timezone()
+                .time_zone()
                 .identifier_with_provider(context.tz_provider())?,
         )
         .into())
@@ -536,7 +536,7 @@ impl ZonedDateTime {
                 JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
             })?;
 
-        let era = zdt.inner.era()?;
+        let era = zdt.inner.era();
         Ok(era
             .map(|tinystr| JsString::from(tinystr.cow_to_lowercase()))
             .into_or_undefined())
@@ -562,7 +562,7 @@ impl ZonedDateTime {
                 JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
             })?;
 
-        Ok(zdt.inner.era_year()?.into_or_undefined())
+        Ok(zdt.inner.era_year().into_or_undefined())
     }
 
     /// 6.3.7 get `Temporal.ZonedDateTime.prototype.year`
@@ -585,7 +585,7 @@ impl ZonedDateTime {
                 JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
             })?;
 
-        Ok(zdt.inner.year()?.into())
+        Ok(zdt.inner.year().into())
     }
 
     /// 6.3.8 get `Temporal.ZonedDateTime.prototype.month`
@@ -608,7 +608,7 @@ impl ZonedDateTime {
                 JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
             })?;
 
-        Ok(zdt.inner.month()?.into())
+        Ok(zdt.inner.month().into())
     }
 
     /// 6.3.9 get `Temporal.ZonedDateTime.prototype.monthCode`
@@ -631,7 +631,7 @@ impl ZonedDateTime {
                 JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
             })?;
 
-        Ok(JsString::from(zdt.inner.month_code()?.as_str()).into())
+        Ok(JsString::from(zdt.inner.month_code().as_str()).into())
     }
 
     /// 6.3.10 get `Temporal.ZonedDateTime.prototype.day`
@@ -654,7 +654,7 @@ impl ZonedDateTime {
                 JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
             })?;
 
-        Ok(zdt.inner.day()?.into())
+        Ok(zdt.inner.day().into())
     }
 
     /// 6.3.11 get `Temporal.ZonedDateTime.prototype.hour`
@@ -677,7 +677,7 @@ impl ZonedDateTime {
                 JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
             })?;
 
-        Ok(zdt.inner.hour()?.into())
+        Ok(zdt.inner.hour().into())
     }
 
     /// 6.3.12 get `Temporal.ZonedDateTime.prototype.minute`
@@ -700,7 +700,7 @@ impl ZonedDateTime {
                 JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
             })?;
 
-        Ok(zdt.inner.minute()?.into())
+        Ok(zdt.inner.minute().into())
     }
 
     /// 6.3.13 get `Temporal.ZonedDateTime.prototype.second`
@@ -723,7 +723,7 @@ impl ZonedDateTime {
                 JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
             })?;
 
-        Ok(zdt.inner.second()?.into())
+        Ok(zdt.inner.second().into())
     }
 
     /// 6.3.14 get `Temporal.ZonedDateTime.prototype.millisecond`
@@ -746,7 +746,7 @@ impl ZonedDateTime {
                 JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
             })?;
 
-        Ok(zdt.inner.millisecond()?.into())
+        Ok(zdt.inner.millisecond().into())
     }
 
     /// 6.3.15 get `Temporal.ZonedDateTime.prototype.microsecond`
@@ -769,7 +769,7 @@ impl ZonedDateTime {
                 JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
             })?;
 
-        Ok(zdt.inner.microsecond()?.into())
+        Ok(zdt.inner.microsecond().into())
     }
 
     /// 6.3.16 get `Temporal.ZonedDateTime.prototype.nanosecond`
@@ -792,7 +792,7 @@ impl ZonedDateTime {
                 JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
             })?;
 
-        Ok(zdt.inner.nanosecond()?.into())
+        Ok(zdt.inner.nanosecond().into())
     }
 
     /// 6.3.17 get `Temporal.ZonedDateTime.prototype.epochMilliseconds`
@@ -861,7 +861,7 @@ impl ZonedDateTime {
                 JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
             })?;
 
-        Ok(zdt.inner.day_of_week()?.into())
+        Ok(zdt.inner.day_of_week().into())
     }
 
     /// 6.3.20 get `Temporal.ZonedDateTime.prototype.dayOfYear`
@@ -884,7 +884,7 @@ impl ZonedDateTime {
                 JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
             })?;
 
-        Ok(zdt.inner.day_of_year()?.into())
+        Ok(zdt.inner.day_of_year().into())
     }
 
     /// 6.3.21 get `Temporal.ZonedDateTime.prototype.weekOfYear`
@@ -907,7 +907,7 @@ impl ZonedDateTime {
                 JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
             })?;
 
-        Ok(zdt.inner.week_of_year()?.into_or_undefined())
+        Ok(zdt.inner.week_of_year().into_or_undefined())
     }
 
     /// 6.3.22 get `Temporal.ZonedDateTime.prototype.yearOfWeek`
@@ -930,7 +930,7 @@ impl ZonedDateTime {
                 JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
             })?;
 
-        Ok(zdt.inner.year_of_week()?.into_or_undefined())
+        Ok(zdt.inner.year_of_week().into_or_undefined())
     }
 
     /// 6.3.23 get `Temporal.ZonedDateTime.prototype.hoursInDay`
@@ -979,7 +979,7 @@ impl ZonedDateTime {
                 JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
             })?;
 
-        Ok(zdt.inner.days_in_week()?.into())
+        Ok(zdt.inner.days_in_week().into())
     }
 
     /// 6.3.25 get `Temporal.ZonedDateTime.prototype.daysInMonth`
@@ -1002,7 +1002,7 @@ impl ZonedDateTime {
                 JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
             })?;
 
-        Ok(zdt.inner.days_in_month()?.into())
+        Ok(zdt.inner.days_in_month().into())
     }
 
     /// 6.3.26 get `Temporal.ZonedDateTime.prototype.daysInYear`
@@ -1025,7 +1025,7 @@ impl ZonedDateTime {
                 JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
             })?;
 
-        Ok(zdt.inner.days_in_year()?.into())
+        Ok(zdt.inner.days_in_year().into())
     }
 
     /// 6.3.27 get `Temporal.ZonedDateTime.prototype.monthsInYear`
@@ -1048,7 +1048,7 @@ impl ZonedDateTime {
                 JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
             })?;
 
-        Ok(zdt.inner.months_in_year()?.into())
+        Ok(zdt.inner.months_in_year().into())
     }
 
     /// 6.3.28 get `Temporal.ZonedDateTime.prototype.inLeapYear`
@@ -1071,7 +1071,7 @@ impl ZonedDateTime {
                 JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
             })?;
 
-        Ok(zdt.inner.in_leap_year()?.into())
+        Ok(zdt.inner.in_leap_year().into())
     }
 
     /// 6.3.29 get Temporal.ZonedDateTime.prototype.offsetNanoseconds
@@ -1292,7 +1292,7 @@ impl ZonedDateTime {
 
         let inner = zdt
             .inner
-            .with_timezone_with_provider(timezone, context.tz_provider())?;
+            .with_time_zone_with_provider(timezone, context.tz_provider())?;
         create_temporal_zoneddatetime(inner, None, context).map(Into::into)
     }
 
@@ -1318,7 +1318,7 @@ impl ZonedDateTime {
 
         let calendar = to_temporal_calendar_identifier(args.get_or_undefined(0))?;
 
-        let inner = zdt.inner.with_calendar(calendar)?;
+        let inner = zdt.inner.with_calendar(calendar);
         create_temporal_zoneddatetime(inner, None, context).map(Into::into)
     }
 
@@ -1818,7 +1818,7 @@ impl ZonedDateTime {
                 JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
             })?;
 
-        let inner = zdt.inner.to_plain_date()?;
+        let inner = zdt.inner.to_plain_date();
         create_temporal_date(inner, None, context).map(Into::into)
     }
 
@@ -1842,7 +1842,7 @@ impl ZonedDateTime {
                 JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
             })?;
 
-        let new = zdt.inner.to_plain_time()?;
+        let new = zdt.inner.to_plain_time();
         create_temporal_time(new, None, context).map(Into::into)
     }
 
@@ -1870,7 +1870,7 @@ impl ZonedDateTime {
                 JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
             })?;
 
-        let new = zdt.inner.to_plain_datetime()?;
+        let new = zdt.inner.to_plain_date_time();
         create_temporal_datetime(new, None, context).map(Into::into)
     }
 }
@@ -2025,7 +2025,7 @@ pub(crate) fn to_temporal_timezone_identifier(
         && let Some(zdt) = obj.downcast_ref::<ZonedDateTime>()
     {
         // i. Return temporalTimeZoneLike.[[TimeZone]].
-        return Ok(*zdt.inner.timezone());
+        return Ok(*zdt.inner.time_zone());
     }
 
     // 2. If temporalTimeZoneLike is not a String, throw a TypeError exception.

--- a/core/engine/src/context/mod.rs
+++ b/core/engine/src/context/mod.rs
@@ -10,7 +10,9 @@ pub use hooks::{DefaultHooks, HostHooks};
 pub use icu::IcuError;
 use intrinsics::Intrinsics;
 #[cfg(feature = "temporal")]
-use timezone_provider::tzif::FsTzdbProvider;
+use temporal_rs::provider::TimeZoneProvider;
+#[cfg(feature = "temporal")]
+use timezone_provider::tzif::CompiledTzdbProvider;
 
 use crate::job::Job;
 use crate::module::DynModuleLoader;
@@ -106,7 +108,7 @@ pub struct Context {
     can_block: bool,
 
     #[cfg(feature = "temporal")]
-    tz_provider: FsTzdbProvider,
+    tz_provider: CompiledTzdbProvider,
 
     /// Intl data provider.
     #[cfg(feature = "intl")]
@@ -890,7 +892,7 @@ impl Context {
 
     /// Get the Time Zone Provider
     #[cfg(feature = "temporal")]
-    pub(crate) fn tz_provider(&self) -> &FsTzdbProvider {
+    pub(crate) fn tz_provider(&self) -> &impl TimeZoneProvider {
         &self.tz_provider
     }
 }
@@ -1101,7 +1103,7 @@ impl ContextBuilder {
             vm,
             strict: false,
             #[cfg(feature = "temporal")]
-            tz_provider: FsTzdbProvider::default(),
+            tz_provider: CompiledTzdbProvider::default(),
             #[cfg(feature = "intl")]
             intl_provider: if let Some(icu) = self.icu {
                 icu


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This is related to ongoing work for #1804

This PR updates Boa to the new 0.1 release of temporal_rs and timezone_provider.

Notably, I've switched us over to `CompiledTzdbProvider` for now, which will come with an increase binary size (I think the jiff_tzdb .dat file is ~200 Kb). I am hoping to update this in the near future to be more configurable though.