### PR TITLE
Optimize `NanBoxedValue` related operations

### DIFF
--- a/core/engine/src/bigint.rs
+++ b/core/engine/src/bigint.rs
@@ -7,6 +7,7 @@ use num_traits::{FromPrimitive, One, ToPrimitive, Zero, pow::Pow};
 use std::{
     fmt::{self, Display},
     ops::{Add, BitAnd, BitOr, BitXor, Div, Mul, Neg, Rem, Shl, Shr, Sub},
+    ptr::NonNull,
     rc::Rc,
 };
 
@@ -334,8 +335,9 @@ impl JsBigInt {
     #[inline]
     #[must_use]
     #[allow(unused, reason = "only used in nan-boxed implementation of JsValue")]
-    pub(crate) fn into_raw(self) -> *const RawBigInt {
-        Rc::into_raw(self.inner)
+    pub(crate) fn into_raw(self) -> NonNull<RawBigInt> {
+        // SAFETY: `Rc::into_raw` must always return a non-null pointer.
+        unsafe { NonNull::new_unchecked(Rc::into_raw(self.inner).cast_mut()) }
     }
 
     /// Constructs a `JsBigInt` from a pointer to [`RawBigInt`].

--- a/core/engine/src/value/inner/nan_boxed.rs
+++ b/core/engine/src/value/inner/nan_boxed.rs
@@ -115,7 +115,7 @@ use boa_string::{JsString, RawJsString};
 use core::fmt;
 use static_assertions::const_assert;
 use std::{
-    mem::ManuallyDrop,
+    mem::{self, ManuallyDrop},
     ptr::{self, NonNull},
 };
 
@@ -139,6 +139,7 @@ const _NAN_BOX_COMPAT_CHECK: () = const {
 ///
 /// All bit magic is done here.
 mod bits {
+    use std::ptr::NonNull;
 
     /// The mask for the bits that indicate if the value is a NaN-value.
     const MASK_NAN: u64 = 0x7FF0_0000_0000_0000;
@@ -262,19 +263,27 @@ mod bits {
         value & MASK_BOOLEAN_VALUE != 0
     }
 
-    pub(super) fn tag_pointer<T>(ptr: *mut T, type_mask: u64) -> u64 {
-        let value = ptr.addr() as u64;
+    #[inline(always)]
+    pub(super) fn tag_pointer<T>(ptr: NonNull<T>, type_mask: u64) -> u64 {
+        #[cold]
+        #[inline(never)]
+        fn unsupported_platform() {
+            panic!(
+                "this platform is not compatible with a nan-boxed `JsValueInner`\n\
+                enable the `jsvalue-enum` feature to use the enum-based `JsValueInner`"
+            )
+        }
+
+        let value = ptr.addr().get() as u64;
         let value_masked: u64 = value & MASK_POINTER_VALUE;
 
         // Assert alignment and location of the pointer.
-        assert_eq!(
-            value_masked, value,
-            "this platform is not compatible with a nan-boxed `JsValueInner`\n\
-            enable the `jsvalue-enum` feature to use the enum-based `JsValueInner`"
-        );
-
-        // Cannot have a null pointer.
-        assert_ne!(value_masked, 0, "pointer is null");
+        // TODO: we may want to have nan-boxing be the default only on
+        // certain platforms, and make it an unsafe operation
+        // to manually enable the implementation.
+        if value_masked != value {
+            unsupported_platform();
+        }
 
         value_masked | type_mask
     }
@@ -385,11 +394,11 @@ impl NanBoxedValue {
     /// pointer.
     ///
     /// This preserves the provenance of the original pointer.
-    fn from_object_like<T>(ptr: *mut T, addr: u64) -> Self {
+    fn from_object_like<T>(ptr: NonNull<T>, addr: u64) -> Self {
         Self {
             #[cfg(target_pointer_width = "32")]
             half: (addr >> 32) as u32,
-            ptr: ptr.cast::<()>().with_addr(addr as usize),
+            ptr: ptr.cast::<()>().as_ptr().with_addr(addr as usize),
         }
     }
 
@@ -445,7 +454,7 @@ impl NanBoxedValue {
     #[must_use]
     #[inline(always)]
     pub(crate) fn bigint(value: JsBigInt) -> Self {
-        let ptr = value.into_raw().cast_mut();
+        let ptr = value.into_raw();
         let addr = bits::tag_pointer(ptr, bits::MASK_BIGINT);
         Self::from_object_like(ptr, addr)
     }
@@ -454,7 +463,7 @@ impl NanBoxedValue {
     #[must_use]
     #[inline(always)]
     pub(crate) fn object(value: JsObject) -> Self {
-        let ptr = value.into_raw().as_ptr();
+        let ptr = value.into_raw();
         let addr = bits::tag_pointer(ptr, bits::MASK_OBJECT);
         Self::from_object_like(ptr, addr)
     }
@@ -463,7 +472,7 @@ impl NanBoxedValue {
     #[must_use]
     #[inline(always)]
     pub(crate) fn symbol(value: JsSymbol) -> Self {
-        let ptr = value.into_raw().as_ptr();
+        let ptr = value.into_raw();
         let addr = bits::tag_pointer(ptr, bits::MASK_SYMBOL);
         Self::from_object_like(ptr, addr)
     }
@@ -472,7 +481,7 @@ impl NanBoxedValue {
     #[must_use]
     #[inline(always)]
     pub(crate) fn string(value: JsString) -> Self {
-        let ptr = value.into_raw().as_ptr();
+        let ptr = value.into_raw();
         let addr = bits::tag_pointer(ptr, bits::MASK_STRING);
         Self::from_object_like(ptr, addr)
     }

--- a/core/engine/src/value/inner/nan_boxed.rs
+++ b/core/engine/src/value/inner/nan_boxed.rs
@@ -265,6 +265,8 @@ mod bits {
 
     #[inline(always)]
     pub(super) fn tag_pointer<T>(ptr: NonNull<T>, type_mask: u64) -> u64 {
+        // Mark this as `cold` since on well-behaved platforms
+        // this will never be called.
         #[cold]
         #[inline(never)]
         fn unsupported_platform() {
@@ -351,6 +353,9 @@ unsafe impl Trace for NanBoxedValue {
 impl Clone for NanBoxedValue {
     #[inline(always)]
     fn clone(&self) -> Self {
+        // This way of inlining ensures the compiler
+        // knows it can convert the match into a
+        // jump table.
         match self.value() & bits::MASK_KIND {
             bits::MASK_OBJECT => unsafe {
                 mem::forget((*self.as_object_unchecked()).clone());

--- a/core/gc/src/internals/gc_header.rs
+++ b/core/gc/src/internals/gc_header.rs
@@ -65,7 +65,7 @@ impl GcHeader {
         #[cold]
         #[inline(never)]
         fn overflow_panic() {
-            panic!("too many references to the gc");
+            panic!("too many references to a gc allocation");
         }
 
         let count = self.ref_count.get().wrapping_add(1);

--- a/core/gc/src/internals/gc_header.rs
+++ b/core/gc/src/internals/gc_header.rs
@@ -1,4 +1,4 @@
-use std::{cell::Cell, fmt, hint};
+use std::{cell::Cell, fmt};
 
 const MARK_MASK: u32 = 1 << (u32::BITS - 1);
 const NON_ROOTS_MASK: u32 = !MARK_MASK;

--- a/core/gc/src/internals/gc_header.rs
+++ b/core/gc/src/internals/gc_header.rs
@@ -65,7 +65,7 @@ impl GcHeader {
         #[cold]
         #[inline(never)]
         fn overflow_panic() {
-            panic!("ref count overflow")
+            panic!("too many references to the gc");
         }
 
         let count = self.ref_count.get();

--- a/core/gc/src/internals/gc_header.rs
+++ b/core/gc/src/internals/gc_header.rs
@@ -60,6 +60,8 @@ impl GcHeader {
     }
 
     pub(crate) fn inc_ref_count(&self) {
+        // Mark this as `cold` since the ref count will
+        // (almost) never overflow.
         #[cold]
         #[inline(never)]
         fn overflow_panic() {

--- a/core/gc/src/internals/gc_header.rs
+++ b/core/gc/src/internals/gc_header.rs
@@ -70,12 +70,6 @@ impl GcHeader {
 
         let count = self.ref_count.get();
 
-        // SAFETY: The reference count will never be zero when this is
-        // called.
-        unsafe {
-            hint::assert_unchecked(count != 0);
-        }
-
         self.ref_count.set(count.wrapping_add(1));
 
         if count == 0 {

--- a/core/gc/src/internals/gc_header.rs
+++ b/core/gc/src/internals/gc_header.rs
@@ -68,9 +68,9 @@ impl GcHeader {
             panic!("too many references to the gc");
         }
 
-        let count = self.ref_count.get();
+        let count = self.ref_count.get().wrapping_add(1);
 
-        self.ref_count.set(count.wrapping_add(1));
+        self.ref_count.set(count);
 
         if count == 0 {
             overflow_panic();


### PR DESCRIPTION
Another batch of optimizations.

- Optimize NanBoxedValue::clone by inlining the calls to `as_object/string/symbol/bigint`.
- Optimize NanBoxedValue::tag_pointer by receiving a `NonNull` pointer, which removes the assertion we have there. Also marks the rarest path (unsupported platform) as a cold function.
- Optimize GcHeader::inc_ref_count by marking the possible ref count overflow as a cold path.

### Main results

RESULT Richards 237
RESULT DeltaBlue 243
RESULT Crypto 192
RESULT RayTrace 524
RESULT EarleyBoyer 618
RESULT RegExp 87.6
RESULT Splay 877
RESULT NavierStokes 427
SCORE 323

### PR results

RESULT Richards 229
RESULT DeltaBlue 238
RESULT Crypto 197
RESULT RayTrace 532
RESULT EarleyBoyer 635
RESULT RegExp 91.8
RESULT Splay 888
RESULT NavierStokes 439
SCORE 327
