### PR TITLE
Bump crates' versions to 1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -314,7 +314,7 @@ dependencies = [
 
 [[package]]
 name = "boa_ast"
-version = "0.21.0"
+version = "1.0.0"
 dependencies = [
  "arbitrary",
  "bitflags 2.10.0",
@@ -329,7 +329,7 @@ dependencies = [
 
 [[package]]
 name = "boa_cli"
-version = "0.21.0"
+version = "1.0.0"
 dependencies = [
  "boa_engine",
  "boa_gc",
@@ -352,7 +352,7 @@ dependencies = [
 
 [[package]]
 name = "boa_engine"
-version = "0.21.0"
+version = "1.0.0"
 dependencies = [
  "aligned-vec",
  "arrayvec",
@@ -432,7 +432,7 @@ dependencies = [
 
 [[package]]
 name = "boa_examples"
-version = "0.21.0"
+version = "1.0.0"
 dependencies = [
  "boa_ast",
  "boa_engine",
@@ -450,7 +450,7 @@ dependencies = [
 
 [[package]]
 name = "boa_gc"
-version = "0.21.0"
+version = "1.0.0"
 dependencies = [
  "boa_macros",
  "boa_string",
@@ -462,7 +462,7 @@ dependencies = [
 
 [[package]]
 name = "boa_icu_provider"
-version = "0.21.0"
+version = "1.0.0"
 dependencies = [
  "icu_casemap",
  "icu_collator",
@@ -482,7 +482,7 @@ dependencies = [
 
 [[package]]
 name = "boa_interner"
-version = "0.21.0"
+version = "1.0.0"
 dependencies = [
  "arbitrary",
  "boa_gc",
@@ -498,7 +498,7 @@ dependencies = [
 
 [[package]]
 name = "boa_macros"
-version = "0.21.0"
+version = "1.0.0"
 dependencies = [
  "cfg-if",
  "cow-utils",
@@ -512,7 +512,7 @@ dependencies = [
 
 [[package]]
 name = "boa_macros_tests"
-version = "0.21.0"
+version = "1.0.0"
 dependencies = [
  "boa_engine",
  "boa_gc",
@@ -521,7 +521,7 @@ dependencies = [
 
 [[package]]
 name = "boa_parser"
-version = "0.21.0"
+version = "1.0.0"
 dependencies = [
  "bitflags 2.10.0",
  "boa_ast",
@@ -538,7 +538,7 @@ dependencies = [
 
 [[package]]
 name = "boa_runtime"
-version = "0.21.0"
+version = "1.0.0"
 dependencies = [
  "boa_engine",
  "boa_gc",
@@ -559,7 +559,7 @@ dependencies = [
 
 [[package]]
 name = "boa_string"
-version = "0.21.0"
+version = "1.0.0"
 dependencies = [
  "fast-float2",
  "itoa",
@@ -571,7 +571,7 @@ dependencies = [
 
 [[package]]
 name = "boa_tester"
-version = "0.21.0"
+version = "1.0.0"
 dependencies = [
  "bitflags 2.10.0",
  "boa_engine",
@@ -595,7 +595,7 @@ dependencies = [
 
 [[package]]
 name = "boa_wasm"
-version = "0.21.0"
+version = "1.0.0"
 dependencies = [
  "boa_engine",
  "console_error_panic_hook",
@@ -1624,7 +1624,7 @@ dependencies = [
 
 [[package]]
 name = "gen-icu4x-data"
-version = "0.21.0"
+version = "1.0.0"
 dependencies = [
  "icu_casemap",
  "icu_collator",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -314,7 +314,7 @@ dependencies = [
 
 [[package]]
 name = "boa_ast"
-version = "1.0.0"
+version = "1.0.0-dev"
 dependencies = [
  "arbitrary",
  "bitflags 2.10.0",
@@ -329,7 +329,7 @@ dependencies = [
 
 [[package]]
 name = "boa_cli"
-version = "1.0.0"
+version = "1.0.0-dev"
 dependencies = [
  "boa_engine",
  "boa_gc",
@@ -352,7 +352,7 @@ dependencies = [
 
 [[package]]
 name = "boa_engine"
-version = "1.0.0"
+version = "1.0.0-dev"
 dependencies = [
  "aligned-vec",
  "arrayvec",
@@ -432,7 +432,7 @@ dependencies = [
 
 [[package]]
 name = "boa_examples"
-version = "1.0.0"
+version = "1.0.0-dev"
 dependencies = [
  "boa_ast",
  "boa_engine",
@@ -450,7 +450,7 @@ dependencies = [
 
 [[package]]
 name = "boa_gc"
-version = "1.0.0"
+version = "1.0.0-dev"
 dependencies = [
  "boa_macros",
  "boa_string",
@@ -462,7 +462,7 @@ dependencies = [
 
 [[package]]
 name = "boa_icu_provider"
-version = "1.0.0"
+version = "1.0.0-dev"
 dependencies = [
  "icu_casemap",
  "icu_collator",
@@ -482,7 +482,7 @@ dependencies = [
 
 [[package]]
 name = "boa_interner"
-version = "1.0.0"
+version = "1.0.0-dev"
 dependencies = [
  "arbitrary",
  "boa_gc",
@@ -498,7 +498,7 @@ dependencies = [
 
 [[package]]
 name = "boa_macros"
-version = "1.0.0"
+version = "1.0.0-dev"
 dependencies = [
  "cfg-if",
  "cow-utils",
@@ -512,7 +512,7 @@ dependencies = [
 
 [[package]]
 name = "boa_macros_tests"
-version = "1.0.0"
+version = "1.0.0-dev"
 dependencies = [
  "boa_engine",
  "boa_gc",
@@ -521,7 +521,7 @@ dependencies = [
 
 [[package]]
 name = "boa_parser"
-version = "1.0.0"
+version = "1.0.0-dev"
 dependencies = [
  "bitflags 2.10.0",
  "boa_ast",
@@ -538,7 +538,7 @@ dependencies = [
 
 [[package]]
 name = "boa_runtime"
-version = "1.0.0"
+version = "1.0.0-dev"
 dependencies = [
  "boa_engine",
  "boa_gc",
@@ -559,7 +559,7 @@ dependencies = [
 
 [[package]]
 name = "boa_string"
-version = "1.0.0"
+version = "1.0.0-dev"
 dependencies = [
  "fast-float2",
  "itoa",
@@ -571,7 +571,7 @@ dependencies = [
 
 [[package]]
 name = "boa_tester"
-version = "1.0.0"
+version = "1.0.0-dev"
 dependencies = [
  "bitflags 2.10.0",
  "boa_engine",
@@ -595,7 +595,7 @@ dependencies = [
 
 [[package]]
 name = "boa_wasm"
-version = "1.0.0"
+version = "1.0.0-dev"
 dependencies = [
  "boa_engine",
  "console_error_panic_hook",
@@ -1624,7 +1624,7 @@ dependencies = [
 
 [[package]]
 name = "gen-icu4x-data"
-version = "1.0.0"
+version = "1.0.0-dev"
 dependencies = [
  "icu_casemap",
  "icu_collator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ exclude = [
 
 [workspace.package]
 edition = "2024"
-version = "1.0.0"
+version = "1.0.0-dev"
 rust-version = "1.91.0"
 authors = ["boa-dev"]
 repository = "https://github.com/boa-dev/boa"
@@ -34,15 +34,15 @@ description = "Boa is a Javascript lexer, parser and compiler written in Rust. C
 [workspace.dependencies]
 
 # Repo Crates
-boa_ast = { version = "~1.0.0", path = "core/ast" }
-boa_engine = { version = "~1.0.0", path = "core/engine" }
-boa_gc = { version = "~1.0.0", path = "core/gc" }
-boa_icu_provider = { version = "~1.0.0", path = "core/icu_provider" }
-boa_interner = { version = "~1.0.0", path = "core/interner" }
-boa_macros = { version = "~1.0.0", path = "core/macros" }
-boa_parser = { version = "~1.0.0", path = "core/parser" }
-boa_runtime = { version = "~1.0.0", path = "core/runtime" }
-boa_string = { version = "~1.0.0", path = "core/string" }
+boa_ast = { version = "~1.0.0-dev", path = "core/ast" }
+boa_engine = { version = "~1.0.0-dev", path = "core/engine" }
+boa_gc = { version = "~1.0.0-dev", path = "core/gc" }
+boa_icu_provider = { version = "~1.0.0-dev", path = "core/icu_provider" }
+boa_interner = { version = "~1.0.0-dev", path = "core/interner" }
+boa_macros = { version = "~1.0.0-dev", path = "core/macros" }
+boa_parser = { version = "~1.0.0-dev", path = "core/parser" }
+boa_runtime = { version = "~1.0.0-dev", path = "core/runtime" }
+boa_string = { version = "~1.0.0-dev", path = "core/string" }
 
 # Utility Repo Crates
 tag_ptr = { version = "~0.1.0", path = "utils/tag_ptr" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ exclude = [
 
 [workspace.package]
 edition = "2024"
-version = "0.21.0"
+version = "1.0.0"
 rust-version = "1.88.0"
 authors = ["boa-dev"]
 repository = "https://github.com/boa-dev/boa"
@@ -34,15 +34,15 @@ description = "Boa is a Javascript lexer, parser and compiler written in Rust. C
 [workspace.dependencies]
 
 # Repo Crates
-boa_ast = { version = "~0.21.0", path = "core/ast" }
-boa_engine = { version = "~0.21.0", path = "core/engine" }
-boa_gc = { version = "~0.21.0", path = "core/gc" }
-boa_icu_provider = { version = "~0.21.0", path = "core/icu_provider" }
-boa_interner = { version = "~0.21.0", path = "core/interner" }
-boa_macros = { version = "~0.21.0", path = "core/macros" }
-boa_parser = { version = "~0.21.0", path = "core/parser" }
-boa_runtime = { version = "~0.21.0", path = "core/runtime" }
-boa_string = { version = "~0.21.0", path = "core/string" }
+boa_ast = { version = "~1.0.0", path = "core/ast" }
+boa_engine = { version = "~1.0.0", path = "core/engine" }
+boa_gc = { version = "~1.0.0", path = "core/gc" }
+boa_icu_provider = { version = "~1.0.0", path = "core/icu_provider" }
+boa_interner = { version = "~1.0.0", path = "core/interner" }
+boa_macros = { version = "~1.0.0", path = "core/macros" }
+boa_parser = { version = "~1.0.0", path = "core/parser" }
+boa_runtime = { version = "~1.0.0", path = "core/runtime" }
+boa_string = { version = "~1.0.0", path = "core/string" }
 
 # Utility Repo Crates
 tag_ptr = { version = "~0.1.0", path = "utils/tag_ptr" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ exclude = [
 [workspace.package]
 edition = "2024"
 version = "1.0.0"
-rust-version = "1.88.0"
+rust-version = "1.91.0"
 authors = ["boa-dev"]
 repository = "https://github.com/boa-dev/boa"
 license = "Unlicense OR MIT"

--- a/core/engine/src/builtins/array/from_async.rs
+++ b/core/engine/src/builtins/array/from_async.rs
@@ -228,7 +228,7 @@ enum AsyncIteratorStateMachine {
     },
 }
 
-/// Part of [`Array.fromAsync ( asyncItems [ , mapfn [ , thisArg ] ] )`][<https://tc39.es/proposal-array-from-async/#sec-array.fromAsync>].
+/// Part of [`Array.fromAsync ( asyncItems [ , mapfn [ , thisArg ] ] )`][https://tc39.es/proposal-array-from-async/#sec-array.fromAsync].
 fn from_async_iterator(
     mut result: JsResult<JsValue>,
     (global_state, state_machine): &(GlobalState, Cell<Option<AsyncIteratorStateMachine>>),

--- a/core/engine/src/builtins/array/from_async.rs
+++ b/core/engine/src/builtins/array/from_async.rs
@@ -228,7 +228,7 @@ enum AsyncIteratorStateMachine {
     },
 }
 
-/// Part of [`Array.fromAsync ( asyncItems [ , mapfn [ , thisArg ] ] )`][https://tc39.es/proposal-array-from-async/#sec-array.fromAsync].
+/// Part of [`Array.fromAsync ( asyncItems [ , mapfn [ , thisArg ] ] )`](https://tc39.es/proposal-array-from-async/#sec-array.fromAsync).
 fn from_async_iterator(
     mut result: JsResult<JsValue>,
     (global_state, state_machine): &(GlobalState, Cell<Option<AsyncIteratorStateMachine>>),
@@ -485,7 +485,7 @@ enum ArrayLikeStateMachine {
     },
 }
 
-/// Part of [`Array.fromAsync ( asyncItems [ , mapfn [ , thisArg ] ] )`][<https://tc39.es/proposal-array-from-async/#sec-array.fromAsync>].
+/// Part of [`Array.fromAsync ( asyncItems [ , mapfn [ , thisArg ] ] )`](https://tc39.es/proposal-array-from-async/#sec-array.fromAsync>).
 fn from_array_like(
     mut result: JsResult<JsValue>,
     (global_state, state_machine): &(GlobalState, Cell<Option<ArrayLikeStateMachine>>),

--- a/core/engine/src/builtins/array/from_async.rs
+++ b/core/engine/src/builtins/array/from_async.rs
@@ -485,7 +485,7 @@ enum ArrayLikeStateMachine {
     },
 }
 
-/// Part of [`Array.fromAsync ( asyncItems [ , mapfn [ , thisArg ] ] )`](https://tc39.es/proposal-array-from-async/#sec-array.fromAsync>).
+/// Part of [`Array.fromAsync ( asyncItems [ , mapfn [ , thisArg ] ] )`](https://tc39.es/proposal-array-from-async/#sec-array.fromAsync).
 fn from_array_like(
     mut result: JsResult<JsValue>,
     (global_state, state_machine): &(GlobalState, Cell<Option<ArrayLikeStateMachine>>),

--- a/core/engine/src/builtins/temporal/plain_date/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_date/mod.rs
@@ -1258,7 +1258,6 @@ impl PlainDate {
     ///
     /// - [ECMAScript Temporal proposal][spec]
     /// - [MDN reference][mdn]
-    /// - [`temporal_rs` documentation][temporal_rs-docs]
     ///
     /// [spec]: https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.valueof
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDate/valueOf

--- a/core/engine/src/property/mod.rs
+++ b/core/engine/src/property/mod.rs
@@ -56,7 +56,7 @@ pub struct PropertyDescriptor {
 }
 
 /// `DescriptorKind` represents the different kinds of property descriptors.
-#[derive(Debug, Clone, Trace, Finalize)]
+#[derive(Debug, Default, Clone, Trace, Finalize)]
 pub enum DescriptorKind {
     /// A data property descriptor.
     Data {
@@ -77,13 +77,8 @@ pub enum DescriptorKind {
     },
 
     /// A generic property descriptor.
+    #[default]
     Generic,
-}
-
-impl Default for DescriptorKind {
-    fn default() -> Self {
-        Self::Generic
-    }
 }
 
 impl PropertyDescriptor {

--- a/core/macros/src/class.rs
+++ b/core/macros/src/class.rs
@@ -688,7 +688,7 @@ pub(crate) fn class_impl(attr: TokenStream, input: TokenStream) -> TokenStream {
             .into();
     };
 
-    let class_impl = visitor.serialize_class_impl(&impl_.self_ty, &name.to_string());
+    let class_impl = visitor.serialize_class_impl(&impl_.self_ty, &name);
 
     let debug = take_path_attr(&mut impl_.attrs, "debug");
 

--- a/core/parser/src/lexer/mod.rs
+++ b/core/parser/src/lexer/mod.rs
@@ -412,18 +412,13 @@ impl<'a> From<&'a [u8]> for Lexer<UTF8Input<&'a [u8]>> {
 /// ECMAScript goal symbols.
 ///
 /// <https://tc39.es/ecma262/#sec-ecmascript-language-lexical-grammar>
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum InputElement {
     Div,
+    #[default]
     RegExp,
     TemplateTail,
     HashbangOrRegExp,
-}
-
-impl Default for InputElement {
-    fn default() -> Self {
-        Self::RegExp
-    }
 }
 
 /// Checks if a character is whitespace as per ECMAScript standards.

--- a/core/runtime/src/message/mod.rs
+++ b/core/runtime/src/message/mod.rs
@@ -2,7 +2,9 @@
 //! supporting functions).
 //!
 //! More information:
-//! - [MDN documentation][<https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage>]
+//! - [MDN documentation][mdn]
+//!
+//! [mdn]: https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage
 
 use crate::store::JsValueStore;
 use boa_engine::realm::Realm;

--- a/tests/tester/src/main.rs
+++ b/tests/tester/src/main.rs
@@ -860,16 +860,14 @@ impl Test {
 }
 
 /// An outcome for a test.
-#[derive(Debug, Clone)]
+#[derive(Debug, Default, Clone)]
 enum Outcome {
+    #[default]
     Positive,
-    Negative { phase: Phase, error_type: ErrorType },
-}
-
-impl Default for Outcome {
-    fn default() -> Self {
-        Self::Positive
-    }
+    Negative {
+        phase: Phase,
+        error_type: ErrorType,
+    },
 }
 
 impl From<Option<Negative>> for Outcome {


### PR DESCRIPTION
Since we already made a breaking change, this bumps all our crates' versions to 1.0.0. This is also a commitment to start working towards releasing a 1.0.0, which many people will be happy about :)

- Fixes clippy lints.
- Bumps our MSRV to 1.91 for future required changes.