### PR TITLE
Allow tester to compare directories

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,6 +91,33 @@ be more readable if you disable parallelism with the `-d` flag. All together it 
 cargo run --release --bin boa_tester -- run -vv -d -s test/language/types/number 2> error.log
 ```
 
+To save test results for later comparison, use the `-o` flag to specify an output directory:
+
+```shell
+cargo run --release --bin boa_tester -- run -o ./test-results
+```
+
+### Comparing Test Results
+
+You can compare two test suite runs to see what changed:
+
+```shell
+cargo run --release --bin boa_tester -- compare <base-results> <new-results>
+```
+
+Both arguments can be either result files (e.g., `latest.json`) or directories containing test results.
+When directories are provided, the tester automatically uses the `latest.json` file from each directory.
+
+For example:
+
+```shell
+# Compare using directories
+cargo run --release --bin boa_tester -- compare ./test-results-main ./test-results-feature
+
+# Compare using explicit files
+cargo run --release --bin boa_tester -- compare ./test-results-main/latest.json ./test-results-feature/latest.json
+```
+
 ## Documentation
 
 To build the development documentation, run:

--- a/tests/tester/src/results.rs
+++ b/tests/tester/src/results.rs
@@ -170,13 +170,26 @@ fn get_test262_commit(test262_path: &Path) -> Result<Box<str>> {
 /// Compares the results of two test suite runs.
 #[allow(clippy::cast_possible_wrap)]
 pub(crate) fn compare_results(base: &Path, new: &Path, markdown: bool) -> Result<()> {
+    // If the path is a directory, use latest.json from that directory
+    let base_path = if base.is_dir() {
+        base.join(LATEST_FILE_NAME)
+    } else {
+        base.to_path_buf()
+    };
+
+    let new_path = if new.is_dir() {
+        new.join(LATEST_FILE_NAME)
+    } else {
+        new.to_path_buf()
+    };
+
     let base_results: ResultInfo = serde_json::from_reader(BufReader::new(
-        fs::File::open(base).wrap_err("could not open the base results file")?,
+        fs::File::open(&base_path).wrap_err("could not open the base results file")?,
     ))
     .wrap_err("could not read the base results")?;
 
     let new_results: ResultInfo = serde_json::from_reader(BufReader::new(
-        fs::File::open(new).wrap_err("could not open the new results file")?,
+        fs::File::open(&new_path).wrap_err("could not open the new results file")?,
     ))
     .wrap_err("could not read the new results")?;
 


### PR DESCRIPTION
The compare command now accepts directories as arguments and will automatically use the `latest.json` file from those directories. This maintains backward compatibility with explicit file paths.
