### PR TITLE
Improve strictness around `Map` and `Set` objects

### DIFF
--- a/core/engine/src/builtins/map/tests.rs
+++ b/core/engine/src/builtins/map/tests.rs
@@ -244,7 +244,7 @@ fn not_a_function() {
     run_test_actions([TestAction::assert_native_error(
         "let map = Map()",
         JsNativeErrorKind::Type,
-        "calling a builtin Map constructor without new is forbidden",
+        "cannot call `Map` constructor without new",
     )]);
 }
 
@@ -351,7 +351,7 @@ fn get_or_insert_computed_this_not_map() {
     run_test_actions([TestAction::assert_native_error(
         "Map.prototype.getOrInsertComputed.call({}, 'k', x => x)",
         JsNativeErrorKind::Type,
-        "`this` is not a Map",
+        "method `Map.prototype.getOrInsertComputed` called on incompatible receiver",
     )]);
 }
 
@@ -360,7 +360,7 @@ fn get_or_insert_computed_requires_callable() {
     run_test_actions([TestAction::assert_native_error(
         "new Map().getOrInsertComputed('k', undefined)",
         JsNativeErrorKind::Type,
-        "Method Map.prototype.getOrInsertComputed called with non-callable callback function",
+        "method `Map.prototype.getOrInsertComputed` called with non-callable callback function",
     )]);
 }
 

--- a/core/engine/src/builtins/mod.rs
+++ b/core/engine/src/builtins/mod.rs
@@ -225,7 +225,7 @@ fn global_binding<B: BuiltInObject>(context: &mut Context) -> JsResult<()> {
 ///    2. Return key.
 ///
 /// [spec]: https://tc39.es/ecma262/multipage/keyed-collections.html#sec-canonicalizekeyedcollectionkey
-fn canonicalize_keyed_collection_value(value: JsValue) -> JsValue {
+pub(crate) fn canonicalize_keyed_collection_key(value: JsValue) -> JsValue {
     match value.as_number() {
         Some(n) if n.is_zero() => JsValue::new(0),
         _ => value,

--- a/examples/src/bin/jsset.rs
+++ b/examples/src/bin/jsset.rs
@@ -9,30 +9,30 @@ fn main() -> Result<(), JsError> {
     // Create an empty set.
     let set = JsSet::new(context);
 
-    assert_eq!(set.size()?, 0);
+    assert_eq!(set.size(), 0);
     set.add(5, context)?;
-    assert_eq!(set.size()?, 1);
+    assert_eq!(set.size(), 1);
     set.add(10, context)?;
-    assert_eq!(set.size()?, 2);
-    set.clear(context)?;
-    assert_eq!(set.size()?, 0);
+    assert_eq!(set.size(), 2);
+    set.clear();
+    assert_eq!(set.size(), 0);
 
     set.add(js_string!("one"), context)?;
     set.add(js_string!("two"), context)?;
     set.add(js_string!("three"), context)?;
 
-    assert!(set.has(js_string!("one"), context)?);
-    assert_eq!(set.has(js_string!("One"), context)?, false);
+    assert!(set.has(js_string!("one")));
+    assert_eq!(set.has(js_string!("One")), false);
 
-    set.delete(js_string!("two"), context)?;
+    set.delete(js_string!("two"));
 
-    assert_eq!(set.has(js_string!("two"), context)?, false);
+    assert_eq!(set.has(js_string!("two"),), false);
 
-    set.clear(context)?;
+    set.clear();
 
-    assert_eq!(set.has(js_string!("one"), context)?, false);
-    assert_eq!(set.has(js_string!("three"), context)?, false);
-    assert_eq!(set.size()?, 0);
+    assert_eq!(set.has(js_string!("one")), false);
+    assert_eq!(set.has(js_string!("three")), false);
+    assert_eq!(set.size(), 0);
 
     // Add a slice into a set;
     set.add_items(
@@ -40,14 +40,14 @@ fn main() -> Result<(), JsError> {
         context,
     )?;
     // Will return 1, as one slice was added.
-    assert_eq!(set.size()?, 1);
+    assert_eq!(set.size(), 1);
 
     // Make a new set from a slice
     let slice_set = JsSet::from_iter([JsValue::new(1), JsValue::new(2), JsValue::new(3)], context);
     // Will return 3, as each element of slice was added into the set.
-    assert_eq!(slice_set.size()?, 3);
+    assert_eq!(slice_set.size(), 3);
 
-    set.clear(context)?;
+    set.clear();
 
     Ok(())
 }


### PR DESCRIPTION
Fixes #4493.
Depends on #4495.

This PR improves strictness on the implementations of `Map` and `Set` by ensuring borrows are as small as possible, and also by reimplementing our lock structs to be a bit less sporadic about when they lock and unlock the underlying map.

Additionally, it cleans up our implementations to use newer APIs such as the `js_error` macro, `upcast/downcast`, etc.