### PR TITLE
Use persistent vector for performance comparison

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,6 +116,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "archery"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e0a5f99dfebb87bb342d0f53bb92c81842e100bbb915223e38349580e5441d"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -300,6 +306,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitmaps"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d084b0137aaa901caf9f1e8b21daa6aa24d41cd806e111335541eff9683bd6"
+
+[[package]]
 name = "blocking"
 version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -392,6 +404,7 @@ dependencies = [
  "icu_plurals",
  "icu_provider",
  "icu_segmenter",
+ "imbl",
  "indexmap",
  "indoc",
  "intrusive-collections",
@@ -457,6 +470,7 @@ dependencies = [
  "either",
  "hashbrown 0.16.0",
  "icu_locale_core",
+ "imbl",
  "thin-vec",
 ]
 
@@ -2443,6 +2457,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "imbl"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fade8ae6828627ad1fa094a891eccfb25150b383047190a3648d66d06186501"
+dependencies = [
+ "archery",
+ "bitmaps",
+ "imbl-sized-chunks",
+ "rand_core",
+ "rand_xoshiro",
+ "version_check",
+]
+
+[[package]]
+name = "imbl-sized-chunks"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f4241005618a62f8d57b2febd02510fb96e0137304728543dfc5fd6f052c22d"
+dependencies = [
+ "bitmaps",
+]
+
+[[package]]
 name = "indenter"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3424,6 +3461,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.3",
+]
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
+dependencies = [
+ "rand_core",
 ]
 
 [[package]]
@@ -4796,6 +4842,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "waker-fn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,6 +138,7 @@ futures-concurrency = "7.6.3"
 dynify = "0.1.2"
 futures-channel = "0.3.31"
 aligned-vec = "0.6.4"
+imbl = { version = "6.1.0" }
 
 # ICU4X
 
@@ -254,3 +255,7 @@ style = { level = "warn", priority = -1 }
 complexity = { level = "warn", priority = -1 }
 perf = { level = "warn", priority = -1 }
 pedantic = { level = "warn", priority = -1 }
+
+[profile.samply]
+inherits = "release"
+debug = true

--- a/core/engine/Cargo.toml
+++ b/core/engine/Cargo.toml
@@ -182,6 +182,7 @@ futures-concurrency.workspace = true
 temporal_rs = { workspace = true, optional = true }
 timezone_provider = { workspace = true, optional = true }
 iana-time-zone = { version = "0.1.64", optional = true }
+imbl.workspace = true
 
 [target.'cfg(all(target_family = "wasm", not(any(target_os = "emscripten", target_os = "wasi"))))'.dependencies]
 web-time = { workspace = true, optional = true }

--- a/core/engine/src/builtins/eval/mod.rs
+++ b/core/engine/src/builtins/eval/mod.rs
@@ -29,6 +29,7 @@ use boa_ast::{
 };
 use boa_gc::Gc;
 use boa_parser::{Parser, Source};
+use imbl::Vector;
 
 use super::{BuiltInBuilder, IntrinsicObject};
 
@@ -93,7 +94,7 @@ impl Eval {
         #[derive(Debug)]
         enum EnvStackAction {
             Truncate(usize),
-            Restore(Vec<Environment>),
+            Restore(Vector<Environment>),
         }
 
         // 1. Assert: If direct is false, then strictCaller is also false.

--- a/core/engine/src/builtins/function/arguments.rs
+++ b/core/engine/src/builtins/function/arguments.rs
@@ -15,6 +15,7 @@ use crate::{
 use boa_ast::{function::FormalParameterList, operations::bound_names, scope::Scope};
 use boa_gc::{Finalize, Gc, Trace};
 use boa_interner::Interner;
+use imbl::Vector;
 use rustc_hash::FxHashMap;
 use thin_vec::{ThinVec, thin_vec};
 
@@ -30,7 +31,7 @@ impl UnmappedArguments {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-createunmappedargumentsobject
     #[allow(clippy::new_ret_no_self)]
-    pub(crate) fn new(arguments_list: &[JsValue], context: &mut Context) -> JsObject {
+    pub(crate) fn new(arguments_list: Vector<JsValue>, context: &mut Context) -> JsObject {
         // 1. Let len be the number of elements in argumentsList.
         let len = arguments_list.len();
 
@@ -214,7 +215,7 @@ impl MappedArguments {
     pub(crate) fn new(
         func: &JsObject,
         binding_indices: &[Option<u32>],
-        arguments_list: &[JsValue],
+        arguments_list: Vector<JsValue>,
         env: &Gc<DeclarativeEnvironment>,
         context: &Context,
     ) -> JsObject {

--- a/core/engine/src/context/mod.rs
+++ b/core/engine/src/context/mod.rs
@@ -504,17 +504,8 @@ impl Context {
     /// The stack trace is returned ordered with the most recent frames first.
     #[inline]
     pub fn stack_trace(&self) -> impl Iterator<Item = &CallFrame> {
-        // Create a list containing the previous frames plus the current frame.
-        let frames: Vec<_> = self
-            .vm
-            .frames
-            .iter()
-            .chain(std::iter::once(&self.vm.frame))
-            .collect();
-
-        // The first frame is always a dummy frame (see `Vm` implementation for more details),
-        // so skip the dummy frame and return the reversed list so that the most recent frames are first.
-        frames.into_iter().skip(1).rev()
+        // Yield the current frame first, followed by the previous frames (skipping the dummy) in reverse order.
+        std::iter::once(&self.vm.frame).chain(self.vm.frames.iter().skip(1).rev())
     }
 
     /// Replaces the currently active realm with `realm`, and returns the old realm.

--- a/core/engine/src/native_function/mod.rs
+++ b/core/engine/src/native_function/mod.rs
@@ -362,9 +362,13 @@ pub(crate) fn native_function_call(
     context.vm.native_active_function = Some(this_function_object);
 
     let result = if constructor.is_some() {
-        function.call(&JsValue::undefined(), &args, context)
+        function.call(
+            &JsValue::undefined(),
+            &args.into_iter().collect::<Vec<_>>(),
+            context,
+        )
     } else {
-        function.call(&this, &args, context)
+        function.call(&this, &args.into_iter().collect::<Vec<_>>(), context)
     }
     .map_err(|err| err.inject_realm(context.realm().clone()));
 
@@ -425,7 +429,7 @@ fn native_function_construct(
     let _this = context.vm.stack.pop();
 
     let result = function
-        .call(&new_target, &args, context)
+        .call(&new_target, &args.into_iter().collect::<Vec<_>>(), context)
         .map_err(|err| err.inject_realm(context.realm().clone()))
         .and_then(|v| match v.variant() {
             JsVariant::Object(o) => Ok(o.clone()),

--- a/core/engine/src/vm/call_frame/mod.rs
+++ b/core/engine/src/vm/call_frame/mod.rs
@@ -11,7 +11,7 @@ use boa_ast::Position;
 use boa_ast::scope::BindingLocator;
 use boa_gc::{Finalize, Gc, Trace};
 use boa_string::JsString;
-use thin_vec::ThinVec;
+use imbl::Vector;
 
 bitflags::bitflags! {
     /// Flags associated with a [`CallFrame`].
@@ -53,12 +53,12 @@ pub struct CallFrame {
     pub(crate) env_fp: u32,
 
     // Iterators and their `[[Done]]` flags that must be closed when an abrupt completion is thrown.
-    pub(crate) iterators: ThinVec<IteratorRecord>,
+    pub(crate) iterators: Vector<IteratorRecord>,
 
     // The stack of bindings being updated.
     // SAFETY: Nothing in `BindingLocator` requires tracing, so this is safe.
     #[unsafe_ignore_trace]
-    pub(crate) binding_stack: Vec<BindingLocator>,
+    pub(crate) binding_stack: Vector<BindingLocator>,
 
     /// How many iterations a loop has done.
     pub(crate) loop_iteration_count: u64,
@@ -122,8 +122,8 @@ impl CallFrame {
             rp: 0,
             env_fp: 0,
             argument_count: 0,
-            iterators: ThinVec::new(),
-            binding_stack: Vec::new(),
+            iterators: Vector::new(),
+            binding_stack: Vector::new(),
             code_block,
             loop_iteration_count: 0,
             active_runnable,

--- a/core/engine/src/vm/opcode/arguments.rs
+++ b/core/engine/src/vm/opcode/arguments.rs
@@ -54,8 +54,8 @@ pub(crate) struct CreateUnmappedArgumentsObject;
 impl CreateUnmappedArgumentsObject {
     #[inline(always)]
     pub(super) fn operation(dst: VaryingOperand, context: &mut Context) {
-        let args = context.vm.stack.get_arguments(context.vm.frame()).to_vec();
-        let arguments = UnmappedArguments::new(&args, context);
+        let args = context.vm.stack.get_arguments(context.vm.frame());
+        let arguments = UnmappedArguments::new(args, context);
         context.vm.set_register(dst.into(), arguments.into());
     }
 }

--- a/core/engine/src/vm/opcode/call/mod.rs
+++ b/core/engine/src/vm/opcode/call/mod.rs
@@ -53,7 +53,7 @@ impl CallEval {
                 .calling_convention_pop_arguments(argument_count.into());
             let _func = context.vm.stack.pop();
             let _this = context.vm.stack.pop();
-            if let Some(x) = arguments.first() {
+            if let Some(x) = arguments.front() {
                 // i. Let argList be ? ArgumentListEvaluation of arguments.
                 // ii. If argList has no elements, return undefined.
                 // iii. Let evalArg be the first element of argList.

--- a/core/engine/src/vm/opcode/environment/mod.rs
+++ b/core/engine/src/vm/opcode/environment/mod.rs
@@ -298,8 +298,8 @@ impl SuperCallDerived {
 
         context.vm.stack.push(JsValue::undefined());
         context.vm.stack.push(super_constructor.clone());
-        for argument in Vec::from(context.vm.stack.get_arguments(context.vm.frame())) {
-            context.vm.stack.push(argument.clone());
+        for argument in context.vm.stack.get_arguments(context.vm.frame()) {
+            context.vm.stack.push(argument);
         }
         context.vm.stack.push(new_target);
 

--- a/core/engine/src/vm/opcode/generator/mod.rs
+++ b/core/engine/src/vm/opcode/generator/mod.rs
@@ -254,7 +254,7 @@ impl GeneratorDelegateNext {
             .vm
             .frame_mut()
             .iterators
-            .pop()
+            .pop_back()
             .expect("iterator stack should have at least an iterator");
 
         match resume_kind {
@@ -305,7 +305,7 @@ impl GeneratorDelegateNext {
             }
         }
 
-        context.vm.frame_mut().iterators.push(iterator_record);
+        context.vm.frame_mut().iterators.push_back(iterator_record);
 
         Ok(())
     }
@@ -347,7 +347,7 @@ impl GeneratorDelegateResume {
             .vm
             .frame_mut()
             .iterators
-            .pop()
+            .pop_back()
             .expect("iterator stack should have at least an iterator");
 
         if resume_kind == GeneratorResumeKind::Throw {
@@ -363,7 +363,7 @@ impl GeneratorDelegateResume {
             return Ok(());
         }
 
-        context.vm.frame_mut().iterators.push(iterator);
+        context.vm.frame_mut().iterators.push_front(iterator);
 
         Ok(())
     }

--- a/core/engine/src/vm/opcode/get/name.rs
+++ b/core/engine/src/vm/opcode/get/name.rs
@@ -136,7 +136,11 @@ impl GetLocator {
             context.vm.frame().code_block.bindings[usize::from(index)].clone();
         context.find_runtime_binding(&mut binding_locator)?;
 
-        context.vm.frame_mut().binding_stack.push(binding_locator);
+        context
+            .vm
+            .frame_mut()
+            .binding_stack
+            .push_back(binding_locator);
 
         Ok(())
     }
@@ -170,7 +174,11 @@ impl GetNameAndLocator {
             JsNativeError::reference().with_message(format!("{name} is not defined"))
         })?;
 
-        context.vm.frame_mut().binding_stack.push(binding_locator);
+        context
+            .vm
+            .frame_mut()
+            .binding_stack
+            .push_back(binding_locator);
         context.vm.set_register(value.into(), result);
         Ok(())
     }

--- a/core/engine/src/vm/opcode/iteration/for_in.rs
+++ b/core/engine/src/vm/opcode/iteration/for_in.rs
@@ -26,7 +26,7 @@ impl CreateForInIterator {
             .vm
             .frame_mut()
             .iterators
-            .push(IteratorRecord::new(iterator, next_method));
+            .push_back(IteratorRecord::new(iterator, next_method));
 
         Ok(())
     }

--- a/core/engine/src/vm/opcode/iteration/get.rs
+++ b/core/engine/src/vm/opcode/iteration/get.rs
@@ -16,7 +16,7 @@ impl GetIterator {
     pub(crate) fn operation(value: VaryingOperand, context: &mut Context) -> JsResult<()> {
         let value = context.vm.get_register(value.into()).clone();
         let iterator = value.get_iterator(IteratorHint::Sync, context)?;
-        context.vm.frame_mut().iterators.push(iterator);
+        context.vm.frame_mut().iterators.push_back(iterator);
         Ok(())
     }
 }
@@ -39,7 +39,7 @@ impl GetAsyncIterator {
     pub(crate) fn operation(value: VaryingOperand, context: &mut Context) -> JsResult<()> {
         let value = context.vm.get_register(value.into()).clone();
         let iterator = value.get_iterator(IteratorHint::Async, context)?;
-        context.vm.frame_mut().iterators.push(iterator);
+        context.vm.frame_mut().iterators.push_back(iterator);
         Ok(())
     }
 }

--- a/core/engine/src/vm/opcode/iteration/iterator.rs
+++ b/core/engine/src/vm/opcode/iteration/iterator.rs
@@ -22,12 +22,12 @@ impl IteratorNext {
             .vm
             .frame_mut()
             .iterators
-            .pop()
+            .pop_back()
             .expect("iterator stack should have at least an iterator");
 
         iterator.step(context)?;
 
-        context.vm.frame_mut().iterators.push(iterator);
+        context.vm.frame_mut().iterators.push_back(iterator);
 
         Ok(())
     }
@@ -57,7 +57,7 @@ impl IteratorFinishAsyncNext {
             .vm
             .frame_mut()
             .iterators
-            .pop()
+            .pop_back()
             .expect("iterator on the call frame must exist");
 
         let resume_kind = context
@@ -74,7 +74,7 @@ impl IteratorFinishAsyncNext {
 
         let value = context.vm.get_register(value.into());
         iterator.update_result(value.clone(), context)?;
-        context.vm.frame_mut().iterators.push(iterator);
+        context.vm.frame_mut().iterators.push_back(iterator);
         Ok(())
     }
 }
@@ -128,13 +128,13 @@ impl IteratorValue {
             .vm
             .frame_mut()
             .iterators
-            .pop()
+            .pop_back()
             .expect("iterator on the call frame must exist");
 
         let iter_value = iterator.value(context)?;
         context.vm.set_register(value.into(), iter_value);
 
-        context.vm.frame_mut().iterators.push(iterator);
+        context.vm.frame_mut().iterators.push_back(iterator);
 
         Ok(())
     }
@@ -186,7 +186,7 @@ impl IteratorReturn {
         (value, called): (VaryingOperand, VaryingOperand),
         context: &mut Context,
     ) -> JsResult<()> {
-        let Some(record) = context.vm.frame_mut().iterators.pop() else {
+        let Some(record) = context.vm.frame_mut().iterators.pop_back() else {
             context.vm.set_register(called.into(), false.into());
             return Ok(());
         };
@@ -237,7 +237,7 @@ impl IteratorToArray {
             .vm
             .frame_mut()
             .iterators
-            .pop()
+            .pop_back()
             .expect("iterator on the call frame must exist");
 
         let mut values = Vec::new();
@@ -246,7 +246,7 @@ impl IteratorToArray {
             let done = match iterator.step(context) {
                 Ok(done) => done,
                 Err(err) => {
-                    context.vm.frame_mut().iterators.push(iterator);
+                    context.vm.frame_mut().iterators.push_back(iterator);
                     return Err(err);
                 }
             };
@@ -258,13 +258,13 @@ impl IteratorToArray {
             match iterator.value(context) {
                 Ok(value) => values.push(value),
                 Err(err) => {
-                    context.vm.frame_mut().iterators.push(iterator);
+                    context.vm.frame_mut().iterators.push_back(iterator);
                     return Err(err);
                 }
             }
         }
 
-        context.vm.frame_mut().iterators.push(iterator);
+        context.vm.frame_mut().iterators.push_back(iterator);
         let result = Array::create_array_from_list(values, context);
         context.vm.set_register(array.into(), result.into());
         Ok(())

--- a/core/engine/src/vm/opcode/push/array.rs
+++ b/core/engine/src/vm/opcode/push/array.rs
@@ -101,7 +101,7 @@ impl PushIteratorToArray {
             .vm
             .frame_mut()
             .iterators
-            .pop()
+            .pop_back()
             .expect("iterator stack should have at least an iterator");
         while let Some(next) = iterator.step_value(context)? {
             Array::push(&array, &[next], context)?;

--- a/core/engine/src/vm/opcode/set/name.rs
+++ b/core/engine/src/vm/opcode/set/name.rs
@@ -85,7 +85,7 @@ impl SetNameByLocator {
         let strict = frame.code_block.strict();
         let binding_locator = frame
             .binding_stack
-            .pop()
+            .pop_back()
             .expect("locator should have been popped before");
         let value = context.vm.get_register(value.into()).clone();
 

--- a/core/gc/Cargo.toml
+++ b/core/gc/Cargo.toml
@@ -28,6 +28,7 @@ boa_string = { workspace = true, optional = true }
 either = { workspace = true, optional = true }
 thin-vec = { workspace = true, optional = true }
 icu_locale_core = { workspace = true, optional = true }
+imbl.workspace = true
 
 [lints]
 workspace = true

--- a/core/gc/src/trace.rs
+++ b/core/gc/src/trace.rs
@@ -14,6 +14,8 @@ use std::{
     sync::atomic,
 };
 
+use imbl::Vector;
+
 use crate::GcErasedPointer;
 
 /// A queue used to trace [`crate::Gc<T>`] non-recursively.
@@ -345,6 +347,16 @@ unsafe impl<T: Trace> Trace for Box<[T]> {
 impl<T: Trace> Finalize for Vec<T> {}
 // SAFETY: All the inner elements of the `Vec` are correctly marked.
 unsafe impl<T: Trace> Trace for Vec<T> {
+    custom_trace!(this, mark, {
+        for e in this {
+            mark(e);
+        }
+    });
+}
+
+impl<T: Trace> Finalize for Vector<T> {}
+// SAFETY: All the inner elements of the `Vector` are correctly marked.
+unsafe impl<T: Trace> Trace for Vector<T> {
     custom_trace!(this, mark, {
         for e in this {
             mark(e);


### PR DESCRIPTION
I'm just trying to replace some Vec with [imbl](https://docs.rs/imbl/latest/imbl/) and I want to see if someone could benchmark it. My best guess is that it should make the performance slightly worse.

This would be a draft PR for a long time, probably this would only introduce marginal return.