### PR TITLE
Throw on negative values when using `Overflow::Reject` in `Temporal.PlainTime.with`

### DIFF
--- a/core/engine/src/builtins/temporal/plain_time/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_time/mod.rs
@@ -31,6 +31,9 @@ use temporal_rs::{
     primitive::FiniteF64,
 };
 
+#[cfg(test)]
+mod tests;
+
 /// The `Temporal.PlainTime` built-in implementation.
 ///
 /// More information:

--- a/core/engine/src/builtins/temporal/plain_time/tests.rs
+++ b/core/engine/src/builtins/temporal/plain_time/tests.rs
@@ -1,0 +1,44 @@
+use indoc::indoc;
+
+use crate::{JsNativeErrorKind, TestAction, run_test_actions};
+
+#[test]
+fn with_overflow_reject_throws_on_negative_components() {
+    // Temporal Builtin tests.
+    run_test_actions([
+        TestAction::run(indoc! {"
+            let plain = new Temporal.PlainTime();
+            let options = {overflow: 'reject'};
+        "}),
+        TestAction::assert_native_error(
+            "plain.with({hour: -1}, options)",
+            JsNativeErrorKind::Range,
+            "time value 'hour' not in 0..23: -1",
+        ),
+        TestAction::assert_native_error(
+            "plain.with({minute: -1}, options)",
+            JsNativeErrorKind::Range,
+            "time value 'minute' not in 0..59: -1",
+        ),
+        TestAction::assert_native_error(
+            "plain.with({second: -1}, options)",
+            JsNativeErrorKind::Range,
+            "time value 'second' not in 0..59: -1",
+        ),
+        TestAction::assert_native_error(
+            "plain.with({millisecond: -1}, options)",
+            JsNativeErrorKind::Range,
+            "time value 'millisecond' not in 0..999: -1",
+        ),
+        TestAction::assert_native_error(
+            "plain.with({microsecond: -1}, options)",
+            JsNativeErrorKind::Range,
+            "time value 'microsecond' not in 0..999: -1",
+        ),
+        TestAction::assert_native_error(
+            "plain.with({nanosecond: -1}, options)",
+            JsNativeErrorKind::Range,
+            "time value 'nanosecond' not in 0..999: -1",
+        ),
+    ]);
+}


### PR DESCRIPTION
This PR fixes the last failing test on the `Temporal.PlainTime` test suite ([`throws-if-time-is-invalid-when-overflow-is-reject.js`](https://github.com/tc39/test262/blob/main/test/built-ins/Temporal/PlainTime/prototype/with/throws-if-time-is-invalid-when-overflow-is-reject.js)).