### PR TITLE
Fix test262 comments on new PR

### DIFF
--- a/.github/workflows/test262.yml
+++ b/.github/workflows/test262.yml
@@ -91,7 +91,7 @@ jobs:
           edit-mode: replace
 
       - name: Write a new comment
-        if: ! steps.previous-comment.outputs.comment-id
+        if: ${{ !steps.previous-comment.outputs.comment-id }}
         uses: peter-evans/create-or-update-comment@v5
         continue-on-error: true
         with:


### PR DESCRIPTION
Whoops, accidentally put the incorrect conditional to make the test262 action comment on a new PR without an existing comment. This fixes that.