### PR TITLE
Fix unconditional `requires_function_scope` in constructor

### DIFF
--- a/core/engine/src/tests/class.rs
+++ b/core/engine/src/tests/class.rs
@@ -72,3 +72,21 @@ fn class_can_access_super_from_static_initializer() {
         TestAction::assert_eq("c.field", js_str!("super field")),
     ]);
 }
+
+// https://github.com/boa-dev/boa/issues/4400
+#[test]
+fn class_in_constructor() {
+    run_test_actions([
+        TestAction::run(indoc! {r#"
+            class C {
+                constructor() {
+                    class D {}
+                    this.v = D.name.toString()
+                }
+            }
+            let c = new C()
+
+        "#}),
+        TestAction::assert_eq("c.v", js_str!("D")),
+    ]);
+}


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request fixes/closes #4400.

It changes the following:

- In `ScopeIndexVisitor`, the `requires_function_scope` flag is always set to true for class constructors.

The root cause is that `compile_class` unconditionally flags the constructor with `HAS_FUNCTION_SCOPE`. However, when all bindings are local, `ScopeIndexVisitor` optimizes away the function scope. This creates a discrepancy between the compile-time state and the runtime state.

I'm not sure if this is the suitable approach. I attempted to remove the `function_scope` during constructor handling in `compile_class`, but this breaks other parts of the code. `CheckReturn` and `SuperCallDerived` rely on reading `this` from the `environment`. So, it seems we have to push the `function_scope` there.