### PR TITLE
Implement RegExp.escape

### DIFF
--- a/core/engine/src/builtins/regexp/mod.rs
+++ b/core/engine/src/builtins/regexp/mod.rs
@@ -787,7 +787,8 @@ impl RegExp {
 
     /// Helper function to check if a character is a WhiteSpace character
     fn is_whitespace(ch: char) -> bool {
-        matches!(ch,
+        matches!(
+            ch,
             '\u{0009}' | // <TAB>
             '\u{000B}' | // <VT>
             '\u{000C}' | // <FF>
@@ -800,17 +801,18 @@ impl RegExp {
             '\u{200A}' | // Various space separators
             '\u{202F}' | // Narrow No-Break Space
             '\u{205F}' | // Medium Mathematical Space
-            '\u{3000}'   // Ideographic Space
+            '\u{3000}' // Ideographic Space
         )
     }
 
     /// Helper function to check if a character is a LineTerminator character
     fn is_line_terminator(ch: char) -> bool {
-        matches!(ch,
+        matches!(
+            ch,
             '\u{000A}' | // <LF>
             '\u{000D}' | // <CR>
             '\u{2028}' | // <LS>
-            '\u{2029}'   // <PS>
+            '\u{2029}' // <PS>
         )
     }
 
@@ -856,7 +858,23 @@ impl RegExp {
             match c {
                 CodePoint::Unicode(ch) => {
                     // EncodeForRegExpEscape step 1: SyntaxCharacter or U+002F (SOLIDUS)
-                    if matches!(ch, '^' | '$' | '\\' | '.' | '*' | '+' | '?' | '(' | ')' | '[' | ']' | '{' | '}' | '|' | '/') {
+                    if matches!(
+                        ch,
+                        '^' | '$'
+                            | '\\'
+                            | '.'
+                            | '*'
+                            | '+'
+                            | '?'
+                            | '('
+                            | ')'
+                            | '['
+                            | ']'
+                            | '{'
+                            | '}'
+                            | '|'
+                            | '/'
+                    ) {
                         escaped.push(b'\\' as u16);
                         escaped.push(ch as u16);
                     }
@@ -864,27 +882,40 @@ impl RegExp {
                     else if ch == '\x09' {
                         escaped.push(b'\\' as u16);
                         escaped.push(b't' as u16);
-                    }
-                    else if ch == '\x0A' {
+                    } else if ch == '\x0A' {
                         escaped.push(b'\\' as u16);
                         escaped.push(b'n' as u16);
-                    }
-                    else if ch == '\x0B' {
+                    } else if ch == '\x0B' {
                         escaped.push(b'\\' as u16);
                         escaped.push(b'v' as u16);
-                    }
-                    else if ch == '\x0C' {
+                    } else if ch == '\x0C' {
                         escaped.push(b'\\' as u16);
                         escaped.push(b'f' as u16);
-                    }
-                    else if ch == '\x0D' {
+                    } else if ch == '\x0D' {
                         escaped.push(b'\\' as u16);
                         escaped.push(b'r' as u16);
                     }
                     // Step 3-5: otherPunctuators or WhiteSpace or LineTerminator
-                    else if matches!(ch, ',' | '-' | '=' | '<' | '>' | '#' | '&' | '!' | '%' | ':' | ';' | '@' | '~' | '\'' | '`' | '"')
-                        || Self::is_whitespace(ch)
-                        || Self::is_line_terminator(ch) {
+                    else if matches!(
+                        ch,
+                        ',' | '-'
+                            | '='
+                            | '<'
+                            | '>'
+                            | '#'
+                            | '&'
+                            | '!'
+                            | '%'
+                            | ':'
+                            | ';'
+                            | '@'
+                            | '~'
+                            | '\''
+                            | '`'
+                            | '"'
+                    ) || Self::is_whitespace(ch)
+                        || Self::is_line_terminator(ch)
+                    {
                         let code = ch as u32;
                         if code <= 0xFF {
                             // Use \xXX format
@@ -906,7 +937,7 @@ impl RegExp {
                         let encoded = ch.encode_utf16(&mut buf);
                         escaped.extend_from_slice(encoded);
                     }
-                },
+                }
                 CodePoint::UnpairedSurrogate(surr) => {
                     // Escape unpaired surrogates using \uXXXX format
                     let escape_seq = format!("\\u{:04x}", surr);

--- a/core/engine/src/builtins/regexp/mod.rs
+++ b/core/engine/src/builtins/regexp/mod.rs
@@ -86,6 +86,7 @@ impl IntrinsicObject for RegExp {
             .name(js_string!("get source"))
             .build();
         let regexp = BuiltInBuilder::from_standard_constructor::<Self>(realm)
+            .static_method(Self::escape, js_string!("escape"), 1)
             .static_accessor(
                 JsSymbol::species(),
                 Some(get_species),
@@ -175,7 +176,7 @@ impl BuiltInObject for RegExp {
 impl BuiltInConstructor for RegExp {
     const CONSTRUCTOR_ARGUMENTS: usize = 2;
     const PROTOTYPE_STORAGE_SLOTS: usize = 30;
-    const CONSTRUCTOR_STORAGE_SLOTS: usize = 2;
+    const CONSTRUCTOR_STORAGE_SLOTS: usize = 3;
 
     const STANDARD_CONSTRUCTOR: fn(&StandardConstructors) -> &StandardConstructor =
         StandardConstructors::regexp;
@@ -770,6 +771,25 @@ impl RegExp {
 
             JsValue::new(js_string!(&s[..]))
         }
+    }
+
+    /// `RegExp.escape( string )`
+    ///
+    /// The `RegExp.escape()` static method escapes any potential regex syntax characters in a string,
+    /// and returns a new string that can be safely used as a literal pattern for the `RegExp()` constructor.
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///  - [MDN documentation][mdn]
+    ///
+    /// [spec]: https://tc39.es/proposal-regex-escaping/#sec-regexp.escape
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/escape
+    pub(crate) fn escape(
+        _: &JsValue,
+        args: &[JsValue],
+        context: &mut Context,
+    ) -> JsResult<JsValue> {
+        Ok(JsValue::new(js_string!("a")))
     }
 
     /// `RegExp.prototype.test( string )`

--- a/core/engine/src/builtins/regexp/mod.rs
+++ b/core/engine/src/builtins/regexp/mod.rs
@@ -816,21 +816,15 @@ impl RegExp {
         )
     }
 
-    pub(crate) fn escape(
-        _: &JsValue,
-        args: &[JsValue],
-        context: &mut Context,
-    ) -> JsResult<JsValue> {
+    pub(crate) fn escape(_: &JsValue, args: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         let arg = args.get_or_undefined(0);
 
         // 1. If S is not a String, throw a TypeError exception.
-        if !arg.is_string() {
+        let Some(string) = arg.as_string() else {
             return Err(JsNativeError::typ()
                 .with_message("RegExp.escape requires a string argument")
                 .into());
-        }
-
-        let string = arg.to_string(context)?;
+        };
 
         // 2. Let escaped be the empty String.
         let mut escaped = CommonJsStringBuilder::new();

--- a/core/engine/src/builtins/regexp/mod.rs
+++ b/core/engine/src/builtins/regexp/mod.rs
@@ -784,8 +784,8 @@ impl RegExp {
     ///
     /// [spec]: https://tc39.es/proposal-regex-escaping/#sec-regexp.escape
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/escape
-
-    /// Helper function to check if a character is a WhiteSpace character
+    ///
+    /// Helper function to check if a character is a `WhiteSpace` character
     fn is_whitespace(ch: char) -> bool {
         matches!(
             ch,
@@ -805,7 +805,7 @@ impl RegExp {
         )
     }
 
-    /// Helper function to check if a character is a LineTerminator character
+    /// Helper function to check if a character is a `LineTerminator` character
     fn is_line_terminator(ch: char) -> bool {
         matches!(
             ch,
@@ -841,17 +841,16 @@ impl RegExp {
             let code = c.as_u32();
 
             // 4.a. If escaped is the empty String and c is matched by either DecimalDigit or AsciiLetter, then
-            if index == 0 {
-                if let CodePoint::Unicode(ch) = c {
-                    if ch.is_ascii_digit() || ch.is_ascii_alphabetic() {
-                        // 4.a.ii-v. Escape using \xXX format
-                        let escape_seq = format!("\\x{:02x}", code);
-                        for ch in escape_seq.encode_utf16() {
-                            escaped.push(ch);
-                        }
-                        continue;
-                    }
+            if index == 0
+                && let CodePoint::Unicode(ch) = c
+                && (ch.is_ascii_digit() || ch.is_ascii_alphabetic())
+            {
+                // 4.a.ii-v. Escape using \xXX format
+                let escape_seq = format!("\\x{code:02x}");
+                for ch in escape_seq.encode_utf16() {
+                    escaped.push(ch);
                 }
+                continue;
             }
 
             // 4.b. Else, set escaped to the string-concatenation of escaped and EncodeForRegExpEscape(c).
@@ -875,25 +874,25 @@ impl RegExp {
                             | '|'
                             | '/'
                     ) {
-                        escaped.push(b'\\' as u16);
+                        escaped.push(u16::from(b'\\'));
                         escaped.push(ch as u16);
                     }
                     // Step 2: ControlEscape characters (Table 64)
                     else if ch == '\x09' {
-                        escaped.push(b'\\' as u16);
-                        escaped.push(b't' as u16);
+                        escaped.push(u16::from(b'\\'));
+                        escaped.push(u16::from(b't'));
                     } else if ch == '\x0A' {
-                        escaped.push(b'\\' as u16);
-                        escaped.push(b'n' as u16);
+                        escaped.push(u16::from(b'\\'));
+                        escaped.push(u16::from(b'n'));
                     } else if ch == '\x0B' {
-                        escaped.push(b'\\' as u16);
-                        escaped.push(b'v' as u16);
+                        escaped.push(u16::from(b'\\'));
+                        escaped.push(u16::from(b'v'));
                     } else if ch == '\x0C' {
-                        escaped.push(b'\\' as u16);
-                        escaped.push(b'f' as u16);
+                        escaped.push(u16::from(b'\\'));
+                        escaped.push(u16::from(b'f'));
                     } else if ch == '\x0D' {
-                        escaped.push(b'\\' as u16);
-                        escaped.push(b'r' as u16);
+                        escaped.push(u16::from(b'\\'));
+                        escaped.push(u16::from(b'r'));
                     }
                     // Step 3-5: otherPunctuators or WhiteSpace or LineTerminator
                     else if matches!(
@@ -919,13 +918,13 @@ impl RegExp {
                         let code = ch as u32;
                         if code <= 0xFF {
                             // Use \xXX format
-                            let escape_seq = format!("\\x{:02x}", code);
+                            let escape_seq = format!("\\x{code:02x}");
                             for ch in escape_seq.encode_utf16() {
                                 escaped.push(ch);
                             }
                         } else {
                             // Use \uXXXX format
-                            let escape_seq = format!("\\u{:04x}", code);
+                            let escape_seq = format!("\\u{code:04x}");
                             for ch in escape_seq.encode_utf16() {
                                 escaped.push(ch);
                             }
@@ -940,7 +939,7 @@ impl RegExp {
                 }
                 CodePoint::UnpairedSurrogate(surr) => {
                     // Escape unpaired surrogates using \uXXXX format
-                    let escape_seq = format!("\\u{:04x}", surr);
+                    let escape_seq = format!("\\u{surr:04x}");
                     for ch in escape_seq.encode_utf16() {
                         escaped.push(ch);
                     }

--- a/core/engine/src/builtins/regexp/tests.rs
+++ b/core/engine/src/builtins/regexp/tests.rs
@@ -89,12 +89,24 @@ fn flags() {
 #[test]
 fn escape() {
     run_test_actions([
-        TestAction::assert_eq(r"RegExp.escape('The Quick Brown Fox')", js_str!("\\x54he\\x20Quick\\x20Brown\\x20Fox")),
-        TestAction::assert_eq(r"RegExp.escape('Buy it. use it. break it. fix it.')", js_str!("\\x42uy\\x20it\\.\\x20use\\x20it\\.\\x20break\\x20it\\.\\x20fix\\x20it\\.")),
+        TestAction::assert_eq(
+            r"RegExp.escape('The Quick Brown Fox')",
+            js_str!("\\x54he\\x20Quick\\x20Brown\\x20Fox"),
+        ),
+        TestAction::assert_eq(
+            r"RegExp.escape('Buy it. use it. break it. fix it.')",
+            js_str!("\\x42uy\\x20it\\.\\x20use\\x20it\\.\\x20break\\x20it\\.\\x20fix\\x20it\\."),
+        ),
         TestAction::assert_eq(r"RegExp.escape('(*.*)')", js_str!("\\(\\*\\.\\*\\)")),
         TestAction::assert_eq(r"RegExp.escape('｡^･ｪ･^｡')", js_str!("｡\\^･ｪ･\\^｡")),
-        TestAction::assert_eq(r"RegExp.escape('😊 *_* +_+ ... 👍')", js_str!("😊\\x20\\*_\\*\\x20\\+_\\+\\x20\\.\\.\\.\\x20👍")),
-        TestAction::assert_eq(r"RegExp.escape('\\d \\D (?:)')", js_str!("\\\\d\\x20\\\\D\\x20\\(\\?\\x3a\\)")),
+        TestAction::assert_eq(
+            r"RegExp.escape('😊 *_* +_+ ... 👍')",
+            js_str!("😊\\x20\\*_\\*\\x20\\+_\\+\\x20\\.\\.\\.\\x20👍"),
+        ),
+        TestAction::assert_eq(
+            r"RegExp.escape('\\d \\D (?:)')",
+            js_str!("\\\\d\\x20\\\\D\\x20\\(\\?\\x3a\\)"),
+        ),
         TestAction::assert_native_error(
             "RegExp.escape(1)",
             JsNativeErrorKind::Type,

--- a/core/engine/src/builtins/regexp/tests.rs
+++ b/core/engine/src/builtins/regexp/tests.rs
@@ -87,6 +87,23 @@ fn flags() {
 }
 
 #[test]
+fn escape() {
+    run_test_actions([
+        TestAction::assert_eq(r"RegExp.escape('The Quick Brown Fox')", js_str!("\\x54he\\x20Quick\\x20Brown\\x20Fox")),
+        TestAction::assert_eq(r"RegExp.escape('Buy it. use it. break it. fix it.')", js_str!("\\x42uy\\x20it\\.\\x20use\\x20it\\.\\x20break\\x20it\\.\\x20fix\\x20it\\.")),
+        TestAction::assert_eq(r"RegExp.escape('(*.*)')", js_str!("\\(\\*\\.\\*\\)")),
+        TestAction::assert_eq(r"RegExp.escape('｡^･ｪ･^｡')", js_str!("｡\\^･ｪ･\\^｡")),
+        TestAction::assert_eq(r"RegExp.escape('😊 *_* +_+ ... 👍')", js_str!("😊\\x20\\*_\\*\\x20\\+_\\+\\x20\\.\\.\\.\\x20👍")),
+        TestAction::assert_eq(r"RegExp.escape('\\d \\D (?:)')", js_str!("\\\\d\\x20\\\\D\\x20\\(\\?\\x3a\\)")),
+        TestAction::assert_native_error(
+            "RegExp.escape(1)",
+            JsNativeErrorKind::Type,
+            "RegExp.escape requires a string argument",
+        ),
+    ])
+}
+
+#[test]
 fn last_index() {
     run_test_actions([
         TestAction::run(r"var regex = /[0-9]+(\.[0-9]+)?/g;"),

--- a/core/engine/src/builtins/regexp/tests.rs
+++ b/core/engine/src/builtins/regexp/tests.rs
@@ -112,7 +112,7 @@ fn escape() {
             JsNativeErrorKind::Type,
             "RegExp.escape requires a string argument",
         ),
-    ])
+    ]);
 }
 
 #[test]

--- a/test262_config.toml
+++ b/test262_config.toml
@@ -17,7 +17,6 @@ features = [
     "json-modules",
     "Intl.DurationFormat",
     "regexp-duplicate-named-groups",
-    "RegExp.escape",
     "iterator-helpers",
     "explicit-resource-management",
 


### PR DESCRIPTION
Closes #4443.

Implements a static method `escape` on the global `RegExp` object. The test cases have been added from the examples given in the [proposal](https://github.com/tc39/proposal-regex-escaping).