### PR TITLE
Fix property initializer's access to outer scope variables

### DIFF
--- a/core/ast/src/scope_analyzer.rs
+++ b/core/ast/src/scope_analyzer.rs
@@ -447,7 +447,9 @@ impl<'ast> VisitorMut<'ast> for BindingEscapeAnalyzer<'_> {
             ClassElement::FieldDefinition(field) | ClassElement::StaticFieldDefinition(field) => {
                 self.visit_property_name_mut(&mut field.name)?;
                 if let Some(e) = &mut field.initializer {
+                    std::mem::swap(&mut self.scope, &mut field.scope);
                     self.visit_expression_mut(e)?;
+                    std::mem::swap(&mut self.scope, &mut field.scope);
                 }
                 ControlFlow::Continue(())
             }

--- a/core/engine/src/tests/class.rs
+++ b/core/engine/src/tests/class.rs
@@ -90,3 +90,30 @@ fn class_in_constructor() {
         TestAction::assert_eq("c.v", js_str!("D")),
     ]);
 }
+
+#[test]
+fn property_initializer_reference_escaped_variable() {
+    run_test_actions([
+        TestAction::run(indoc! {r#"
+            function run() {
+                const x = "D";
+                class C {
+                    a = x;
+                    static b = x;
+                    #c = x;
+                    static #d = x;
+
+                    getC() { return this.#c }
+                    static getD() { return C.#d }
+                }
+                return C
+            }
+            var Z = run();
+            var z = new Z();
+        "#}),
+        TestAction::assert_eq("z.a", js_str!("D")),
+        TestAction::assert_eq("Z.b", js_str!("D")),
+        TestAction::assert_eq("z.getC()", js_str!("D")),
+        TestAction::assert_eq("Z.getD()", js_str!("D")),
+    ]);
+}


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request fixes #4326.

It changes the following:

- visit class element field initializers with `field.scope` in `BindingEscapeAnalyzer`
