### PR TITLE
Remove `environments` and `realm` fields from the Vm

### DIFF
--- a/core/engine/src/builtins/eval/mod.rs
+++ b/core/engine/src/builtins/eval/mod.rs
@@ -137,7 +137,13 @@ impl Eval {
         // 8. Let inDerivedConstructor be false.
         // 9. Let inClassFieldInitializer be false.
         // a. Let thisEnvRec be GetThisEnvironment().
-        let flags = match context.vm.frame.environments.get_this_environment().as_function() {
+        let flags = match context
+            .vm
+            .frame
+            .environments
+            .get_this_environment()
+            .as_function()
+        {
             // 10. If direct is true, then
             //     b. If thisEnvRec is a Function Environment Record, then
             Some(function_env) if direct => {

--- a/core/engine/src/builtins/eval/mod.rs
+++ b/core/engine/src/builtins/eval/mod.rs
@@ -137,7 +137,7 @@ impl Eval {
         // 8. Let inDerivedConstructor be false.
         // 9. Let inClassFieldInitializer be false.
         // a. Let thisEnvRec be GetThisEnvironment().
-        let flags = match context.vm.environments.get_this_environment().as_function() {
+        let flags = match context.vm.frame.environments.get_this_environment().as_function() {
             // 10. If direct is true, then
             //     b. If thisEnvRec is a Function Environment Record, then
             Some(function_env) if direct => {
@@ -205,11 +205,11 @@ impl Eval {
 
             // Poison the last parent function environment, because it may contain new declarations after/during eval.
             if !strict {
-                context.vm.environments.poison_until_last_function();
+                context.vm.frame.environments.poison_until_last_function();
             }
 
             // Set the compile time environment to the current running environment and save the number of current environments.
-            let environments_len = context.vm.environments.len();
+            let environments_len = context.vm.frame.environments.len();
 
             // Pop any added runtime environments that were not removed during the eval execution.
             EnvStackAction::Truncate(environments_len)
@@ -217,22 +217,22 @@ impl Eval {
             // If the call to eval is indirect, the code is executed in the global environment.
 
             // Pop all environments before the eval execution.
-            let environments = context.vm.environments.pop_to_global();
+            let environments = context.vm.frame.environments.pop_to_global();
 
             // Restore all environments to the state from before the eval execution.
             EnvStackAction::Restore(environments)
         };
 
         let context = &mut context.guard(move |ctx| match action {
-            EnvStackAction::Truncate(len) => ctx.vm.environments.truncate(len),
+            EnvStackAction::Truncate(len) => ctx.vm.frame.environments.truncate(len),
             EnvStackAction::Restore(envs) => {
-                ctx.vm.environments.truncate(0);
-                ctx.vm.environments.extend(envs);
+                ctx.vm.frame.environments.truncate(0);
+                ctx.vm.frame.environments.extend(envs);
             }
         });
 
         let (var_environment, mut variable_scope) =
-            if let Some(e) = context.vm.environments.outer_function_environment() {
+            if let Some(e) = context.vm.frame.environments.outer_function_environment() {
                 (e.0, e.1)
             } else {
                 (
@@ -259,7 +259,7 @@ impl Eval {
             context,
         )?;
 
-        let in_with = context.vm.environments.has_object_environment();
+        let in_with = context.vm.frame.environments.has_object_environment();
 
         let source_text = SourceText::new(source);
         let spanned_source_text = SpannedSourceText::new_source_only(source_text);
@@ -321,8 +321,8 @@ impl Eval {
             var_environment.extend_from_compile();
         }
 
-        let env_fp = context.vm.environments.len() as u32;
-        let environments = context.vm.environments.clone();
+        let env_fp = context.vm.frame.environments.len() as u32;
+        let environments = context.vm.frame.environments.clone();
         let realm = context.realm().clone();
         context.vm.push_frame_with_stack(
             CallFrame::new(code_block, None, environments, realm)

--- a/core/engine/src/builtins/function/mod.rs
+++ b/core/engine/src/builtins/function/mod.rs
@@ -653,7 +653,7 @@ impl BuiltInFunctionObject {
             return Err(js_error!(SyntaxError: "failed to analyze function scope: {}", reason));
         }
 
-        let in_with = context.vm.environments.has_object_environment();
+        let in_with = context.vm.frame.environments.has_object_environment();
         let spanned_source_text = SpannedSourceText::new_empty();
 
         let code = FunctionCompiler::new(spanned_source_text)
@@ -672,9 +672,9 @@ impl BuiltInFunctionObject {
                 context.interner_mut(),
             );
 
-        let environments = context.vm.environments.pop_to_global();
+        let environments = context.vm.frame.environments.pop_to_global();
         let function_object = crate::vm::create_function_object(code, prototype, context);
-        context.vm.environments.extend(environments);
+        context.vm.frame.environments.extend(environments);
 
         Ok(function_object)
     }
@@ -1050,8 +1050,8 @@ pub(crate) fn function_call(
     let mut last_env = 0;
 
     if code.has_binding_identifier() {
-        let index = context.vm.environments.push_lexical(1);
-        context.vm.environments.put_lexical_value(
+        let index = context.vm.frame.environments.push_lexical(1);
+        context.vm.frame.environments.put_lexical_value(
             BindingLocatorScope::Stack(index),
             0,
             function_object.clone().into(),
@@ -1060,7 +1060,7 @@ pub(crate) fn function_call(
     }
 
     if code.has_function_scope() {
-        context.vm.environments.push_function(
+        context.vm.frame.environments.push_function(
             code.constant_scope(last_env),
             FunctionSlots::new(this, function_object.clone(), None),
         );
@@ -1147,8 +1147,8 @@ fn function_construct(
     let mut last_env = 0;
 
     if code.has_binding_identifier() {
-        let index = context.vm.environments.push_lexical(1);
-        context.vm.environments.put_lexical_value(
+        let index = context.vm.frame.environments.push_lexical(1);
+        context.vm.frame.environments.put_lexical_value(
             BindingLocatorScope::Stack(index),
             0,
             this_function_object.clone().into(),
@@ -1157,7 +1157,7 @@ fn function_construct(
     }
 
     if code.has_function_scope() {
-        context.vm.environments.push_function(
+        context.vm.frame.environments.push_function(
             code.constant_scope(last_env),
             FunctionSlots::new(
                 this.clone().map_or(ThisBindingStatus::Uninitialized, |o| {

--- a/core/engine/src/builtins/generator/mod.rs
+++ b/core/engine/src/builtins/generator/mod.rs
@@ -66,7 +66,7 @@ impl GeneratorContext {
     /// Creates a new `GeneratorContext` from the current `Context` state.
     pub(crate) fn from_current(context: &mut Context, async_generator: Option<JsObject>) -> Self {
         let mut frame = context.vm.frame().clone();
-        frame.environments = context.vm.environments.clone();
+        frame.environments = context.vm.frame.environments.clone();
         frame.realm = context.realm().clone();
         let mut stack = context.vm.stack.split_off_frame(&frame);
 

--- a/core/engine/src/builtins/json/mod.rs
+++ b/core/engine/src/builtins/json/mod.rs
@@ -115,7 +115,7 @@ impl Json {
         // But if it's incorrect, just call `parser.parse_script_with_source` here
         let script = parser.parse_script(&Scope::new_global(), context.interner_mut())?;
         let code_block = {
-            let in_with = context.vm.environments.has_object_environment();
+            let in_with = context.vm.frame.environments.has_object_environment();
             // If the source is needed then call `parser.parse_script_with_source` and pass `source_text` here.
             let spanned_source_text = SpannedSourceText::new_empty();
             let mut compiler = ByteCompiler::new(
@@ -138,9 +138,9 @@ impl Json {
 
         let realm = context.realm().clone();
 
-        let env_fp = context.vm.environments.len() as u32;
+        let env_fp = context.vm.frame.environments.len() as u32;
         context.vm.push_frame_with_stack(
-            CallFrame::new(code_block, None, context.vm.environments.clone(), realm)
+            CallFrame::new(code_block, None, context.vm.frame.environments.clone(), realm)
                 .with_env_fp(env_fp)
                 .with_flags(CallFrameFlags::EXIT_EARLY),
             JsValue::undefined(),

--- a/core/engine/src/builtins/json/mod.rs
+++ b/core/engine/src/builtins/json/mod.rs
@@ -140,9 +140,14 @@ impl Json {
 
         let env_fp = context.vm.frame.environments.len() as u32;
         context.vm.push_frame_with_stack(
-            CallFrame::new(code_block, None, context.vm.frame.environments.clone(), realm)
-                .with_env_fp(env_fp)
-                .with_flags(CallFrameFlags::EXIT_EARLY),
+            CallFrame::new(
+                code_block,
+                None,
+                context.vm.frame.environments.clone(),
+                realm,
+            )
+            .with_env_fp(env_fp)
+            .with_flags(CallFrameFlags::EXIT_EARLY),
             JsValue::undefined(),
             JsValue::null(),
         );

--- a/core/engine/src/bytecompiler/declarations.rs
+++ b/core/engine/src/bytecompiler/declarations.rs
@@ -212,7 +212,7 @@ pub(crate) fn eval_declaration_instantiation_context(
     //         i. If privateIdentifiers does not contain binding.[[Description]],
     //            append binding.[[Description]] to privateIdentifiers.
     //     b. Set pointer to pointer.[[OuterPrivateEnvironment]].
-    let private_identifiers = context.vm.environments.private_name_descriptions();
+    let private_identifiers = context.vm.frame.environments.private_name_descriptions();
     let private_identifiers = private_identifiers
         .into_iter()
         .map(|ident| {

--- a/core/engine/src/context/mod.rs
+++ b/core/engine/src/context/mod.rs
@@ -136,7 +136,7 @@ impl std::fmt::Debug for Context {
         let mut debug = f.debug_struct("Context");
 
         debug
-            .field("realm", &self.vm.realm)
+            .field("realm", &self.vm.frame.realm)
             .field("interner", &self.interner)
             .field("vm", &self.vm)
             .field("strict", &self.strict)
@@ -432,21 +432,21 @@ impl Context {
     #[inline]
     #[must_use]
     pub fn global_object(&self) -> JsObject {
-        self.vm.realm.global_object().clone()
+        self.vm.frame.realm.global_object().clone()
     }
 
     /// Returns the currently active intrinsic constructors and objects.
     #[inline]
     #[must_use]
     pub fn intrinsics(&self) -> &Intrinsics {
-        self.vm.realm.intrinsics()
+        self.vm.frame.realm.intrinsics()
     }
 
     /// Returns the currently active realm.
     #[inline]
     #[must_use]
     pub const fn realm(&self) -> &Realm {
-        &self.vm.realm
+        &self.vm.frame.realm
     }
 
     /// Set the value of trace on the context
@@ -521,9 +521,10 @@ impl Context {
     #[inline]
     pub fn enter_realm(&mut self, realm: Realm) -> Realm {
         self.vm
+            .frame
             .environments
             .replace_global(realm.environment().clone());
-        std::mem::replace(&mut self.vm.realm, realm)
+        std::mem::replace(&mut self.vm.frame.realm, realm)
     }
 
     /// Create a new Realm with the default global bindings.
@@ -641,7 +642,7 @@ impl Context {
 
     /// Swaps the currently active realm with `realm`.
     pub(crate) fn swap_realm(&mut self, realm: &mut Realm) {
-        std::mem::swap(&mut self.vm.realm, realm);
+        std::mem::swap(&mut self.vm.frame.realm, realm);
     }
 
     /// Increment and get the parser identifier.

--- a/core/engine/src/module/source.rs
+++ b/core/engine/src/module/source.rs
@@ -1702,7 +1702,7 @@ impl SourceTextModule {
                 ImportBinding::Namespace { locator, module } => {
                     // i. Let namespace be GetModuleNamespace(importedModule).
                     let namespace = module.namespace(context);
-                    context.vm.environments.put_lexical_value(
+                    context.vm.frame.environments.put_lexical_value(
                         locator.scope(),
                         locator.binding_index(),
                         namespace.into(),
@@ -1714,6 +1714,7 @@ impl SourceTextModule {
                 } => match export_locator.binding_name() {
                     BindingName::Name(name) => context
                         .vm
+                        .frame
                         .environments
                         .current_declarative_ref()
                         .expect("must be declarative")
@@ -1723,7 +1724,7 @@ impl SourceTextModule {
                         .set_indirect(locator.binding_index(), export_locator.module, name),
                     BindingName::Namespace => {
                         let namespace = export_locator.module.namespace(context);
-                        context.vm.environments.put_lexical_value(
+                        context.vm.frame.environments.put_lexical_value(
                             locator.scope(),
                             locator.binding_index(),
                             namespace.into(),
@@ -1739,7 +1740,7 @@ impl SourceTextModule {
 
             let function = create_function_object_fast(code, context);
 
-            context.vm.environments.put_lexical_value(
+            context.vm.frame.environments.put_lexical_value(
                 locator.scope(),
                 locator.binding_index(),
                 function.into(),

--- a/core/engine/src/script.rs
+++ b/core/engine/src/script.rs
@@ -210,12 +210,12 @@ impl Script {
     fn prepare_run(&self, context: &mut Context) -> JsResult<()> {
         let codeblock = self.codeblock(context)?;
 
-        let env_fp = context.vm.environments.len() as u32;
+        let env_fp = context.vm.frame.environments.len() as u32;
         context.vm.push_frame_with_stack(
             CallFrame::new(
                 codeblock,
                 Some(ActiveRunnable::Script(self.clone())),
-                context.vm.environments.clone(),
+                context.vm.frame.environments.clone(),
                 self.inner.realm.clone(),
             )
             .with_env_fp(env_fp)

--- a/core/engine/src/vm/code_block.rs
+++ b/core/engine/src/vm/code_block.rs
@@ -1071,7 +1071,7 @@ pub(crate) fn create_function_object(
     let is_generator = code.is_generator();
     let function = OrdinaryFunction::new(
         code,
-        context.vm.environments.clone(),
+        context.vm.frame.environments.clone(),
         script_or_module,
         context.realm().clone(),
     );
@@ -1140,7 +1140,7 @@ pub(crate) fn create_function_object_fast(code: Gc<CodeBlock>, context: &mut Con
     let has_prototype_property = code.has_prototype_property();
     let function = OrdinaryFunction::new(
         code,
-        context.vm.environments.clone(),
+        context.vm.frame.environments.clone(),
         script_or_module,
         context.realm().clone(),
     );

--- a/core/engine/src/vm/mod.rs
+++ b/core/engine/src/vm/mod.rs
@@ -82,7 +82,7 @@ pub struct Vm {
     ///
     /// See [`ReThrow`](crate::vm::Opcode::ReThrow) and [`ReThrow`](crate::vm::Opcode::Exception) opcodes.
     ///
-    /// This is also used to eliminates [`crate::JsNativeError`] to opaque conversion if not needed.
+    /// This eliminates the conversion between [`crate::JsNativeError`] and [`crate::JsValue`] if not needed.
     pub(crate) pending_exception: Option<JsError>,
     pub(crate) runtime_limits: RuntimeLimits,
 
@@ -414,7 +414,7 @@ impl Vm {
                 Gc::new(CodeBlock::new(JsString::default(), 0, true)),
                 None,
                 EnvironmentStack::new(realm.environment().clone()),
-                realm.clone(),
+                realm,
             ),
             stack: Stack::new(1024),
             return_value: JsValue::undefined(),

--- a/core/engine/src/vm/opcode/arguments.rs
+++ b/core/engine/src/vm/opcode/arguments.rs
@@ -24,6 +24,7 @@ impl CreateMappedArgumentsObject {
         let args = context.vm.stack.get_arguments(context.vm.frame());
         let env = context
             .vm
+            .frame
             .environments
             .current_declarative_ref()
             .expect("must be declarative");

--- a/core/engine/src/vm/opcode/binary_ops/mod.rs
+++ b/core/engine/src/vm/opcode/binary_ops/mod.rs
@@ -154,6 +154,7 @@ impl InPrivate {
 
         let name = context
             .vm
+            .frame
             .environments
             .resolve_private_identifier(name)
             .expect("private name must be in environment");

--- a/core/engine/src/vm/opcode/control_flow/return.rs
+++ b/core/engine/src/vm/opcode/control_flow/return.rs
@@ -65,7 +65,7 @@ impl CheckReturn {
             } else {
                 let realm = frame.realm.clone();
 
-                match context.vm.environments.get_this_binding() {
+                match context.vm.frame.environments.get_this_binding() {
                     Err(err) => {
                         let err = err.inject_realm(realm);
                         context.vm.pending_exception = Some(err);

--- a/core/engine/src/vm/opcode/control_flow/return.rs
+++ b/core/engine/src/vm/opcode/control_flow/return.rs
@@ -50,11 +50,11 @@ impl CheckReturn {
         } else if !this.is_undefined() {
             this.clone()
         } else if !result.is_undefined() {
-            let realm = context.vm.frame().realm.clone();
             context.vm.pending_exception = Some(
+                // Avoid setting the realm here, since it needs to be set by the parent
+                // execution context.
                 JsNativeError::typ()
                     .with_message("derived constructor can only return an Object or undefined")
-                    .with_realm(realm)
                     .into(),
             );
             return context.handle_throw();
@@ -63,11 +63,10 @@ impl CheckReturn {
             if frame.has_this_value_cached() {
                 this.clone()
             } else {
-                let realm = frame.realm.clone();
-
                 match context.vm.frame.environments.get_this_binding() {
                     Err(err) => {
-                        let err = err.inject_realm(realm);
+                        // Avoid setting the realm here, since it needs to be set by the parent
+                        // execution context.
                         context.vm.pending_exception = Some(err);
                         return context.handle_throw();
                     }

--- a/core/engine/src/vm/opcode/define/mod.rs
+++ b/core/engine/src/vm/opcode/define/mod.rs
@@ -20,7 +20,7 @@ impl DefVar {
         // TODO: spec specifies to return `empty` on empty vars, but we're trying to initialize.
         let binding_locator = context.vm.frame().code_block.bindings[usize::from(index)].clone();
 
-        context.vm.environments.put_value_if_uninitialized(
+        context.vm.frame.environments.put_value_if_uninitialized(
             binding_locator.scope(),
             binding_locator.binding_index(),
             JsValue::undefined(),
@@ -79,7 +79,7 @@ impl PutLexicalValue {
     ) {
         let value = context.vm.get_register(value.into());
         let binding_locator = context.vm.frame().code_block.bindings[usize::from(index)].clone();
-        context.vm.environments.put_lexical_value(
+        context.vm.frame.environments.put_lexical_value(
             binding_locator.scope(),
             binding_locator.binding_index(),
             value.clone(),

--- a/core/engine/src/vm/opcode/environment/mod.rs
+++ b/core/engine/src/vm/opcode/environment/mod.rs
@@ -25,6 +25,7 @@ impl This {
 
         let this = context
             .vm
+            .frame
             .environments
             .get_this_binding()?
             .unwrap_or(context.realm().global_this().clone().into());
@@ -82,6 +83,7 @@ impl Super {
         let home_object = {
             let env = context
                 .vm
+                .frame
                 .environments
                 .get_this_environment()
                 .as_function()
@@ -128,6 +130,7 @@ impl SuperCallPrepare {
     pub(super) fn operation(dst: VaryingOperand, context: &mut Context) {
         let this_env = context
             .vm
+            .frame
             .environments
             .get_this_environment()
             .as_function()
@@ -173,6 +176,7 @@ impl SuperCall {
 
         let this_env = context
             .vm
+            .frame
             .environments
             .get_this_environment()
             .as_function()
@@ -237,6 +241,7 @@ impl SuperCallSpread {
 
         let this_env = context
             .vm
+            .frame
             .environments
             .get_this_environment()
             .as_function()
@@ -275,6 +280,7 @@ impl SuperCallDerived {
     pub(super) fn operation((): (), context: &mut Context) -> JsResult<()> {
         let this_env = context
             .vm
+            .frame
             .environments
             .get_this_environment()
             .as_function()
@@ -340,6 +346,7 @@ impl BindThisValue {
         // 7. Let thisER be GetThisEnvironment().
         let this_env = context
             .vm
+            .frame
             .environments
             .get_this_environment()
             .as_function()

--- a/core/engine/src/vm/opcode/get/private.rs
+++ b/core/engine/src/vm/opcode/get/private.rs
@@ -25,6 +25,7 @@ impl GetPrivateField {
         let object = object.to_object(context)?;
         let name = context
             .vm
+            .frame
             .environments
             .resolve_private_identifier(name)
             .expect("private name must be in environment");

--- a/core/engine/src/vm/opcode/meta/mod.rs
+++ b/core/engine/src/vm/opcode/meta/mod.rs
@@ -18,6 +18,7 @@ impl NewTarget {
     pub(super) fn operation(dst: VaryingOperand, context: &mut Context) {
         let new_target = if let Some(new_target) = context
             .vm
+            .frame
             .environments
             .get_this_environment()
             .as_function()

--- a/core/engine/src/vm/opcode/pop/mod.rs
+++ b/core/engine/src/vm/opcode/pop/mod.rs
@@ -30,7 +30,7 @@ pub(crate) struct PopEnvironment;
 impl PopEnvironment {
     #[inline(always)]
     pub(super) fn operation((): (), context: &mut Context) {
-        context.vm.environments.pop();
+        context.vm.frame.environments.pop();
     }
 }
 

--- a/core/engine/src/vm/opcode/push/environment.rs
+++ b/core/engine/src/vm/opcode/push/environment.rs
@@ -20,6 +20,7 @@ impl PushScope {
         let scope = context.vm.frame().code_block().constant_scope(index.into());
         context
             .vm
+            .frame
             .environments
             .push_lexical(scope.num_bindings_non_local());
     }
@@ -43,7 +44,7 @@ impl PushObjectEnvironment {
     pub(crate) fn operation(value: VaryingOperand, context: &mut Context) -> JsResult<()> {
         let object = context.vm.get_register(value.into()).clone();
         let object = object.to_object(context)?;
-        context.vm.environments.push_object(object);
+        context.vm.frame.environments.push_object(object);
         Ok(())
     }
 }
@@ -86,7 +87,7 @@ impl PushPrivateEnvironment {
             .downcast_mut::<OrdinaryFunction>()
             .expect("class object must be function")
             .push_private_environment(environment.clone());
-        context.vm.environments.push_private(environment);
+        context.vm.frame.environments.push_private(environment);
     }
 }
 
@@ -106,7 +107,7 @@ pub(crate) struct PopPrivateEnvironment;
 impl PopPrivateEnvironment {
     #[inline(always)]
     pub(crate) fn operation((): (), context: &mut Context) {
-        context.vm.environments.pop_private();
+        context.vm.frame.environments.pop_private();
     }
 }
 

--- a/core/engine/src/vm/opcode/set/private.rs
+++ b/core/engine/src/vm/opcode/set/private.rs
@@ -28,6 +28,7 @@ impl SetPrivateField {
         let base_obj = object.to_object(context)?;
         let name = context
             .vm
+            .frame
             .environments
             .resolve_private_identifier(name)
             .expect("private name must be in environment");


### PR DESCRIPTION
Since those are accessible from the active `frame` field, we don't need to store them twice.