### PR TITLE
Implement upsert methods for Map

### DIFF
--- a/core/engine/src/builtins/mod.rs
+++ b/core/engine/src/builtins/mod.rs
@@ -38,6 +38,7 @@ mod builder;
 
 use builder::BuiltInBuilder;
 use error::Error;
+use num_traits::Zero;
 
 #[cfg(feature = "annex-b")]
 pub mod escape;
@@ -192,6 +193,23 @@ fn global_binding<B: BuiltInObject>(context: &mut Context) -> JsResult<()> {
         context,
     )?;
     Ok(())
+}
+
+/// [`CanonicalizeKeyedCollectionKey ( key )`][spec]
+///
+/// The abstract operation `CanonicalizeKeyedCollectionKey` takes argument key (an ECMAScript
+/// language value) and returns an ECMAScript language value. It performs the following steps
+/// when called:
+///
+///    1. If key is -0𝔽, return +0𝔽.
+///    2. Return key.
+///
+/// [spec]: https://tc39.es/ecma262/multipage/keyed-collections.html#sec-canonicalizekeyedcollectionkey
+fn canonicalize_keyed_collection_value(value: JsValue) -> JsValue {
+    match value.as_number() {
+        Some(n) if n.is_zero() => JsValue::new(0),
+        _ => value,
+    }
 }
 
 impl Realm {

--- a/core/engine/src/builtins/set/mod.rs
+++ b/core/engine/src/builtins/set/mod.rs
@@ -21,7 +21,10 @@ use self::ordered_set::OrderedSet;
 use super::iterable::IteratorHint;
 use crate::{
     Context, JsArgs, JsResult, JsString, JsValue,
-    builtins::{BuiltInBuilder, BuiltInConstructor, BuiltInObject, IntrinsicObject},
+    builtins::{
+        BuiltInBuilder, BuiltInConstructor, BuiltInObject, IntrinsicObject,
+        canonicalize_keyed_collection_value,
+    },
     context::intrinsics::{Intrinsics, StandardConstructor, StandardConstructors},
     error::JsNativeError,
     js_string,
@@ -112,23 +115,6 @@ fn get_set_record(obj: &JsValue, context: &mut Context) -> JsResult<SetRecord> {
         has: has.clone(),
         keys: keys.clone(),
     })
-}
-
-/// [`CanonicalizeKeyedCollectionKey ( key )`][spec]
-///
-/// The abstract operation `CanonicalizeKeyedCollectionKey` takes argument key (an ECMAScript
-/// language value) and returns an ECMAScript language value. It performs the following steps
-/// when called:
-///
-///    1. If key is -0𝔽, return +0𝔽.
-///    2. Return key.
-///
-/// [spec]: https://tc39.es/ecma262/#sec-set-iterable
-fn canonicalize_keyed_collection_value(value: JsValue) -> JsValue {
-    match value.as_number() {
-        Some(n) if n.is_zero() => JsValue::new(0),
-        _ => value,
-    }
 }
 
 #[derive(Debug, Clone)]

--- a/test262_config.toml
+++ b/test262_config.toml
@@ -5,66 +5,66 @@ commit = "a073f479f80b336256b7fc4e04700c827293e2fe"
 flags = []
 
 features = [
-  ### Unimplemented features:
+    ### Unimplemented features:
 
-  "FinalizationRegistry",
-  "IsHTMLDDA",
-  "symbols-as-weakmap-keys",
-  "Intl.DisplayNames",
-  "Intl.RelativeTimeFormat",
-  "Intl-enumeration",
-  "import-attributes",
-  "json-modules",
-  "Intl.DurationFormat",
-  "regexp-duplicate-named-groups",
-  "RegExp.escape",
-  "iterator-helpers",
-  "explicit-resource-management",
+    "FinalizationRegistry",
+    "IsHTMLDDA",
+    "symbols-as-weakmap-keys",
+    "Intl.DisplayNames",
+    "Intl.RelativeTimeFormat",
+    "Intl-enumeration",
+    "import-attributes",
+    "json-modules",
+    "Intl.DurationFormat",
+    "regexp-duplicate-named-groups",
+    "RegExp.escape",
+    "iterator-helpers",
+    "explicit-resource-management",
 
-  ### Pending proposals
+    ### Pending proposals
 
-  # https://github.com/tc39/proposal-intl-locale-info
-  "Intl.Locale-info",
+    # https://github.com/tc39/proposal-intl-locale-info
+    "Intl.Locale-info",
 
-  # https://github.com/tc39/proposal-regexp-legacy-features
-  "legacy-regexp",
+    # https://github.com/tc39/proposal-regexp-legacy-features
+    "legacy-regexp",
 
-  # https://github.com/tc39/proposal-defer-import-eval
-  "import-defer",
+    # https://github.com/tc39/proposal-defer-import-eval
+    "import-defer",
 
-  # https://github.com/tc39/proposal-iterator-sequencing
-  "iterator-sequencing",
+    # https://github.com/tc39/proposal-iterator-sequencing
+    "iterator-sequencing",
 
-  # https://github.com/tc39/proposal-realms
-  "ShadowRealm",
+    # https://github.com/tc39/proposal-realms
+    "ShadowRealm",
 
-  # https://github.com/tc39/proposal-decorators
-  "decorators",
+    # https://github.com/tc39/proposal-decorators
+    "decorators",
 
-  # https://github.com/tc39/proposal-json-parse-with-source
-  "json-parse-with-source",
+    # https://github.com/tc39/proposal-json-parse-with-source
+    "json-parse-with-source",
 
-  # Uint8Array Base64
-  # https://github.com/tc39/proposal-arraybuffer-base64
-  "uint8array-base64",
+    # Uint8Array Base64
+    # https://github.com/tc39/proposal-arraybuffer-base64
+    "uint8array-base64",
 
-  # Source Phase Imports
-  # https://github.com/tc39/proposal-source-phase-imports
-  "source-phase-imports",
-  # test262 special specifier
-  "source-phase-imports-module-source",
+    # Source Phase Imports
+    # https://github.com/tc39/proposal-source-phase-imports
+    "source-phase-imports",
+    # test262 special specifier
+    "source-phase-imports-module-source",
 
-  ### Non-standard
-  "caller",
+    ### Non-standard
+    "caller",
 ]
 
 tests = [
-  # Should throw an OOM error instead of filling the whole RAM.
-  "test/staging/sm/String/replace-math.js",
-  # Panics
-  "test/staging/sm/expressions/optional-chain-first-expression.js",
-  "test/staging/sm/regress/regress-554955-2.js",
-  "test/staging/sm/class/fields-static-class-name-binding-eval.js",
-  "test/staging/sm/regress/regress-554955-1.js",
-  "test/staging/sm/regress/regress-554955-3.js",
+    # Should throw an OOM error instead of filling the whole RAM.
+    "test/staging/sm/String/replace-math.js",
+    # Panics
+    "test/staging/sm/expressions/optional-chain-first-expression.js",
+    "test/staging/sm/regress/regress-554955-2.js",
+    "test/staging/sm/class/fields-static-class-name-binding-eval.js",
+    "test/staging/sm/regress/regress-554955-1.js",
+    "test/staging/sm/regress/regress-554955-3.js",
 ]

--- a/test262_config.toml
+++ b/test262_config.toml
@@ -5,70 +5,66 @@ commit = "a073f479f80b336256b7fc4e04700c827293e2fe"
 flags = []
 
 features = [
-    ### Unimplemented features:
+  ### Unimplemented features:
 
-    "FinalizationRegistry",
-    "IsHTMLDDA",
-    "symbols-as-weakmap-keys",
-    "Intl.DisplayNames",
-    "Intl.RelativeTimeFormat",
-    "Intl-enumeration",
-    "import-attributes",
-    "json-modules",
-    "Intl.DurationFormat",
-    "regexp-duplicate-named-groups",
-    "RegExp.escape",
-    "iterator-helpers",
-    "explicit-resource-management",
+  "FinalizationRegistry",
+  "IsHTMLDDA",
+  "symbols-as-weakmap-keys",
+  "Intl.DisplayNames",
+  "Intl.RelativeTimeFormat",
+  "Intl-enumeration",
+  "import-attributes",
+  "json-modules",
+  "Intl.DurationFormat",
+  "regexp-duplicate-named-groups",
+  "RegExp.escape",
+  "iterator-helpers",
+  "explicit-resource-management",
 
-    ### Pending proposals
+  ### Pending proposals
 
-    # https://github.com/tc39/proposal-intl-locale-info
-    "Intl.Locale-info",
+  # https://github.com/tc39/proposal-intl-locale-info
+  "Intl.Locale-info",
 
-    # https://github.com/tc39/proposal-regexp-legacy-features
-    "legacy-regexp",
+  # https://github.com/tc39/proposal-regexp-legacy-features
+  "legacy-regexp",
 
-    # https://github.com/tc39/proposal-defer-import-eval
-    "import-defer",
+  # https://github.com/tc39/proposal-defer-import-eval
+  "import-defer",
 
-    # https://github.com/tc39/proposal-iterator-sequencing
-    "iterator-sequencing",
+  # https://github.com/tc39/proposal-iterator-sequencing
+  "iterator-sequencing",
 
-    # https://github.com/tc39/proposal-realms
-    "ShadowRealm",
+  # https://github.com/tc39/proposal-realms
+  "ShadowRealm",
 
-    # https://github.com/tc39/proposal-decorators
-    "decorators",
+  # https://github.com/tc39/proposal-decorators
+  "decorators",
 
-    # https://github.com/tc39/proposal-json-parse-with-source
-    "json-parse-with-source",
+  # https://github.com/tc39/proposal-json-parse-with-source
+  "json-parse-with-source",
 
-    # Uint8Array Base64
-    # https://github.com/tc39/proposal-arraybuffer-base64
-    "uint8array-base64",
+  # Uint8Array Base64
+  # https://github.com/tc39/proposal-arraybuffer-base64
+  "uint8array-base64",
 
-    # Upsert
-    # https://github.com/tc39/proposal-upsert
-    "upsert",
+  # Source Phase Imports
+  # https://github.com/tc39/proposal-source-phase-imports
+  "source-phase-imports",
+  # test262 special specifier
+  "source-phase-imports-module-source",
 
-    # Source Phase Imports
-    # https://github.com/tc39/proposal-source-phase-imports
-    "source-phase-imports",
-    # test262 special specifier
-    "source-phase-imports-module-source",
-
-    ### Non-standard
-    "caller",
+  ### Non-standard
+  "caller",
 ]
 
 tests = [
-    # Should throw an OOM error instead of filling the whole RAM.
-    "test/staging/sm/String/replace-math.js",
-    # Panics
-    "test/staging/sm/expressions/optional-chain-first-expression.js",
-    "test/staging/sm/regress/regress-554955-2.js",
-    "test/staging/sm/class/fields-static-class-name-binding-eval.js",
-    "test/staging/sm/regress/regress-554955-1.js",
-    "test/staging/sm/regress/regress-554955-3.js",
+  # Should throw an OOM error instead of filling the whole RAM.
+  "test/staging/sm/String/replace-math.js",
+  # Panics
+  "test/staging/sm/expressions/optional-chain-first-expression.js",
+  "test/staging/sm/regress/regress-554955-2.js",
+  "test/staging/sm/class/fields-static-class-name-binding-eval.js",
+  "test/staging/sm/regress/regress-554955-1.js",
+  "test/staging/sm/regress/regress-554955-3.js",
 ]


### PR DESCRIPTION
This Pull Request implements part of [the Upsert proposal](https://tc39.es/proposal-upsert/) for `Map`.

It changes the following:

- Adds `Map.prototype.getOrInsert` method.
- Adds `Map.prototype.getOrInsertComputed` method.
- Implements canonicalization of keys (`-0` → `+0`) per the spec draft.
- Includes new tests for both methods to ensure correct behavior.