### PR TITLE
Add `SparseElement` variant for simple sparse array storage

### DIFF
--- a/cli/src/debug/object.rs
+++ b/cli/src/debug/object.rs
@@ -22,7 +22,7 @@ fn id(_: &JsValue, args: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
 }
 
 /// Returns objects pointer in memory.
-fn indexed_elements_type(_: &JsValue, args: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+fn indexed_storage_type(_: &JsValue, args: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
     let Some(value) = args.first() else {
         return Err(JsNativeError::typ()
             .with_message("expected object argument")
@@ -39,7 +39,8 @@ fn indexed_elements_type(_: &JsValue, args: &[JsValue], _: &mut Context) -> JsRe
         IndexProperties::DenseI32(_) => "DenseI32",
         IndexProperties::DenseF64(_) => "DenseF64",
         IndexProperties::DenseElement(_) => "DenseElement",
-        IndexProperties::Sparse(_) => "SparseElement",
+        IndexProperties::SparseElement(_) => "SparseElement",
+        IndexProperties::SparseProperty(_) => "SparseProperty",
     };
     Ok(js_string!(typ).into())
 }
@@ -48,8 +49,8 @@ pub(super) fn create_object(context: &mut Context) -> JsObject {
     ObjectInitializer::new(context)
         .function(NativeFunction::from_fn_ptr(id), js_string!("id"), 1)
         .function(
-            NativeFunction::from_fn_ptr(indexed_elements_type),
-            js_string!("indexedElementsType"),
+            NativeFunction::from_fn_ptr(indexed_storage_type),
+            js_string!("indexedStorageType"),
             1,
         )
         .build()

--- a/core/engine/src/value/mod.rs
+++ b/core/engine/src/value/mod.rs
@@ -339,10 +339,12 @@ impl JsValue {
             return Some(integer);
         }
 
-        if let Some(rational) = self.0.as_float64()
-            && rational == f64::from(rational as i32)
-        {
-            return Some(rational as i32);
+        if let Some(rational) = self.0.as_float64() {
+            let int_val = rational as i32;
+            // Use bitwise comparison to handle -0.0 correctly
+            if rational.to_bits() == f64::from(int_val).to_bits() {
+                return Some(int_val);
+            }
         }
         None
     }

--- a/docs/boa_object.md
+++ b/docs/boa_object.md
@@ -170,21 +170,25 @@ This function returns indexed storage type.
 Example:
 
 ```JavaScript
-let a = [1, 2]
+let a = [1, 2];
 
-$boa.object.indexedStorageType(a) // 'DenseI32'
+$boa.object.indexedStorageType(a); // 'DenseI32'
 
-a.push(0xdeadbeef)
-$boa.object.indexedStorageType(a) // 'DenseI32'
+a.push(0xdeadbeef);
+$boa.object.indexedStorageType(a); // 'DenseI32'
 
-a.push(0.5)
-$boa.object.indexedStorageType(a) // 'DenseF64'
+a.push(0.5);
+$boa.object.indexedStorageType(a); // 'DenseF64'
 
-a.push("Hello")
-$boa.object.indexedStorageType(a) // 'DenseElement'
+a.push("Hello");
+$boa.object.indexedStorageType(a); // 'DenseElement'
 
-a[100] = 100 // Make a hole
-$boa.object.indexedStorageType(a) // 'SparseElement'
+a[100] = 100; // Make a hole
+$boa.object.indexedStorageType(a); // 'SparseElement'
+
+// Non-simple property descriptor (e.g., non-writable)
+Object.defineProperty(a, 2, { value: 10, writable: false });
+$boa.object.indexedStorageType(a); // 'SparseProperty'
 ```
 
 ## Module `$boa.optimizer`


### PR DESCRIPTION
Introduce a new `SparseElement` variant to `IndexedProperties` that stores simple values (data descriptors with all flags true) in a hash map without full property descriptors. This optimizes memory usage for sparse arrays.