### PR TITLE
perf: Improve `Math.sumPrecise` Performance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5465,9 +5465,9 @@ dependencies = [
 
 [[package]]
 name = "xsum"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fabb88ff489bf82568f8bec84ef6beca0b94762d0519521fafc739f0464193"
+checksum = "50bb108f04eb86f4390cb4d387bcac9c9db41100990ac0b3d527fb8c24a04daa"
 
 [[package]]
 name = "yoke"

--- a/core/engine/Cargo.toml
+++ b/core/engine/Cargo.toml
@@ -97,7 +97,7 @@ cow-utils.workspace = true
 futures-lite.workspace = true
 float16 = { version = "0.1", optional = true }
 lz4_flex = { workspace = true, optional = true }
-xsum = { version = "0.1.4", optional = true }
+xsum = { version = "0.1.5", optional = true }
 serde = { workspace = true, features = ["derive", "rc"] }
 serde_json.workspace = true
 rand.workspace = true


### PR DESCRIPTION
improve `Math.sumPrecise` performance by using `XsumVariant` instead of `XsumAuto`

<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

It changes the following:

- `XsumAuto` has some overhead to determine when to switch from `XsumSmall` to `XsumLarge`, so use `XsumVariant` instead.

