### PR TITLE
Add strict types to `Promise` objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ tests_wpt
 *.events
 chrome_profiler.json
 *.mm_profdata
+profile.json.gz
 
 # Logs
 *.log

--- a/core/engine/src/builtins/array/mod.rs
+++ b/core/engine/src/builtins/array/mod.rs
@@ -366,7 +366,8 @@ impl Array {
         }
 
         let array =
-            JsObject::from_proto_and_data_with_shared_shape(context.root_shape(), prototype, Array);
+            JsObject::from_proto_and_data_with_shared_shape(context.root_shape(), prototype, Array)
+                .upcast();
 
         // 6. Perform ! OrdinaryDefineOwnProperty(A, "length", PropertyDescriptor { [[Value]]: 𝔽(length), [[Writable]]: true, [[Enumerable]]: false, [[Configurable]]: false }).
         ordinary_define_own_property(

--- a/core/engine/src/builtins/async_generator/mod.rs
+++ b/core/engine/src/builtins/async_generator/mod.rs
@@ -517,7 +517,9 @@ impl AsyncGenerator {
         );
 
         let promise = match promise_completion {
-            Ok(value) => value,
+            Ok(value) => value
+                .downcast::<Promise>()
+                .expect("%Promise% constructor must always return a Promise object"),
             // 8. If promiseCompletion is an abrupt completion, then
             Err(e) => {
                 // a. Perform AsyncGeneratorCompleteStep(generator, promiseCompletion, true).

--- a/core/engine/src/builtins/error/aggregate.rs
+++ b/core/engine/src/builtins/error/aggregate.rs
@@ -89,7 +89,8 @@ impl BuiltInConstructor for AggregateError {
             context.root_shape(),
             prototype,
             Error::with_caller_position(ErrorKind::Aggregate, context),
-        );
+        )
+        .upcast();
 
         // 3. If message is not undefined, then
         let message = args.get_or_undefined(1);

--- a/core/engine/src/builtins/error/eval.rs
+++ b/core/engine/src/builtins/error/eval.rs
@@ -84,7 +84,7 @@ impl BuiltInConstructor for EvalError {
             context.root_shape(),
             prototype,
             Error::with_caller_position(ErrorKind::Eval, context),
-        );
+        ).upcast();
 
         // 3. If message is not undefined, then
         let message = args.get_or_undefined(0);

--- a/core/engine/src/builtins/error/eval.rs
+++ b/core/engine/src/builtins/error/eval.rs
@@ -84,7 +84,8 @@ impl BuiltInConstructor for EvalError {
             context.root_shape(),
             prototype,
             Error::with_caller_position(ErrorKind::Eval, context),
-        ).upcast();
+        )
+        .upcast();
 
         // 3. If message is not undefined, then
         let message = args.get_or_undefined(0);

--- a/core/engine/src/builtins/error/mod.rs
+++ b/core/engine/src/builtins/error/mod.rs
@@ -223,7 +223,8 @@ impl BuiltInConstructor for Error {
             context.root_shape(),
             prototype,
             Error::with_caller_position(ErrorKind::Error, context),
-        ).upcast();
+        )
+        .upcast();
 
         // 3. If message is not undefined, then
         let message = args.get_or_undefined(0);

--- a/core/engine/src/builtins/error/mod.rs
+++ b/core/engine/src/builtins/error/mod.rs
@@ -223,7 +223,7 @@ impl BuiltInConstructor for Error {
             context.root_shape(),
             prototype,
             Error::with_caller_position(ErrorKind::Error, context),
-        );
+        ).upcast();
 
         // 3. If message is not undefined, then
         let message = args.get_or_undefined(0);

--- a/core/engine/src/builtins/error/range.rs
+++ b/core/engine/src/builtins/error/range.rs
@@ -82,7 +82,8 @@ impl BuiltInConstructor for RangeError {
             context.root_shape(),
             prototype,
             Error::with_caller_position(ErrorKind::Range, context),
-        ).upcast();
+        )
+        .upcast();
 
         // 3. If message is not undefined, then
         let message = args.get_or_undefined(0);

--- a/core/engine/src/builtins/error/range.rs
+++ b/core/engine/src/builtins/error/range.rs
@@ -82,7 +82,7 @@ impl BuiltInConstructor for RangeError {
             context.root_shape(),
             prototype,
             Error::with_caller_position(ErrorKind::Range, context),
-        );
+        ).upcast();
 
         // 3. If message is not undefined, then
         let message = args.get_or_undefined(0);

--- a/core/engine/src/builtins/error/reference.rs
+++ b/core/engine/src/builtins/error/reference.rs
@@ -84,7 +84,8 @@ impl BuiltInConstructor for ReferenceError {
             context.root_shape(),
             prototype,
             Error::with_caller_position(ErrorKind::Reference, context),
-        ).upcast();
+        )
+        .upcast();
 
         // 3. If message is not undefined, then
         let message = args.get_or_undefined(0);

--- a/core/engine/src/builtins/error/reference.rs
+++ b/core/engine/src/builtins/error/reference.rs
@@ -84,7 +84,7 @@ impl BuiltInConstructor for ReferenceError {
             context.root_shape(),
             prototype,
             Error::with_caller_position(ErrorKind::Reference, context),
-        );
+        ).upcast();
 
         // 3. If message is not undefined, then
         let message = args.get_or_undefined(0);

--- a/core/engine/src/builtins/error/syntax.rs
+++ b/core/engine/src/builtins/error/syntax.rs
@@ -87,7 +87,7 @@ impl BuiltInConstructor for SyntaxError {
             context.root_shape(),
             prototype,
             Error::with_caller_position(ErrorKind::Syntax, context),
-        );
+        ).upcast();
 
         // 3. If message is not undefined, then
         let message = args.get_or_undefined(0);

--- a/core/engine/src/builtins/error/syntax.rs
+++ b/core/engine/src/builtins/error/syntax.rs
@@ -87,7 +87,8 @@ impl BuiltInConstructor for SyntaxError {
             context.root_shape(),
             prototype,
             Error::with_caller_position(ErrorKind::Syntax, context),
-        ).upcast();
+        )
+        .upcast();
 
         // 3. If message is not undefined, then
         let message = args.get_or_undefined(0);

--- a/core/engine/src/builtins/error/type.rs
+++ b/core/engine/src/builtins/error/type.rs
@@ -90,7 +90,8 @@ impl BuiltInConstructor for TypeError {
             context.root_shape(),
             prototype,
             Error::with_caller_position(ErrorKind::Type, context),
-        ).upcast();
+        )
+        .upcast();
 
         // 3. If message is not undefined, then
         let message = args.get_or_undefined(0);

--- a/core/engine/src/builtins/error/type.rs
+++ b/core/engine/src/builtins/error/type.rs
@@ -90,7 +90,7 @@ impl BuiltInConstructor for TypeError {
             context.root_shape(),
             prototype,
             Error::with_caller_position(ErrorKind::Type, context),
-        );
+        ).upcast();
 
         // 3. If message is not undefined, then
         let message = args.get_or_undefined(0);

--- a/core/engine/src/builtins/error/uri.rs
+++ b/core/engine/src/builtins/error/uri.rs
@@ -83,7 +83,8 @@ impl BuiltInConstructor for UriError {
             context.root_shape(),
             prototype,
             Error::with_caller_position(ErrorKind::Uri, context),
-        ).upcast();
+        )
+        .upcast();
 
         // 3. If message is not undefined, then
         let message = args.get_or_undefined(0);

--- a/core/engine/src/builtins/error/uri.rs
+++ b/core/engine/src/builtins/error/uri.rs
@@ -83,7 +83,7 @@ impl BuiltInConstructor for UriError {
             context.root_shape(),
             prototype,
             Error::with_caller_position(ErrorKind::Uri, context),
-        );
+        ).upcast();
 
         // 3. If message is not undefined, then
         let message = args.get_or_undefined(0);

--- a/core/engine/src/builtins/function/bound.rs
+++ b/core/engine/src/builtins/function/bound.rs
@@ -73,7 +73,7 @@ impl BoundFunction {
                 this,
                 args,
             },
-        ))
+        ).upcast())
     }
 
     /// Get a reference to the bound function's this.

--- a/core/engine/src/builtins/function/bound.rs
+++ b/core/engine/src/builtins/function/bound.rs
@@ -73,7 +73,8 @@ impl BoundFunction {
                 this,
                 args,
             },
-        ).upcast())
+        )
+        .upcast())
     }
 
     /// Get a reference to the bound function's this.

--- a/core/engine/src/builtins/function/mod.rs
+++ b/core/engine/src/builtins/function/mod.rs
@@ -1114,7 +1114,8 @@ fn function_construct(
             context.root_shape(),
             prototype,
             OrdinaryObject,
-        ).upcast();
+        )
+        .upcast();
 
         this.initialize_instance_elements(this_function_object, context)?;
 

--- a/core/engine/src/builtins/function/mod.rs
+++ b/core/engine/src/builtins/function/mod.rs
@@ -1114,7 +1114,7 @@ fn function_construct(
             context.root_shape(),
             prototype,
             OrdinaryObject,
-        );
+        ).upcast();
 
         this.initialize_instance_elements(this_function_object, context)?;
 

--- a/core/engine/src/builtins/intl/date_time_format.rs
+++ b/core/engine/src/builtins/intl/date_time_format.rs
@@ -183,7 +183,8 @@ pub(crate) fn to_date_time_options(
         context.root_shape(),
         options,
         OrdinaryObject,
-    ).upcast();
+    )
+    .upcast();
 
     // 3. Let needDefaults be true.
     let mut need_defaults = true;

--- a/core/engine/src/builtins/intl/date_time_format.rs
+++ b/core/engine/src/builtins/intl/date_time_format.rs
@@ -183,7 +183,7 @@ pub(crate) fn to_date_time_options(
         context.root_shape(),
         options,
         OrdinaryObject,
-    );
+    ).upcast();
 
     // 3. Let needDefaults be true.
     let mut need_defaults = true;

--- a/core/engine/src/builtins/intl/options.rs
+++ b/core/engine/src/builtins/intl/options.rs
@@ -132,7 +132,7 @@ pub(super) fn coerce_options_to_object(
             context.root_shape(),
             None,
             OrdinaryObject,
-        ));
+        ).upcast());
     }
 
     // 2. Return ? ToObject(options).

--- a/core/engine/src/builtins/intl/options.rs
+++ b/core/engine/src/builtins/intl/options.rs
@@ -132,7 +132,8 @@ pub(super) fn coerce_options_to_object(
             context.root_shape(),
             None,
             OrdinaryObject,
-        ).upcast());
+        )
+        .upcast());
     }
 
     // 2. Return ? ToObject(options).

--- a/core/engine/src/builtins/intl/segmenter/iterator.rs
+++ b/core/engine/src/builtins/intl/segmenter/iterator.rs
@@ -98,7 +98,8 @@ impl SegmentIterator {
                 string,
                 next_segment_index: 0,
             },
-        ).upcast()
+        )
+        .upcast()
     }
     /// [`%SegmentIteratorPrototype%.next ( )`][spec]
     ///

--- a/core/engine/src/builtins/intl/segmenter/iterator.rs
+++ b/core/engine/src/builtins/intl/segmenter/iterator.rs
@@ -98,7 +98,7 @@ impl SegmentIterator {
                 string,
                 next_segment_index: 0,
             },
-        )
+        ).upcast()
     }
     /// [`%SegmentIteratorPrototype%.next ( )`][spec]
     ///

--- a/core/engine/src/builtins/intl/segmenter/segments.rs
+++ b/core/engine/src/builtins/intl/segmenter/segments.rs
@@ -44,7 +44,7 @@ impl Segments {
             context.root_shape(),
             context.intrinsics().objects().segments_prototype(),
             Self { segmenter, string },
-        )
+        ).upcast()
     }
 
     /// [`%SegmentsPrototype%.containing ( index )`][spec]

--- a/core/engine/src/builtins/intl/segmenter/segments.rs
+++ b/core/engine/src/builtins/intl/segmenter/segments.rs
@@ -44,7 +44,8 @@ impl Segments {
             context.root_shape(),
             context.intrinsics().objects().segments_prototype(),
             Self { segmenter, string },
-        ).upcast()
+        )
+        .upcast()
     }
 
     /// [`%SegmentsPrototype%.containing ( index )`][spec]

--- a/core/engine/src/builtins/iterable/async_from_sync_iterator.rs
+++ b/core/engine/src/builtins/iterable/async_from_sync_iterator.rs
@@ -72,7 +72,8 @@ impl AsyncFromSyncIterator {
             Self {
                 sync_iterator_record,
             },
-        );
+        )
+        .upcast();
 
         // 3. Let nextMethod be ! Get(asyncIterator, "next").
         let next_method = async_iterator
@@ -347,7 +348,10 @@ impl AsyncFromSyncIterator {
                     "closing an iterator with an error must always return an error back",
                 ))
             }
-            other => other,
+            other => other.map(|o| {
+                o.downcast::<Promise>()
+                    .expect("%Promise% constructor must return a `Promise` object")
+            }),
         };
 
         // 8. IfAbruptRejectPromise(valueWrapper, promiseCapability).

--- a/core/engine/src/builtins/map/mod.rs
+++ b/core/engine/src/builtins/map/mod.rs
@@ -148,7 +148,8 @@ impl BuiltInConstructor for Map {
             context.root_shape(),
             prototype,
             <OrderedMap<JsValue>>::new(),
-        ).upcast();
+        )
+        .upcast();
 
         // 4. If iterable is either undefined or null, return map.
         let iterable = match args.get_or_undefined(0) {

--- a/core/engine/src/builtins/map/mod.rs
+++ b/core/engine/src/builtins/map/mod.rs
@@ -148,7 +148,7 @@ impl BuiltInConstructor for Map {
             context.root_shape(),
             prototype,
             <OrderedMap<JsValue>>::new(),
-        );
+        ).upcast();
 
         // 4. If iterable is either undefined or null, return map.
         let iterable = match args.get_or_undefined(0) {

--- a/core/engine/src/builtins/object/for_in_iterator.rs
+++ b/core/engine/src/builtins/object/for_in_iterator.rs
@@ -83,7 +83,7 @@ impl ForInIterator {
                 .iterator_prototypes()
                 .for_in(),
             Self::new(object),
-        )
+        ).upcast()
     }
 
     /// %ForInIteratorPrototype%.next( )

--- a/core/engine/src/builtins/object/for_in_iterator.rs
+++ b/core/engine/src/builtins/object/for_in_iterator.rs
@@ -83,7 +83,8 @@ impl ForInIterator {
                 .iterator_prototypes()
                 .for_in(),
             Self::new(object),
-        ).upcast()
+        )
+        .upcast()
     }
 
     /// %ForInIteratorPrototype%.next( )

--- a/core/engine/src/builtins/object/mod.rs
+++ b/core/engine/src/builtins/object/mod.rs
@@ -462,7 +462,8 @@ impl OrdinaryObject {
                     context.root_shape(),
                     prototype.as_object(),
                     OrdinaryObject,
-                ).upcast()
+                )
+                .upcast()
             }
             _ => {
                 return Err(JsNativeError::typ()

--- a/core/engine/src/builtins/object/mod.rs
+++ b/core/engine/src/builtins/object/mod.rs
@@ -462,7 +462,7 @@ impl OrdinaryObject {
                     context.root_shape(),
                     prototype.as_object(),
                     OrdinaryObject,
-                )
+                ).upcast()
             }
             _ => {
                 return Err(JsNativeError::typ()

--- a/core/engine/src/builtins/proxy/mod.rs
+++ b/core/engine/src/builtins/proxy/mod.rs
@@ -183,7 +183,7 @@ impl Proxy {
             context.root_shape(),
             context.intrinsics().constructors().object().prototype(),
             Self::new(target.clone(), handler.clone()),
-        );
+        ).upcast();
 
         // 8. Return P.
         Ok(p)

--- a/core/engine/src/builtins/proxy/mod.rs
+++ b/core/engine/src/builtins/proxy/mod.rs
@@ -183,7 +183,8 @@ impl Proxy {
             context.root_shape(),
             context.intrinsics().constructors().object().prototype(),
             Self::new(target.clone(), handler.clone()),
-        ).upcast();
+        )
+        .upcast();
 
         // 8. Return P.
         Ok(p)

--- a/core/engine/src/builtins/set/mod.rs
+++ b/core/engine/src/builtins/set/mod.rs
@@ -225,7 +225,7 @@ impl BuiltInConstructor for Set {
             context.root_shape(),
             prototype,
             OrderedSet::default(),
-        );
+        ).upcast();
 
         // 4. If iterable is either undefined or null, return set.
         let iterable = args.get_or_undefined(0);
@@ -269,7 +269,7 @@ impl Set {
             context.root_shape(),
             prototype,
             OrderedSet::new(),
-        )
+        ).upcast()
     }
 
     /// Utility for constructing `Set` objects from an iterator of `JsValue`'s.

--- a/core/engine/src/builtins/set/mod.rs
+++ b/core/engine/src/builtins/set/mod.rs
@@ -225,7 +225,8 @@ impl BuiltInConstructor for Set {
             context.root_shape(),
             prototype,
             OrderedSet::default(),
-        ).upcast();
+        )
+        .upcast();
 
         // 4. If iterable is either undefined or null, return set.
         let iterable = args.get_or_undefined(0);
@@ -269,7 +270,8 @@ impl Set {
             context.root_shape(),
             prototype,
             OrderedSet::new(),
-        ).upcast()
+        )
+        .upcast()
     }
 
     /// Utility for constructing `Set` objects from an iterator of `JsValue`'s.

--- a/core/engine/src/builtins/string/mod.rs
+++ b/core/engine/src/builtins/string/mod.rs
@@ -271,7 +271,8 @@ impl String {
         // 5. Set S.[[DefineOwnProperty]] as specified in 10.4.3.2.
         // 6. Set S.[[OwnPropertyKeys]] as specified in 10.4.3.3.
         let s =
-            JsObject::from_proto_and_data_with_shared_shape(context.root_shape(), prototype, value).upcast();
+            JsObject::from_proto_and_data_with_shared_shape(context.root_shape(), prototype, value)
+                .upcast();
 
         // 8. Perform ! DefinePropertyOrThrow(S, "length", PropertyDescriptor { [[Value]]: 𝔽(length),
         // [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: false }).

--- a/core/engine/src/builtins/string/mod.rs
+++ b/core/engine/src/builtins/string/mod.rs
@@ -271,7 +271,7 @@ impl String {
         // 5. Set S.[[DefineOwnProperty]] as specified in 10.4.3.2.
         // 6. Set S.[[OwnPropertyKeys]] as specified in 10.4.3.3.
         let s =
-            JsObject::from_proto_and_data_with_shared_shape(context.root_shape(), prototype, value);
+            JsObject::from_proto_and_data_with_shared_shape(context.root_shape(), prototype, value).upcast();
 
         // 8. Perform ! DefinePropertyOrThrow(S, "length", PropertyDescriptor { [[Value]]: 𝔽(length),
         // [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: false }).

--- a/core/engine/src/builtins/string/string_iterator.rs
+++ b/core/engine/src/builtins/string/string_iterator.rs
@@ -68,7 +68,8 @@ impl StringIterator {
                 string,
                 next_index: 0,
             },
-        ).upcast()
+        )
+        .upcast()
     }
 
     /// `StringIterator.prototype.next( )`

--- a/core/engine/src/builtins/string/string_iterator.rs
+++ b/core/engine/src/builtins/string/string_iterator.rs
@@ -68,7 +68,7 @@ impl StringIterator {
                 string,
                 next_index: 0,
             },
-        )
+        ).upcast()
     }
 
     /// `StringIterator.prototype.next( )`

--- a/core/engine/src/builtins/typed_array/builtin.rs
+++ b/core/engine/src/builtins/typed_array/builtin.rs
@@ -2776,7 +2776,8 @@ impl BuiltinTypedArray {
         let len = values.len() as u64;
         // 2. Perform ? AllocateTypedArrayBuffer(O, len).
         let buf = Self::allocate_buffer::<T>(len, context)?;
-        let obj = JsObject::from_proto_and_data_with_shared_shape(context.root_shape(), proto, buf).upcast();
+        let obj = JsObject::from_proto_and_data_with_shared_shape(context.root_shape(), proto, buf)
+            .upcast();
 
         // 3. Let k be 0.
         // 4. Repeat, while k < len,
@@ -2826,7 +2827,8 @@ impl BuiltinTypedArray {
 
         // 2. Let obj be ! IntegerIndexedObjectCreate(proto).
         let obj =
-            JsObject::from_proto_and_data_with_shared_shape(context.root_shape(), proto, indexed).upcast();
+            JsObject::from_proto_and_data_with_shared_shape(context.root_shape(), proto, indexed)
+                .upcast();
 
         // 9. Return obj.
         Ok(obj)
@@ -2981,7 +2983,8 @@ impl BuiltinTypedArray {
                 Some(byte_length),
                 Some(element_length),
             ),
-        ).upcast();
+        )
+        .upcast();
 
         // 17. Return unused.
         Ok(obj)
@@ -3094,7 +3097,8 @@ impl BuiltinTypedArray {
             context.root_shape(),
             proto,
             TypedArray::new(buffer, T::ERASED, offset, byte_length, array_length),
-        ).upcast())
+        )
+        .upcast())
     }
 
     /// `InitializeTypedArrayFromArrayLike ( O, arrayLike )`
@@ -3113,7 +3117,8 @@ impl BuiltinTypedArray {
 
         // 2. Perform ? AllocateTypedArrayBuffer(O, len).
         let buf = Self::allocate_buffer::<T>(len, context)?;
-        let obj = JsObject::from_proto_and_data_with_shared_shape(context.root_shape(), proto, buf).upcast();
+        let obj = JsObject::from_proto_and_data_with_shared_shape(context.root_shape(), proto, buf)
+            .upcast();
 
         // 3. Let k be 0.
         // 4. Repeat, while k < len,

--- a/core/engine/src/builtins/typed_array/builtin.rs
+++ b/core/engine/src/builtins/typed_array/builtin.rs
@@ -2776,7 +2776,7 @@ impl BuiltinTypedArray {
         let len = values.len() as u64;
         // 2. Perform ? AllocateTypedArrayBuffer(O, len).
         let buf = Self::allocate_buffer::<T>(len, context)?;
-        let obj = JsObject::from_proto_and_data_with_shared_shape(context.root_shape(), proto, buf);
+        let obj = JsObject::from_proto_and_data_with_shared_shape(context.root_shape(), proto, buf).upcast();
 
         // 3. Let k be 0.
         // 4. Repeat, while k < len,
@@ -2826,7 +2826,7 @@ impl BuiltinTypedArray {
 
         // 2. Let obj be ! IntegerIndexedObjectCreate(proto).
         let obj =
-            JsObject::from_proto_and_data_with_shared_shape(context.root_shape(), proto, indexed);
+            JsObject::from_proto_and_data_with_shared_shape(context.root_shape(), proto, indexed).upcast();
 
         // 9. Return obj.
         Ok(obj)
@@ -2981,7 +2981,7 @@ impl BuiltinTypedArray {
                 Some(byte_length),
                 Some(element_length),
             ),
-        );
+        ).upcast();
 
         // 17. Return unused.
         Ok(obj)
@@ -3094,7 +3094,7 @@ impl BuiltinTypedArray {
             context.root_shape(),
             proto,
             TypedArray::new(buffer, T::ERASED, offset, byte_length, array_length),
-        ))
+        ).upcast())
     }
 
     /// `InitializeTypedArrayFromArrayLike ( O, arrayLike )`
@@ -3113,7 +3113,7 @@ impl BuiltinTypedArray {
 
         // 2. Perform ? AllocateTypedArrayBuffer(O, len).
         let buf = Self::allocate_buffer::<T>(len, context)?;
-        let obj = JsObject::from_proto_and_data_with_shared_shape(context.root_shape(), proto, buf);
+        let obj = JsObject::from_proto_and_data_with_shared_shape(context.root_shape(), proto, buf).upcast();
 
         // 3. Let k be 0.
         // 4. Repeat, while k < len,

--- a/core/engine/src/builtins/weak_map/mod.rs
+++ b/core/engine/src/builtins/weak_map/mod.rs
@@ -100,7 +100,7 @@ impl BuiltInConstructor for WeakMap {
             context.root_shape(),
             prototype,
             NativeWeakMap::new(),
-        );
+        ).upcast();
 
         // 4. If iterable is either undefined or null, return map.
         let iterable = args.get_or_undefined(0);

--- a/core/engine/src/builtins/weak_map/mod.rs
+++ b/core/engine/src/builtins/weak_map/mod.rs
@@ -100,7 +100,8 @@ impl BuiltInConstructor for WeakMap {
             context.root_shape(),
             prototype,
             NativeWeakMap::new(),
-        ).upcast();
+        )
+        .upcast();
 
         // 4. If iterable is either undefined or null, return map.
         let iterable = args.get_or_undefined(0);

--- a/core/engine/src/builtins/weak_set/mod.rs
+++ b/core/engine/src/builtins/weak_set/mod.rs
@@ -89,7 +89,8 @@ impl BuiltInConstructor for WeakSet {
             context.root_shape(),
             prototype,
             NativeWeakSet::new(),
-        ).upcast();
+        )
+        .upcast();
 
         // 4. If iterable is either undefined or null, return set.
         let iterable = args.get_or_undefined(0);

--- a/core/engine/src/builtins/weak_set/mod.rs
+++ b/core/engine/src/builtins/weak_set/mod.rs
@@ -89,7 +89,7 @@ impl BuiltInConstructor for WeakSet {
             context.root_shape(),
             prototype,
             NativeWeakSet::new(),
-        );
+        ).upcast();
 
         // 4. If iterable is either undefined or null, return set.
         let iterable = args.get_or_undefined(0);

--- a/core/engine/src/class.rs
+++ b/core/engine/src/class.rs
@@ -49,14 +49,14 @@
 //!     // This is also called on instance construction, but it receives the object wrapping the
 //!     // native data as its `instance` argument.
 //!     fn object_constructor(
-//!         instance: &JsObject,
+//!         instance: &JsObject<Self>,
 //!         args: &[JsValue],
 //!         context: &mut Context,
 //!     ) -> JsResult<()> {
 //!         let age = args.get_or_undefined(1).to_number(context)?;
 //!
 //!         // Roughly equivalent to `this.age = Number(age)`.
-//!         instance.set(js_string!("age"), age, true, context)?;
+//!         instance.clone().upcast().set(js_string!("age"), age, true, context)?;
 //!
 //!         Ok(())
 //!     }

--- a/core/engine/src/class.rs
+++ b/core/engine/src/class.rs
@@ -140,7 +140,7 @@ pub trait Class: NativeObject + Sized {
     /// stored inside the native data.
     #[allow(unused_variables)] // Saves work when IDEs autocomplete trait impls.
     fn object_constructor(
-        instance: &JsObject,
+        instance: &JsObject<Self>,
         args: &[JsValue],
         context: &mut Context,
     ) -> JsResult<()> {
@@ -201,7 +201,7 @@ pub trait Class: NativeObject + Sized {
 
         Self::object_constructor(&object, args, context)?;
 
-        Ok(object)
+        Ok(object.upcast())
     }
 
     /// Constructs an instance of this class from its inner native data.
@@ -233,7 +233,7 @@ pub trait Class: NativeObject + Sized {
 
         Self::object_constructor(&object, &[], context)?;
 
-        Ok(object)
+        Ok(object.upcast())
     }
 }
 

--- a/core/engine/src/context/hooks.rs
+++ b/core/engine/src/context/hooks.rs
@@ -1,6 +1,6 @@
 use crate::{
     Context, JsResult, JsString, JsValue,
-    builtins::promise::OperationType,
+    builtins::{Promise, promise::OperationType},
     context::intrinsics::Intrinsics,
     job::JobCallback,
     object::{JsFunction, JsObject},
@@ -105,7 +105,7 @@ pub trait HostHooks {
     /// [spec]: https://tc39.es/ecma262/#sec-host-promise-rejection-tracker
     fn promise_rejection_tracker(
         &self,
-        _promise: &JsObject,
+        _promise: &JsObject<Promise>,
         _operation: OperationType,
         _context: &mut Context,
     ) {

--- a/core/engine/src/error.rs
+++ b/core/engine/src/error.rs
@@ -1265,7 +1265,8 @@ impl JsNativeError {
             context.root_shape(),
             prototype,
             Error::with_shadow_entry(tag, position.0.clone()),
-        );
+        )
+        .upcast();
 
         o.create_non_enumerable_data_property_or_throw(
             js_string!("message"),

--- a/core/engine/src/module/source.rs
+++ b/core/engine/src/module/source.rs
@@ -1322,6 +1322,11 @@ impl SourceTextModule {
             context,
         )
         .expect("cannot fail for the %Promise% intrinsic");
+        let promise = capability
+            .promise
+            .clone()
+            .downcast::<Promise>()
+            .expect("%Promise% constructor must always return a `Promise` object");
 
         // 4. Let fulfilledClosure be a new Abstract Closure with no parameters that captures module and performs the following steps when called:
         // 5. Let onFulfilled be CreateBuiltinFunction(fulfilledClosure, 0, "", « »).
@@ -1358,7 +1363,7 @@ impl SourceTextModule {
 
         // 8. Perform PerformPromiseThen(capability.[[Promise]], onFulfilled, onRejected).
         Promise::perform_promise_then(
-            capability.promise(),
+            &promise,
             Some(on_fulfilled),
             Some(on_rejected),
             None,

--- a/core/engine/src/native_function/mod.rs
+++ b/core/engine/src/native_function/mod.rs
@@ -440,7 +440,8 @@ fn native_function_construct(
                         context.root_shape(),
                         prototype,
                         OrdinaryObject,
-                    ))
+                    )
+                    .upcast())
                 } else {
                     Err(JsNativeError::typ()
                         .with_message("derived constructor can only return an Object or undefined")

--- a/core/engine/src/object/builtins/jsdate.rs
+++ b/core/engine/src/object/builtins/jsdate.rs
@@ -46,7 +46,8 @@ impl JsDate {
         let prototype = context.intrinsics().constructors().date().prototype();
         let now = Date::utc_now(context);
         let inner =
-            JsObject::from_proto_and_data_with_shared_shape(context.root_shape(), prototype, now);
+            JsObject::from_proto_and_data_with_shared_shape(context.root_shape(), prototype, now)
+                .upcast();
 
         Self { inner }
     }
@@ -554,7 +555,8 @@ impl JsDate {
                 context.root_shape(),
                 prototype,
                 date_time,
-            ),
+            )
+            .upcast(),
         })
     }
 }

--- a/core/engine/src/object/builtins/jsmap.rs
+++ b/core/engine/src/object/builtins/jsmap.rs
@@ -199,6 +199,7 @@ impl JsMap {
             prototype,
             <OrderedMap<JsValue>>::new(),
         )
+        .upcast()
     }
 
     /// Returns a new [`JsMapIterator`] object that yields the `[key, value]` pairs within the [`JsMap`] in insertion order.

--- a/core/engine/src/object/builtins/jsproxy.rs
+++ b/core/engine/src/object/builtins/jsproxy.rs
@@ -529,7 +529,8 @@ impl JsProxyBuilder {
             context.root_shape(),
             context.intrinsics().constructors().object().prototype(),
             Proxy::new(self.target, handler),
-        );
+        )
+        .upcast();
 
         JsProxy { inner: proxy }
     }

--- a/core/engine/src/object/jsobject.rs
+++ b/core/engine/src/object/jsobject.rs
@@ -190,7 +190,7 @@ impl JsObject {
         root_shape: &RootShape,
         prototype: O,
         data: T,
-    ) -> Self {
+    ) -> JsObject<T> {
         let internal_methods = data.internal_methods();
         let inner = Gc::new(VTableObject {
             object: GcRefCell::new(Object {
@@ -205,7 +205,7 @@ impl JsObject {
             vtable: internal_methods,
         });
 
-        JsObject { inner }.upcast()
+        JsObject { inner }
     }
 
     /// Downcasts the object's inner data if the object is of type `T`.

--- a/core/engine/src/object/mod.rs
+++ b/core/engine/src/object/mod.rs
@@ -510,7 +510,8 @@ impl<'ctx> ObjectInitializer<'ctx> {
             context.root_shape(),
             context.intrinsics().constructors().object().prototype(),
             data,
-        );
+        )
+        .upcast();
         Self { context, object }
     }
 
@@ -521,7 +522,8 @@ impl<'ctx> ObjectInitializer<'ctx> {
         context: &'ctx mut Context,
     ) -> Self {
         let object =
-            JsObject::from_proto_and_data_with_shared_shape(context.root_shape(), proto, data);
+            JsObject::from_proto_and_data_with_shared_shape(context.root_shape(), proto, data)
+                .upcast();
         Self { context, object }
     }
 

--- a/core/engine/src/value/conversions/mod.rs
+++ b/core/engine/src/value/conversions/mod.rs
@@ -1,6 +1,7 @@
 //! Conversions from JavaScript values into Rust values, and the other way around.
 
 use super::{JsBigInt, JsObject, JsString, JsSymbol, JsValue};
+use crate::NativeObject;
 use crate::value::inner::InnerValue;
 use crate::{js_string, string::JsStr};
 
@@ -91,10 +92,10 @@ impl From<bool> for JsValue {
     }
 }
 
-impl From<JsObject> for JsValue {
+impl<T: NativeObject> From<JsObject<T>> for JsValue {
     #[inline]
-    fn from(object: JsObject) -> Self {
-        Self::from_inner(InnerValue::object(object))
+    fn from(object: JsObject<T>) -> Self {
+        Self::from_inner(InnerValue::object(object.upcast()))
     }
 }
 

--- a/core/engine/src/value/mod.rs
+++ b/core/engine/src/value/mod.rs
@@ -262,16 +262,16 @@ impl JsValue {
     /// Returns the value as an object if the value is a promise, otherwise `None`.
     #[inline]
     #[must_use]
-    pub(crate) fn as_promise_object(&self) -> Option<JsObject> {
-        self.as_object().filter(|obj| obj.is::<Promise>())
+    pub(crate) fn as_promise_object(&self) -> Option<JsObject<Promise>> {
+        self.as_object()
+            .and_then(|obj| obj.downcast::<Promise>().ok())
     }
 
     /// Returns the value as a promise if the value is a promise, otherwise `None`.
     #[inline]
     #[must_use]
     pub fn as_promise(&self) -> Option<JsPromise> {
-        self.as_promise_object()
-            .and_then(|o| JsPromise::from_object(o).ok())
+        self.as_promise_object().map(JsPromise::from)
     }
 
     /// Returns true if the value is a regular expression object.

--- a/core/engine/src/vm/opcode/await/mod.rs
+++ b/core/engine/src/vm/opcode/await/mod.rs
@@ -34,7 +34,9 @@ impl Await {
             value.clone(),
             context,
         ) {
-            Ok(promise) => promise,
+            Ok(promise) => promise
+                .downcast::<Promise>()
+                .expect("%Promise% constructor must return a `Promise` object"),
             Err(err) => return context.handle_error(err),
         };
 

--- a/core/engine/src/vm/opcode/set/class_prototype.rs
+++ b/core/engine/src/vm/opcode/set/class_prototype.rs
@@ -34,7 +34,8 @@ impl SetClassPrototype {
             context.root_shape(),
             prototype,
             OrdinaryObject,
-        );
+        )
+        .upcast();
         let class = context.vm.get_register(class.into()).clone();
 
         {


### PR DESCRIPTION
Changes the return value of `JsObject::from_proto_and_data_with_shared_shape` to not upcast to `JsObject`, which in some cases allows storing `JsObject<Promise>` directly instead of having to downcast.

This process could also be done with the rest of the builtins, especially the iterator objects.