### PR TITLE
Unflag temporal as experimental and turn it on by default

### DIFF
--- a/core/engine/Cargo.toml
+++ b/core/engine/Cargo.toml
@@ -12,7 +12,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [features]
-default = ["float16", "xsum"]
+default = ["float16", "xsum", "temporal"]
 
 embedded_lz4 = ["boa_macros/embedded_lz4", "lz4_flex"]
 
@@ -71,7 +71,7 @@ annex-b = ["boa_ast/annex-b", "boa_parser/annex-b"]
 temporal = ["dep:icu_calendar", "dep:temporal_rs", "dep:iana-time-zone", "dep:timezone_provider", "timezone_provider/tzif"]
 
 # Enable experimental features, like Stage 3 proposals.
-experimental = ["temporal"]
+experimental = []
 
 # Enable binding to JS APIs for system related utilities.
 js = ["dep:web-time", "dep:getrandom"]


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request removes temporal as an experimental feature and moves it to default.

Boa's implementation is generally complete. We have made the Time Zone Provider available for configuration on the context, and small changes should be needed moving forward for the implementation.
