### PR TITLE
Extract engine errors as their own `JsError` variant

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -188,8 +188,9 @@ strip = "none"
 
 # The test profile, used for `cargo test`.
 [profile.test]
+inherits = "dev"
 # Enables thin local LTO and some optimizations.
-opt-level = 1
+# opt-level = 1
 
 # The benchmark profile, used for `cargo bench`.
 [profile.bench]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -188,9 +188,8 @@ strip = "none"
 
 # The test profile, used for `cargo test`.
 [profile.test]
-inherits = "dev"
 # Enables thin local LTO and some optimizations.
-# opt-level = 1
+opt-level = 1
 
 # The benchmark profile, used for `cargo bench`.
 [profile.bench]

--- a/core/engine/src/builtins/error/mod.rs
+++ b/core/engine/src/builtins/error/mod.rs
@@ -123,7 +123,7 @@ pub enum ErrorKind {
 /// This is used internally to convert between [`JsObject`] and
 /// [`JsNativeError`] correctly, but it can also be used to manually create `Error`
 /// objects. However, the recommended way to create them is to construct a
-/// `JsNativeError` first, then call [`JsNativeError::to_opaque`],
+/// `JsNativeError` first, then call [`JsNativeError::into_opaque`],
 /// which will assign its prototype, properties and kind automatically.
 ///
 /// For a description of every error kind and its usage, see

--- a/core/engine/src/builtins/generator/mod.rs
+++ b/core/engine/src/builtins/generator/mod.rs
@@ -380,7 +380,7 @@ impl Generator {
 
         let (value, resume_kind) = match abrupt_completion {
             Ok(value) => (value, GeneratorResumeKind::Return),
-            Err(err) => (err.to_opaque(context), GeneratorResumeKind::Throw),
+            Err(err) => (err.into_opaque(context)?, GeneratorResumeKind::Throw),
         };
 
         let record = generator_context.resume(Some(value), resume_kind, context);

--- a/core/engine/src/builtins/iterable/async_from_sync_iterator.rs
+++ b/core/engine/src/builtins/iterable/async_from_sync_iterator.rs
@@ -263,7 +263,7 @@ impl AsyncFromSyncIterator {
                         &JsValue::undefined(),
                         &[JsNativeError::typ()
                             .with_message("sync iterator does not have a throw method")
-                            .to_opaque(context)
+                            .into_opaque(context)
                             .into()],
                         context,
                     )

--- a/core/engine/src/lib.rs
+++ b/core/engine/src/lib.rs
@@ -118,7 +118,7 @@ pub mod prelude {
     pub use crate::{
         bigint::JsBigInt,
         context::Context,
-        error::{JsError, JsNativeError, JsNativeErrorKind},
+        error::{EngineError, JsError, JsNativeError, JsNativeErrorKind, RuntimeLimitError},
         host_defined::HostDefined,
         interop::{IntoJsFunctionCopied, UnsafeIntoJsFunction},
         module::{IntoJsModule, Module},
@@ -187,9 +187,6 @@ impl JsArgs for [JsValue] {
 
 #[cfg(test)]
 use std::borrow::Cow;
-
-#[cfg(test)]
-use crate::error::{EngineError, RuntimeLimitError};
 
 /// A test action executed in a test function.
 #[cfg(test)]

--- a/core/engine/src/module/mod.rs
+++ b/core/engine/src/module/mod.rs
@@ -465,7 +465,7 @@ impl Module {
     ///
     /// [spec]: https://tc39.es/ecma262/#table-abstract-methods-of-module-records
     #[inline]
-    pub fn evaluate(&self, context: &mut Context) -> JsPromise {
+    pub fn evaluate(&self, context: &mut Context) -> JsResult<JsPromise> {
         match self.kind() {
             ModuleKind::SourceText(src) => src.evaluate(self, context),
             ModuleKind::Synthetic(synth) => synth.evaluate(self, context),
@@ -486,7 +486,7 @@ impl Module {
             // 1. If module is not a Cyclic Module Record, then
             ModuleKind::Synthetic(synth) => {
                 // a. Let promise be ! module.Evaluate().
-                let promise: JsPromise = synth.evaluate(self, context);
+                let promise: JsPromise = synth.evaluate(self, context)?;
                 let state = promise.state();
                 match state {
                     PromiseState::Pending => {
@@ -553,7 +553,7 @@ impl Module {
             .then(
                 Some(
                     NativeFunction::from_copy_closure_with_captures(
-                        |_, _, module, context| Ok(module.evaluate(context).into()),
+                        |_, _, module, context| Ok(module.evaluate(context)?.into()),
                         self.clone(),
                     )
                     .to_js_function(context.realm()),

--- a/core/engine/src/native_function/mod.rs
+++ b/core/engine/src/native_function/mod.rs
@@ -213,7 +213,7 @@ impl NativeFunction {
                     match result {
                         Ok(v) => resolvers.resolve.call(&JsValue::undefined(), &[v], context),
                         Err(e) => {
-                            let e = e.to_opaque(context);
+                            let e = e.into_opaque(context)?;
                             resolvers.reject.call(&JsValue::undefined(), &[e], context)
                         }
                     }

--- a/core/engine/src/vm/mod.rs
+++ b/core/engine/src/vm/mod.rs
@@ -648,9 +648,9 @@ impl Context {
         {
             use crate::error::EngineError;
             if self.instructions_remaining == 0 {
-                return ControlFlow::Break(
-                    CompletionRecord::Throw(EngineError::NoInstructionsRemain.into()),
-                );
+                return ControlFlow::Break(CompletionRecord::Throw(
+                    EngineError::NoInstructionsRemain.into(),
+                ));
             }
             self.instructions_remaining -= 1;
         }

--- a/core/engine/src/vm/mod.rs
+++ b/core/engine/src/vm/mod.rs
@@ -646,10 +646,11 @@ impl Context {
     {
         #[cfg(feature = "fuzz")]
         {
+            use crate::error::EngineError;
             if self.instructions_remaining == 0 {
-                return ControlFlow::Break(CompletionRecord::Throw(JsError::from_native(
-                    JsNativeError::no_instructions_remain(),
-                )));
+                return ControlFlow::Break(
+                    CompletionRecord::Throw(EngineError::NoInstructionsRemain.into()),
+                );
             }
             self.instructions_remaining -= 1;
         }

--- a/core/engine/src/vm/mod.rs
+++ b/core/engine/src/vm/mod.rs
@@ -8,6 +8,7 @@ use crate::{
     Context, JsError, JsNativeError, JsObject, JsResult, JsString, JsValue, Module,
     builtins::promise::{PromiseCapability, ResolvingFunctions},
     environments::EnvironmentStack,
+    error::RuntimeLimitError,
     object::JsFunction,
     realm::Realm,
     script::Script,
@@ -858,15 +859,11 @@ impl Context {
     pub(crate) fn check_runtime_limits(&self) -> JsResult<()> {
         // Must throw if the number of recursive calls exceeds the defined limit.
         if self.vm.runtime_limits.recursion_limit() <= self.vm.frames.len() {
-            return Err(JsNativeError::runtime_limit()
-                .with_message("exceeded maximum number of recursive calls")
-                .into());
+            return Err(RuntimeLimitError::Recursion.into());
         }
         // Must throw if the stack size exceeds the defined maximum length.
         if self.vm.runtime_limits.stack_size_limit() <= self.vm.stack.stack.len() {
-            return Err(JsNativeError::runtime_limit()
-                .with_message("exceeded maximum call stack length")
-                .into());
+            return Err(RuntimeLimitError::StackSize.into());
         }
 
         Ok(())

--- a/core/engine/src/vm/opcode/await/mod.rs
+++ b/core/engine/src/vm/opcode/await/mod.rs
@@ -212,9 +212,13 @@ impl CompletePromiseCapability {
         };
 
         if let Some(error) = context.vm.pending_exception.take() {
+            let value = match error.into_opaque(context) {
+                Ok(value) => value,
+                Err(err) => return context.handle_error(err),
+            };
             promise_capability
                 .reject()
-                .call(&JsValue::undefined(), &[error.to_opaque(context)], context)
+                .call(&JsValue::undefined(), &[value], context)
                 .expect("cannot fail per spec");
         } else {
             let return_value = context.vm.get_return_value();

--- a/core/engine/src/vm/opcode/generator/mod.rs
+++ b/core/engine/src/vm/opcode/generator/mod.rs
@@ -99,7 +99,7 @@ pub(crate) struct AsyncGeneratorClose;
 
 impl AsyncGeneratorClose {
     #[inline(always)]
-    pub(super) fn operation((): (), context: &mut Context) {
+    pub(super) fn operation((): (), context: &mut Context) -> JsResult<()> {
         // Step 3.e-g in [AsyncGeneratorStart](https://tc39.es/ecma262/#sec-asyncgeneratorstart)
         let generator = context
             .vm
@@ -130,11 +130,12 @@ impl AsyncGeneratorClose {
         drop(r#gen);
 
         // j. Perform AsyncGeneratorCompleteStep(acGenerator, result, true).
-        AsyncGenerator::complete_step(&generator, result, true, None, context);
+        AsyncGenerator::complete_step(&generator, result, true, None, context)?;
         // k. Perform AsyncGeneratorDrainQueue(acGenerator).
-        AsyncGenerator::drain_queue(&generator, context);
+        AsyncGenerator::drain_queue(&generator, context)?;
 
         // l. Return undefined.
+        Ok(())
     }
 }
 

--- a/core/engine/src/vm/opcode/iteration/loop_ops.rs
+++ b/core/engine/src/vm/opcode/iteration/loop_ops.rs
@@ -1,4 +1,4 @@
-use crate::JsNativeError;
+use crate::error::RuntimeLimitError;
 use crate::{Context, JsResult, vm::opcode::Operation};
 
 /// `IncrementLoopIteration` implements the Opcode Operation for `Opcode::IncrementLoopIteration`.
@@ -16,9 +16,7 @@ impl IncrementLoopIteration {
         let previous_iteration_count = frame.loop_iteration_count;
 
         if previous_iteration_count > max {
-            return Err(JsNativeError::runtime_limit()
-                .with_message(format!("Maximum loop iteration limit {max} exceeded"))
-                .into());
+            return Err(RuntimeLimitError::LoopIteration.into());
         }
 
         frame.loop_iteration_count = previous_iteration_count.wrapping_add(1);

--- a/core/engine/src/vm/runtime_limits.rs
+++ b/core/engine/src/vm/runtime_limits.rs
@@ -19,7 +19,7 @@ impl Default for RuntimeLimits {
     fn default() -> Self {
         Self {
             loop_iteration: u64::MAX,
-            recursion: 2048,
+            recursion: 512,
             backtrace_limit: 50,
             stack_size: 1024 * 10,
         }

--- a/core/engine/src/vm/runtime_limits.rs
+++ b/core/engine/src/vm/runtime_limits.rs
@@ -19,7 +19,7 @@ impl Default for RuntimeLimits {
     fn default() -> Self {
         Self {
             loop_iteration: u64::MAX,
-            recursion: 512,
+            recursion: 2048,
             backtrace_limit: 50,
             stack_size: 1024 * 10,
         }

--- a/core/engine/src/vm/tests.rs
+++ b/core/engine/src/vm/tests.rs
@@ -495,7 +495,7 @@ fn long_object_chain_gc_trace_stack_overflow() {
 
 // See: https://github.com/boa-dev/boa/issues/4515
 #[test]
-#[ignore]
+#[ignore = "causes a stack overflow while #4535 is not fixed"]
 fn recursion_in_async_gen_throws_uncatchable_error() {
     run_test_actions([TestAction::assert_runtime_limit_error(
         indoc! {r#"

--- a/core/engine/src/vm/tests.rs
+++ b/core/engine/src/vm/tests.rs
@@ -495,6 +495,7 @@ fn long_object_chain_gc_trace_stack_overflow() {
 
 // See: https://github.com/boa-dev/boa/issues/4515
 #[test]
+#[ignore]
 fn recursion_in_async_gen_throws_uncatchable_error() {
     run_test_actions([TestAction::assert_runtime_limit_error(
         indoc! {r#"
@@ -506,5 +507,5 @@ fn recursion_in_async_gen_throws_uncatchable_error() {
             });
         "#},
         RuntimeLimitError::Recursion,
-    )])
+    )]);
 }

--- a/core/engine/src/vm/tests.rs
+++ b/core/engine/src/vm/tests.rs
@@ -1,3 +1,4 @@
+use crate::error::RuntimeLimitError;
 use crate::vm::CallFrame;
 use crate::vm::call_frame::CallFrameLocation;
 use crate::vm::source_info::SourcePath;
@@ -321,12 +322,11 @@ fn loop_runtime_limit() {
         TestAction::inspect_context(|context| {
             context.runtime_limits_mut().set_loop_iteration_limit(10);
         }),
-        TestAction::assert_native_error(
+        TestAction::assert_runtime_limit_error(
             indoc! {r#"
                 for (let i = 0; i < 20; ++i) { }
             "#},
-            JsNativeErrorKind::RuntimeLimit,
-            "Maximum loop iteration limit 10 exceeded",
+            RuntimeLimitError::LoopIteration,
         ),
         TestAction::assert_eq(
             indoc! {r#"
@@ -334,12 +334,11 @@ fn loop_runtime_limit() {
             "#},
             JsValue::undefined(),
         ),
-        TestAction::assert_native_error(
+        TestAction::assert_runtime_limit_error(
             indoc! {r#"
                 while (1) { }
             "#},
-            JsNativeErrorKind::RuntimeLimit,
-            "Maximum loop iteration limit 10 exceeded",
+            RuntimeLimitError::LoopIteration,
         ),
     ]);
 }
@@ -361,13 +360,9 @@ fn recursion_runtime_limit() {
         TestAction::inspect_context(|context| {
             context.runtime_limits_mut().set_recursion_limit(10);
         }),
-        TestAction::assert_native_error(
-            "factorial(11)",
-            JsNativeErrorKind::RuntimeLimit,
-            "exceeded maximum number of recursive calls",
-        ),
+        TestAction::assert_runtime_limit_error("factorial(11)", RuntimeLimitError::Recursion),
         TestAction::assert_eq("factorial(8)", JsValue::new(40_320)),
-        TestAction::assert_native_error(
+        TestAction::assert_runtime_limit_error(
             indoc! {r#"
                 function x() {
                     x()
@@ -375,8 +370,7 @@ fn recursion_runtime_limit() {
 
                 x()
             "#},
-            JsNativeErrorKind::RuntimeLimit,
-            "exceeded maximum number of recursive calls",
+            RuntimeLimitError::Recursion,
         ),
     ]);
 }
@@ -497,4 +491,20 @@ fn long_object_chain_gc_trace_stack_overflow() {
         "#}),
         TestAction::inspect_context(|_| boa_gc::force_collect()),
     ]);
+}
+
+// See: https://github.com/boa-dev/boa/issues/4515
+#[test]
+fn recursion_in_async_gen_throws_uncatchable_error() {
+    run_test_actions([TestAction::assert_runtime_limit_error(
+        indoc! {r#"
+            async function* f() {}
+            f().return({
+              get then() {
+                this.then;
+              },
+            });
+        "#},
+        RuntimeLimitError::Recursion,
+    )])
 }

--- a/core/engine/src/vm/tests.rs
+++ b/core/engine/src/vm/tests.rs
@@ -495,7 +495,7 @@ fn long_object_chain_gc_trace_stack_overflow() {
 
 // See: https://github.com/boa-dev/boa/issues/4515
 #[test]
-#[ignore = "causes a stack overflow while #4535 is not fixed"]
+#[ignore = "TODO(#4535): causes a stack overflow while the issue is not fixed"]
 fn recursion_in_async_gen_throws_uncatchable_error() {
     run_test_actions([TestAction::assert_runtime_limit_error(
         indoc! {r#"

--- a/examples/src/bin/jspromise.rs
+++ b/examples/src/bin/jspromise.rs
@@ -32,7 +32,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             Ok(JsValue::undefined())
         },
         context,
-    );
+    )?;
 
     // Add success and error handlers
     let _promise = promise

--- a/examples/src/bin/modules.rs
+++ b/examples/src/bin/modules.rs
@@ -77,7 +77,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                     // This returns a `JsPromise` since a module could have
                     // top-level await statements, which defers module execution to the
                     // job queue.
-                    |_, _, module, context| Ok(module.evaluate(context).into()),
+                    |_, _, module, context| Ok(module.evaluate(context)?.into()),
                     module.clone(),
                 )
                 .to_js_function(context.realm()),

--- a/tests/tester/src/exec/mod.rs
+++ b/tests/tester/src/exec/mod.rs
@@ -457,7 +457,10 @@ impl Test {
                         return (false, format!("Uncaught {err}"));
                     }
 
-                    let promise = module.evaluate(context);
+                    let promise = match module.evaluate(context) {
+                        Ok(p) => p,
+                        Err(err) => return (false, format!("Uncaught {err}")),
+                    };
 
                     if let Err(err) = context.run_jobs() {
                         return (false, format!("Uncaught {err}"));


### PR DESCRIPTION
Related to #4515.

Extracts a new `EngineError` type that is a new variant of `JsError` that cannot be converted to a `JsValue` using `into_erased`.

This also makes `into_erased` fallible for `JsError`, which IMO is fine since we really want to make sure users handle engine errors gracefully.

EDIT: Unfortunately, this doesn't fully address #4515 because the stack overflows on the CI profile. Will open an issue related to that.