### PR TITLE
Editorconfig: specify indentation and dont overrule Makefile

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,3 +11,12 @@ indent_style = space
 [{Makefile,**.mk}]
 # Use tabs for indentation (Makefiles require tabs)
 indent_style = tab
+
+[{*.js,*.json,*.mjs}]
+indent_size = 2
+
+[*.md]
+indent_size = 2
+
+[flake.lock]
+#

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,11 +1,13 @@
 root = true
 
-[{Makefile,**.mk}]
-# Use tabs for indentation (Makefiles require tabs)
-indent_style = tab
-
 [*]
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+indent_size = 4
+indent_style = space
+
+[{Makefile,**.mk}]
+# Use tabs for indentation (Makefiles require tabs)
+indent_style = tab

--- a/.prettierignore
+++ b/.prettierignore
@@ -10,3 +10,6 @@ dist
 test262
 playwright-report
 test-results
+
+# For some reason Prettier likes to reformat JSON lock files.
+flake.lock


### PR DESCRIPTION
Before, the Makefile rule was overridden as rules are evaluated in order and merged in order. Also, if your editor is set to a different tab size/style, it wasn't correct for this project.

This will avoid changes like these in PRs: https://github.com/boa-dev/boa/pull/4436/files#diff-5f57f7d9e7e1a6c330e90b09112acd05a90d11afde996c58dd056f69e30fc4c1