### PR TITLE
Remove js-related bindings for non-js wasm builds

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,3 @@
-[target.wasm32-unknown-unknown]
-rustflags = ['--cfg', 'getrandom_backend="wasm_js"']
-
 # TODO: track https://github.com/rust-lang/rust/issues/141626 for a resolution
 [target.x86_64-pc-windows-msvc]
 rustflags = ['-Csymbol-mangling-version=v0']

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,6 @@ thin-vec = "0.2.14"
 time = { version = "0.3.44", default-features = false, features = [
     "local-offset",
     "large-dates",
-    "wasm-bindgen",
     "parsing",
     "formatting",
     "macros",

--- a/core/engine/Cargo.toml
+++ b/core/engine/Cargo.toml
@@ -74,7 +74,7 @@ temporal = ["dep:icu_calendar", "dep:temporal_rs", "dep:iana-time-zone", "dep:ti
 experimental = ["temporal"]
 
 # Enable binding to JS APIs for system related utilities.
-js = ["dep:web-time", "dep:getrandom"]
+js = ["dep:web-time", "dep:getrandom", "getrandom/wasm_js", "time/wasm-bindgen"]
 
 # Enable support for Float16 typed arrays
 float16 = ["dep:float16"]


### PR DESCRIPTION
Fixes #4526.

This does not fix the issue for builds with the `temporal` feature enabled. We need to send a patch to `iana-time-zone` to avoid importing `js-sys` unconditionally, but use a feature instead; right now it is impossible to conditionally add `js-sys` for `iana-time-zone`.