### PR TITLE
Add a simple cargo-make to the project

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -11,11 +11,20 @@ workspace = false
 
 [tasks.test262]
 command = "cargo"
-args = ["run", "--release", "--bin", "boa_tester", "--", "run", "${@}"]
+args = ["run", "@@remove-empty(RELEASE_ARG)", "--bin", "boa_tester", "--", "run", "${@}"]
 workspace = false
 
 [tasks.bench-js]
 condition = { env_set = [ "BOA_DATA_ROOT" ] }
 command = "cargo"
-args = ["run", "--bin", "boa", "--release", "--", "${BOA_DATA_ROOT}/bench/bench-v8/combined.js"]
+args = ["run", "--bin", "boa", "--release", "--", "@@remove-empty(BOA_DATA_ROOT)bench/bench-v8/combined.js"]
 workspace = false
+
+[env.development]
+RELEASE_ARG=""
+
+[env.profiling]
+RELEASE_ARG="--profile=release-dbg"
+
+[env.production]
+RELEASE_ARG="--release"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,0 +1,21 @@
+[tasks.format]
+install_crate = "rustfmt"
+command = "cargo"
+args = ["fmt", "--", "--emit=files"]
+workspace = false
+
+[tasks.test]
+command = "cargo"
+args = ["test", "${@}"]
+workspace = false
+
+[tasks.test262]
+command = "cargo"
+args = ["run", "--release", "--bin", "boa_tester", "--", "run", "${@}"]
+workspace = false
+
+[tasks.bench-js]
+condition = { env_set = [ "BOA_DATA_ROOT" ] }
+command = "cargo"
+args = ["run", "--bin", "boa", "--release", "--", "${BOA_DATA_ROOT}/bench/bench-v8/combined.js"]
+workspace = false


### PR DESCRIPTION
It makes it easier to run `test262` and JS benchmarks.