### PR TITLE
Add temporal_rs feature flag for Temporal.Duration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,7 +124,7 @@ cfg-if = "1.0.4"
 either = "1.15.0"
 sys-locale = "0.3.2"
 timezone_provider = { version = "0.1.2" }
-temporal_rs = { version = "0.1.2", default-features = false }
+temporal_rs = { version = "0.1.2", default-features = false, features = ["float64_representable_durations"] }
 web-time = "1.1.0"
 criterion = "0.7.0"
 float-cmp = "0.10.0"


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This PR updates the features for temporal_rs. I forgot to add it on the last PR. It primarily ensures the Duration's are f64 representable when constructed.
