### PR TITLE
Parse `debugger` as statement

### DIFF
--- a/core/ast/src/expression/mod.rs
+++ b/core/ast/src/expression/mod.rs
@@ -185,9 +185,6 @@ pub enum Expression {
     /// It is not a valid expression node.
     #[doc(hidden)]
     FormalParameterList(FormalParameterList),
-
-    #[doc(hidden)]
-    Debugger,
 }
 
 impl Expression {
@@ -233,7 +230,6 @@ impl Expression {
             Self::Parenthesized(expr) => expr.to_interned_string(interner),
             Self::RegExpLiteral(regexp) => regexp.to_interned_string(interner),
             Self::FormalParameterList(_) => unreachable!(),
-            Self::Debugger => "debugger".to_owned(),
         }
     }
 
@@ -327,7 +323,7 @@ impl Spanned for Expression {
             Self::Parenthesized(expr) => expr.span(),
             Self::RegExpLiteral(regexp) => regexp.span(),
             // TODO: Remove `FormalParameterList` and `Debugger` nodes
-            Self::FormalParameterList(_) | Self::Debugger => Span::EMPTY,
+            Self::FormalParameterList(_) => Span::EMPTY,
         }
     }
 }
@@ -386,10 +382,6 @@ impl VisitWith for Expression {
             Self::FormalParameterList(fpl) => visitor.visit_formal_parameter_list(fpl),
             Self::NewTarget(new_target) => visitor.visit_new_target(new_target),
             Self::ImportMeta(import_meta) => visitor.visit_import_meta(import_meta),
-            Self::Debugger => {
-                // do nothing; can be handled as special case by visitor
-                ControlFlow::Continue(())
-            }
         }
     }
 
@@ -432,10 +424,6 @@ impl VisitWith for Expression {
             Self::FormalParameterList(fpl) => visitor.visit_formal_parameter_list_mut(fpl),
             Self::NewTarget(new_target) => visitor.visit_new_target_mut(new_target),
             Self::ImportMeta(import_meta) => visitor.visit_import_meta_mut(import_meta),
-            Self::Debugger => {
-                // do nothing; can be handled as special case by visitor
-                ControlFlow::Continue(())
-            }
         }
     }
 }

--- a/core/ast/src/operations/mod.rs
+++ b/core/ast/src/operations/mod.rs
@@ -875,6 +875,7 @@ impl<'ast> Visitor<'ast> for VarDeclaredNamesVisitor<'_> {
     fn visit_statement(&mut self, node: &'ast Statement) -> ControlFlow<Self::BreakTy> {
         match node {
             Statement::Empty
+            | Statement::Debugger
             | Statement::Expression(_)
             | Statement::Continue(_)
             | Statement::Break(_)
@@ -1451,6 +1452,7 @@ where
                 Statement::Block(node) => self.visit_block(node),
                 Statement::Var(_)
                 | Statement::Empty
+                | Statement::Debugger
                 | Statement::Expression(_)
                 | Statement::Return(_)
                 | Statement::Throw(_) => ControlFlow::Continue(()),
@@ -2091,6 +2093,7 @@ impl<'ast> Visitor<'ast> for VarScopedDeclarationsVisitor<'_> {
             Statement::Try(s) => self.visit(s),
             Statement::With(s) => self.visit(s),
             Statement::Empty
+            | Statement::Debugger
             | Statement::Expression(_)
             | Statement::Continue(_)
             | Statement::Break(_)

--- a/core/ast/src/statement/mod.rs
+++ b/core/ast/src/statement/mod.rs
@@ -105,6 +105,18 @@ pub enum Statement {
 
     /// See [`With`].
     With(With),
+
+    /// A `debugger` statement.
+    ///
+    /// The debugger statement invokes any available debugging functionality.
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///  - [MDN documentation][mdn]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-debugger-statement
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/debugger
+    Debugger,
 }
 
 impl Statement {
@@ -134,6 +146,7 @@ impl Statement {
             Self::Throw(throw) => throw.to_interned_string(interner),
             Self::Try(try_catch) => return try_catch.to_indented_string(interner, indentation),
             Self::With(with) => return with.to_interned_string(interner),
+            Self::Debugger => "debugger".to_owned(),
         };
         s.push(';');
         s
@@ -195,7 +208,7 @@ impl VisitWith for Statement {
         match self {
             Self::Block(b) => visitor.visit_block(b),
             Self::Var(v) => visitor.visit_var_declaration(v),
-            Self::Empty => {
+            Self::Empty | Self::Debugger => {
                 // do nothing; there is nothing to visit here
                 ControlFlow::Continue(())
             }
@@ -224,7 +237,7 @@ impl VisitWith for Statement {
         match self {
             Self::Block(b) => visitor.visit_block_mut(b),
             Self::Var(v) => visitor.visit_var_declaration_mut(v),
-            Self::Empty => {
+            Self::Empty | Self::Debugger => {
                 // do nothing; there is nothing to visit here
                 ControlFlow::Continue(())
             }

--- a/core/engine/src/bytecompiler/expression/mod.rs
+++ b/core/engine/src/bytecompiler/expression/mod.rs
@@ -430,7 +430,6 @@ impl ByteCompiler<'_> {
             }
             // TODO: try to remove this variant somehow
             Expression::FormalParameterList(_) => unreachable!(),
-            Expression::Debugger => (),
         }
     }
 }

--- a/core/engine/src/bytecompiler/statement/mod.rs
+++ b/core/engine/src/bytecompiler/statement/mod.rs
@@ -100,7 +100,7 @@ impl ByteCompiler<'_> {
                 self.register_allocator.dealloc(value);
             }
             Statement::With(with) => self.compile_with(with, use_expr),
-            Statement::Empty => {}
+            Statement::Empty | Statement::Debugger => {}
         }
     }
 

--- a/core/parser/src/parser/expression/primary/mod.rs
+++ b/core/parser/src/parser/expression/primary/mod.rs
@@ -128,10 +128,6 @@ where
                     .parse(cursor, interner)
                     .map(Into::into)
             }
-            TokenKind::Keyword((Keyword::Debugger, _)) => {
-                cursor.advance(interner);
-                Ok(ast::Expression::Debugger)
-            }
             TokenKind::Keyword((Keyword::Async, contain_escaped_char)) => {
                 let contain_escaped_char = *contain_escaped_char;
                 let skip_n = if cursor.peek_is_line_terminator(0, interner).or_abrupt()? {

--- a/core/parser/src/parser/statement/mod.rs
+++ b/core/parser/src/parser/statement/mod.rs
@@ -217,7 +217,11 @@ where
 
                 ExpressionStatement::new(self.allow_yield, self.allow_await).parse(cursor, interner)
             }
-
+            TokenKind::Keyword((Keyword::Debugger, _)) => {
+                cursor.advance(interner);
+                cursor.expect_semicolon("debugger statement", interner)?;
+                Ok(ast::Statement::Debugger)
+            }
             _ => {
                 ExpressionStatement::new(self.allow_yield, self.allow_await).parse(cursor, interner)
             }

--- a/core/parser/src/parser/tests/mod.rs
+++ b/core/parser/src/parser/tests/mod.rs
@@ -803,3 +803,24 @@ fn stress_test_operations() {
             .is_ok()
     );
 }
+
+#[test]
+fn debugger_statement() {
+    check_script_parser(
+        "debugger;",
+        vec![Statement::Debugger.into()],
+        &mut Interner::default(),
+    );
+
+    check_script_parser(
+        "debugger",
+        vec![Statement::Debugger.into()],
+        &mut Interner::default(),
+    );
+
+    check_invalid_script("!debugger");
+
+    check_invalid_script("let x = debugger;");
+
+    check_invalid_script("debugger + debugger");
+}


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request fixes #4482 .

It changes the following:

- parser, parse `debugger` as statement instead of expression.

