### PR TITLE
ci: fix test262_release action

### DIFF
--- a/.github/workflows/test262_release.yml
+++ b/.github/workflows/test262_release.yml
@@ -53,7 +53,7 @@ jobs:
           cd data
           git config user.name "GitHub Actions"
           git config user.email "actions@github.com"
-          git add test262/results/${{ github.ref_name }}
+          git add test262/refs/tags/${{ github.ref_name }}
           git commit -m "Update Test262 results for release ${{ github.ref_name }}"
           git push
         env:


### PR DESCRIPTION
Release action [failed to upload the data for v0.21](https://github.com/boa-dev/boa/actions/runs/18700411793/job/53327762059). This PR fixes that. 
