### PR TITLE
Correctly throw when DateTimeFormat receives a NaN timestamp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ node_modules
 .DS_Store
 yarn-error.log
 .vscode/settings.json
+.zed/settings.json
 
 # debug is used for testing changes locally
 /debug

--- a/core/engine/src/builtins/intl/date_time_format/mod.rs
+++ b/core/engine/src/builtins/intl/date_time_format/mod.rs
@@ -323,6 +323,15 @@ impl DateTimeFormat {
 
                         // 5. Return ? FormatDateTime(dtf, x).
 
+                        // A.O 11.5.6 PartitionDateTimePattern
+
+                        // 1. Let x be TimeClip(x).
+                        // 2. If x is NaN, throw a RangeError exception.
+                        let x = time_clip(x);
+                        if x.is_nan() {
+                            return Err(js_error!(RangeError: "formatted date cannot be NaN"));
+                        }
+
                         // A.O 11.5.12 ToLocalTime
                        let time_zone_offset = match dtf.borrow().data().time_zone {
                             // 1. If IsTimeZoneOffsetString(timeZoneIdentifier) is true, then


### PR DESCRIPTION
Test `test/intl402/DateTimeFormat/prototype/format/throws-value-non-finite.js` was panicking when running the test suite in debug mode. This PR fixes the panic.
