### PR TITLE
Restructure Intl implementation to use ICU4X's locale preferences

### DIFF
--- a/core/engine/src/builtins/intl/collator/mod.rs
+++ b/core/engine/src/builtins/intl/collator/mod.rs
@@ -190,7 +190,7 @@ impl BuiltInConstructor for Collator {
 
         let mut intl_options = IntlOptions {
             matcher,
-            service_options: {
+            preferences: {
                 let mut prefs = CollatorPreferences::default();
                 prefs.collation_type = collation;
                 prefs.numeric_ordering = numeric.map(|kn| {
@@ -217,16 +217,16 @@ impl BuiltInConstructor for Collator {
         // 21. Let collation be r.[[co]].
         // 22. If collation is null, let collation be "default".
         // 23. Set collator.[[Collation]] to collation.
-        let collation = intl_options.service_options.collation_type;
+        let collation = intl_options.preferences.collation_type;
 
         // 24. If relevantExtensionKeys contains "kn", then
         //     a. Set collator.[[Numeric]] to SameValue(r.[[kn]], "true").
         let numeric =
-            intl_options.service_options.numeric_ordering == Some(CollationNumericOrdering::True);
+            intl_options.preferences.numeric_ordering == Some(CollationNumericOrdering::True);
 
         // 25. If relevantExtensionKeys contains "kf", then
         //     a. Set collator.[[CaseFirst]] to r.[[kf]].
-        let case_first = intl_options.service_options.case_first;
+        let case_first = intl_options.preferences.case_first;
 
         // 26. Let sensitivity be ? GetOption(options, "sensitivity", string, « "base", "accent", "case", "variant" », undefined).
         // 28. Set collator.[[Sensitivity]] to sensitivity.
@@ -259,12 +259,12 @@ impl BuiltInConstructor for Collator {
         options.max_variable = max_variable;
 
         if usage == Usage::Search {
-            intl_options.service_options.collation_type = Some(CollationType::Search);
+            intl_options.preferences.collation_type = Some(CollationType::Search);
         }
 
         let collator = icu_collator::Collator::try_new_with_buffer_provider(
             context.intl_provider().erased_provider(),
-            intl_options.service_options,
+            intl_options.preferences,
             options,
         )
         .map_err(|e| JsNativeError::typ().with_message(e.to_string()))?;

--- a/core/engine/src/builtins/intl/collator/mod.rs
+++ b/core/engine/src/builtins/intl/collator/mod.rs
@@ -14,9 +14,7 @@ use crate::{
         BuiltInBuilder, BuiltInConstructor, BuiltInObject, IntrinsicObject, OrdinaryObject,
         options::get_option,
     },
-    context::
-        intrinsics::{Intrinsics, StandardConstructor, StandardConstructors}
-    ,
+    context::intrinsics::{Intrinsics, StandardConstructor, StandardConstructors},
     js_string,
     native_function::NativeFunction,
     object::{

--- a/core/engine/src/builtins/intl/collator/options.rs
+++ b/core/engine/src/builtins/intl/collator/options.rs
@@ -4,10 +4,11 @@ use icu_collator::{
     CollatorPreferences,
     options::{CaseLevel, Strength},
     preferences::{CollationCaseFirst, CollationType},
+    provider::CollationMetadataV1,
 };
 use icu_locale::{LanguageIdentifier, preferences::PreferenceKey};
 use icu_provider::{
-    DataMarker, DataMarkerAttributes, DryDataProvider,
+    DataMarkerAttributes,
     prelude::icu_locale_core::{extensions::unicode, preferences::LocalePreferences},
 };
 
@@ -17,6 +18,7 @@ use crate::{
         intl::{ServicePreferences, locale::validate_extension},
         options::{OptionType, ParsableOptionType},
     },
+    context::icu::IntlProvider,
 };
 
 #[derive(Debug, Clone, Copy)]
@@ -108,19 +110,12 @@ impl OptionType for CollationCaseFirst {
 }
 
 impl ServicePreferences for CollatorPreferences {
-    fn validate_extensions<M: DataMarker>(
-        &mut self,
-        id: &LanguageIdentifier,
-        provider: &impl DryDataProvider<M>,
-    ) {
+    fn validate_extensions(&mut self, id: &LanguageIdentifier, provider: &IntlProvider) {
         self.collation_type = self.collation_type.take().filter(|co| {
             let attr = DataMarkerAttributes::from_str_or_panic(co.as_str());
-            co != &CollationType::Search && validate_extension::<M>(id, attr, provider)
+            co != &CollationType::Search
+                && validate_extension::<CollationMetadataV1>(id, attr, provider)
         });
-    }
-
-    fn set_locale(&mut self, locale: LocalePreferences) {
-        self.locale_preferences = locale
     }
 
     fn as_unicode(&self) -> unicode::Unicode {

--- a/core/engine/src/builtins/intl/collator/options.rs
+++ b/core/engine/src/builtins/intl/collator/options.rs
@@ -147,9 +147,9 @@ impl ServicePreferences for CollatorPreferences {
     }
 
     fn intersection(&self, other: &Self) -> Self {
-        let mut inter = self.clone();
+        let mut inter = *self;
         if inter.locale_preferences != other.locale_preferences {
-            inter.locale_preferences = LocalePreferences::default()
+            inter.locale_preferences = LocalePreferences::default();
         }
         if inter.collation_type != other.collation_type {
             inter.collation_type.take();

--- a/core/engine/src/builtins/intl/collator/options.rs
+++ b/core/engine/src/builtins/intl/collator/options.rs
@@ -110,7 +110,7 @@ impl OptionType for CollationCaseFirst {
 }
 
 impl ServicePreferences for CollatorPreferences {
-    fn validate_extensions(&mut self, id: &LanguageIdentifier, provider: &IntlProvider) {
+    fn validate(&mut self, id: &LanguageIdentifier, provider: &IntlProvider) {
         self.collation_type = self.collation_type.take().filter(|co| {
             let attr = DataMarkerAttributes::from_str_or_panic(co.as_str());
             co != &CollationType::Search
@@ -142,8 +142,10 @@ impl ServicePreferences for CollatorPreferences {
         exts
     }
 
-    fn extend(&mut self, other: &Self) {
-        self.extend(*other);
+    fn extended(&self, other: &Self) -> Self {
+        let mut result = *self;
+        result.extend(*other);
+        result
     }
 
     fn intersection(&self, other: &Self) -> Self {

--- a/core/engine/src/builtins/intl/collator/options.rs
+++ b/core/engine/src/builtins/intl/collator/options.rs
@@ -6,7 +6,7 @@ use icu_collator::{
     preferences::{CollationCaseFirst, CollationType},
     provider::CollationMetadataV1,
 };
-use icu_locale::{LanguageIdentifier, preferences::PreferenceKey};
+use icu_locale::LanguageIdentifier;
 use icu_provider::{
     DataMarkerAttributes,
     prelude::icu_locale_core::{extensions::unicode, preferences::LocalePreferences},
@@ -118,50 +118,5 @@ impl ServicePreferences for CollatorPreferences {
         });
     }
 
-    fn as_unicode(&self) -> unicode::Unicode {
-        let mut exts = unicode::Unicode::new();
-
-        if let Some(co) = self.collation_type
-            && let Some(value) = co.unicode_extension_value()
-        {
-            exts.keywords.set(unicode::key!("co"), value);
-        }
-
-        if let Some(kn) = self.numeric_ordering
-            && let Some(value) = kn.unicode_extension_value()
-        {
-            exts.keywords.set(unicode::key!("kn"), value);
-        }
-
-        if let Some(kf) = self.case_first
-            && let Some(value) = kf.unicode_extension_value()
-        {
-            exts.keywords.set(unicode::key!("kf"), value);
-        }
-
-        exts
-    }
-
-    fn extended(&self, other: &Self) -> Self {
-        let mut result = *self;
-        result.extend(*other);
-        result
-    }
-
-    fn intersection(&self, other: &Self) -> Self {
-        let mut inter = *self;
-        if inter.locale_preferences != other.locale_preferences {
-            inter.locale_preferences = LocalePreferences::default();
-        }
-        if inter.collation_type != other.collation_type {
-            inter.collation_type.take();
-        }
-        if inter.case_first != other.case_first {
-            inter.case_first.take();
-        }
-        if inter.numeric_ordering != other.numeric_ordering {
-            inter.numeric_ordering.take();
-        }
-        inter
-    }
+    impl_service_preferences!(collation_type, numeric_ordering, case_first);
 }

--- a/core/engine/src/builtins/intl/date_time_format/mod.rs
+++ b/core/engine/src/builtins/intl/date_time_format/mod.rs
@@ -96,9 +96,9 @@ pub(crate) struct DateTimeFormat {
 impl Service for DateTimeFormat {
     type LangMarker = DecimalSymbolsV1;
 
-    type LocaleOptions = DateTimeFormatterPreferences;
+    type Preferences = DateTimeFormatterPreferences;
 
-    fn resolve(locale: &mut Locale, options: &mut Self::LocaleOptions, provider: &IntlProvider) {
+    fn resolve(locale: &mut Locale, options: &mut Self::Preferences, provider: &IntlProvider) {
         let locale_preferences = DateTimeFormatterPreferences::from(&*locale);
         // TODO: Determine if any locale_preferences processing is needed here.
 

--- a/core/engine/src/builtins/intl/date_time_format/options.rs
+++ b/core/engine/src/builtins/intl/date_time_format/options.rs
@@ -585,7 +585,7 @@ impl TimeZoneName {
 //
 // See https://tc39.es/ecma402/#sec-intl.datetimeformat-internal-slots
 impl ServicePreferences for DateTimeFormatterPreferences {
-    fn validate_extensions(&mut self, id: &LanguageIdentifier, provider: &IntlProvider) {
+    fn validate(&mut self, id: &LanguageIdentifier, provider: &IntlProvider) {
         // Handle LDML unicode key "nu", Numbering system
         self.numbering_system = self.numbering_system.take().filter(|nu| {
             let attr = DataMarkerAttributes::from_str_or_panic(nu.as_str());
@@ -628,8 +628,10 @@ impl ServicePreferences for DateTimeFormatterPreferences {
         exts
     }
 
-    fn extend(&mut self, other: &Self) {
-        self.extend(*other);
+    fn extended(&self, other: &Self) -> Self {
+        let mut result = *self;
+        result.extend(*other);
+        result
     }
 
     fn intersection(&self, other: &Self) -> Self {

--- a/core/engine/src/builtins/intl/date_time_format/options.rs
+++ b/core/engine/src/builtins/intl/date_time_format/options.rs
@@ -20,7 +20,7 @@ use icu_datetime::{
     preferences::{CalendarAlgorithm, HourCycle as IcuHourCycle},
 };
 use icu_decimal::provider::DecimalSymbolsV1;
-use icu_locale::{extensions::unicode::Value, preferences::PreferenceKey};
+use icu_locale::extensions::unicode::Value;
 use icu_provider::{
     DataMarkerAttributes,
     prelude::icu_locale_core::{
@@ -604,50 +604,5 @@ impl ServicePreferences for DateTimeFormatterPreferences {
         // behaviour.
     }
 
-    fn as_unicode(&self) -> unicode::Unicode {
-        let mut exts = unicode::Unicode::new();
-
-        if let Some(nu) = self.numbering_system
-            && let Some(value) = nu.unicode_extension_value()
-        {
-            exts.keywords.set(unicode::key!("nu"), value);
-        }
-
-        if let Some(ca) = self.calendar_algorithm
-            && let Some(value) = ca.unicode_extension_value()
-        {
-            exts.keywords.set(unicode::key!("ca"), value);
-        }
-
-        if let Some(hc) = self.hour_cycle
-            && let Some(value) = hc.unicode_extension_value()
-        {
-            exts.keywords.set(unicode::key!("hc"), value);
-        }
-
-        exts
-    }
-
-    fn extended(&self, other: &Self) -> Self {
-        let mut result = *self;
-        result.extend(*other);
-        result
-    }
-
-    fn intersection(&self, other: &Self) -> Self {
-        let mut inter = *self;
-        if inter.locale_preferences != other.locale_preferences {
-            inter.locale_preferences = LocalePreferences::default();
-        }
-        if inter.numbering_system != other.numbering_system {
-            inter.numbering_system.take();
-        }
-        if inter.calendar_algorithm != other.calendar_algorithm {
-            inter.calendar_algorithm.take();
-        }
-        if inter.hour_cycle != other.hour_cycle {
-            inter.hour_cycle.take();
-        }
-        inter
-    }
+    impl_service_preferences!(numbering_system, calendar_algorithm, hour_cycle);
 }

--- a/core/engine/src/builtins/intl/date_time_format/options.rs
+++ b/core/engine/src/builtins/intl/date_time_format/options.rs
@@ -633,9 +633,9 @@ impl ServicePreferences for DateTimeFormatterPreferences {
     }
 
     fn intersection(&self, other: &Self) -> Self {
-        let mut inter = self.clone();
+        let mut inter = *self;
         if inter.locale_preferences != other.locale_preferences {
-            inter.locale_preferences = LocalePreferences::default()
+            inter.locale_preferences = LocalePreferences::default();
         }
         if inter.numbering_system != other.numbering_system {
             inter.numbering_system.take();

--- a/core/engine/src/builtins/intl/list_format/mod.rs
+++ b/core/engine/src/builtins/intl/list_format/mod.rs
@@ -11,9 +11,7 @@ use icu_locale::Locale;
 use crate::{
     Context, JsArgs, JsData, JsNativeError, JsResult, JsString, JsValue,
     builtins::{
-        Array, BuiltInBuilder, BuiltInConstructor, BuiltInObject, IntrinsicObject, OrdinaryObject,
-        iterable::IteratorHint,
-        options::{get_option, get_options_object},
+        Array, BuiltInBuilder, BuiltInConstructor, BuiltInObject, IntrinsicObject, OrdinaryObject, intl::options::EmptyPreferences, iterable::IteratorHint, options::{get_option, get_options_object}
     },
     context::intrinsics::{Intrinsics, StandardConstructor, StandardConstructors},
     js_string,
@@ -48,7 +46,7 @@ impl Service for ListFormat {
 
     const ATTRIBUTES: &'static icu_provider::DataMarkerAttributes = ListFormatterPatterns::WIDE;
 
-    type LocaleOptions = ();
+    type Preferences = EmptyPreferences;
 }
 
 impl IntrinsicObject for ListFormat {

--- a/core/engine/src/builtins/intl/list_format/mod.rs
+++ b/core/engine/src/builtins/intl/list_format/mod.rs
@@ -11,7 +11,10 @@ use icu_locale::Locale;
 use crate::{
     Context, JsArgs, JsData, JsNativeError, JsResult, JsString, JsValue,
     builtins::{
-        Array, BuiltInBuilder, BuiltInConstructor, BuiltInObject, IntrinsicObject, OrdinaryObject, intl::options::EmptyPreferences, iterable::IteratorHint, options::{get_option, get_options_object}
+        Array, BuiltInBuilder, BuiltInConstructor, BuiltInObject, IntrinsicObject, OrdinaryObject,
+        intl::options::EmptyPreferences,
+        iterable::IteratorHint,
+        options::{get_option, get_options_object},
     },
     context::intrinsics::{Intrinsics, StandardConstructor, StandardConstructors},
     js_string,

--- a/core/engine/src/builtins/intl/locale/tests.rs
+++ b/core/engine/src/builtins/intl/locale/tests.rs
@@ -29,9 +29,9 @@ struct TestService;
 impl Service for TestService {
     type LangMarker = PluralsCardinalV1;
 
-    type LocaleOptions = TestOptions;
+    type Preferences = TestOptions;
 
-    fn resolve(locale: &mut Locale, options: &mut Self::LocaleOptions, provider: &IntlProvider) {
+    fn resolve(locale: &mut Locale, options: &mut Self::Preferences, provider: &IntlProvider) {
         let loc_hc = locale
             .extensions
             .unicode

--- a/core/engine/src/builtins/intl/locale/tests.rs
+++ b/core/engine/src/builtins/intl/locale/tests.rs
@@ -48,7 +48,7 @@ impl ServicePreferences for TestPreferences {
 
     fn extend(&mut self, other: &Self) {
         if self.nu.is_none() {
-            self.nu = other.nu
+            self.nu = other.nu;
         }
     }
 

--- a/core/engine/src/builtins/intl/locale/tests.rs
+++ b/core/engine/src/builtins/intl/locale/tests.rs
@@ -19,7 +19,7 @@ use crate::{
     context::icu::IntlProvider,
 };
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Copy, Clone)]
 struct TestPreferences {
     nu: Option<NumberingSystem>,
 }
@@ -38,7 +38,7 @@ impl From<&Locale> for TestPreferences {
 }
 
 impl ServicePreferences for TestPreferences {
-    fn validate_extensions(&mut self, id: &LanguageIdentifier, provider: &IntlProvider) {
+    fn validate(&mut self, id: &LanguageIdentifier, provider: &IntlProvider) {
         if self.nu.is_some() {
             return;
         }
@@ -63,14 +63,16 @@ impl ServicePreferences for TestPreferences {
         exts
     }
 
-    fn extend(&mut self, other: &Self) {
-        if self.nu.is_none() {
-            self.nu = other.nu;
+    fn extended(&self, other: &Self) -> Self {
+        let mut result = *self;
+        if result.nu.is_none() {
+            result.nu = other.nu;
         }
+        result
     }
 
     fn intersection(&self, other: &Self) -> Self {
-        let mut inter = self.clone();
+        let mut inter = *self;
         if inter.nu != other.nu {
             inter.nu.take();
         }

--- a/core/engine/src/builtins/intl/locale/utils.rs
+++ b/core/engine/src/builtins/intl/locale/utils.rs
@@ -401,19 +401,19 @@ where
     provider
         .locale_canonicalizer()?
         .canonicalize(&mut found_locale);
-    let mut locale_prefs: S::Preferences = S::Preferences::from(&found_locale);
+    let mut locale_prefs = S::Preferences::from(&found_locale);
 
     options
-        .service_options
+        .preferences
         .validate_extensions(&found_locale.id, provider);
     locale_prefs.validate_extensions(&found_locale.id, provider);
 
+    let mut prefs = locale_prefs.clone();
+
     // This also sets the locale to the found locale.
-    options.service_options.extend(&locale_prefs);
-    found_locale.extensions.unicode = options
-        .service_options
-        .intersection(&locale_prefs)
-        .as_unicode();
+    prefs.extend(&options.preferences);
+    found_locale.extensions.unicode = prefs.intersection(&locale_prefs).as_unicode();
+    options.preferences = prefs;
 
     // 12. Return result.
     Ok(found_locale)

--- a/core/engine/src/builtins/intl/locale/utils.rs
+++ b/core/engine/src/builtins/intl/locale/utils.rs
@@ -403,15 +403,12 @@ where
         .canonicalize(&mut found_locale);
     let mut locale_prefs = S::Preferences::from(&found_locale);
 
-    options
-        .preferences
-        .validate_extensions(&found_locale.id, provider);
-    locale_prefs.validate_extensions(&found_locale.id, provider);
+    options.preferences.validate(&found_locale.id, provider);
+    locale_prefs.validate(&found_locale.id, provider);
 
-    let mut prefs = locale_prefs.clone();
+    // This should not touch the found locale.
+    let prefs = locale_prefs.extended(&options.preferences);
 
-    // This also sets the locale to the found locale.
-    prefs.extend(&options.preferences);
     found_locale.extensions.unicode = prefs.intersection(&locale_prefs).as_unicode();
     options.preferences = prefs;
 

--- a/core/engine/src/builtins/intl/locale/utils.rs
+++ b/core/engine/src/builtins/intl/locale/utils.rs
@@ -394,7 +394,7 @@ where
     // ensures:
     // - All options provided by the locale are valid.
     // - All options provided by args are valid.
-    // - Options provided by args are extended (but not overriden) by
+    // - Options provided by args are extended (but not overridden) by
     //   options provided in the locale.
     // - Only the locale options that extended the args options are
     //   added to the final locale.

--- a/core/engine/src/builtins/intl/mod.rs
+++ b/core/engine/src/builtins/intl/mod.rs
@@ -179,26 +179,36 @@ impl Intl {
     }
 }
 
+/// A set of preferences that can be provided to a [`Service`] through
+/// a locale.
 trait ServicePreferences: for<'a> From<&'a icu_locale::Locale> + Clone {
-    fn validate_extensions(&mut self, id: &LanguageIdentifier, provider: &IntlProvider);
+    /// Validates that every preference value is available.
+    ///
+    /// This usually entails having to query the `IntlProvider` to check
+    /// if it has the required data to support the requested values.
+    fn validate(&mut self, id: &LanguageIdentifier, provider: &IntlProvider);
+
+    /// Converts this set of preferences into a Unicode locale extension.
     fn as_unicode(&self) -> unicode::Unicode;
-    fn extend(&mut self, other: &Self);
+
+    /// Extends all values set in `self` with the values set in `other`.
+    fn extended(&self, other: &Self) -> Self;
+
+    /// Gets the set of preference values that are the same in `self` and `other`.
     fn intersection(&self, other: &Self) -> Self;
 }
 
 /// A service component that is part of the `Intl` API.
 ///
 /// This needs to be implemented for every `Intl` service in order to use the functions
-/// defined in `locale::utils`, such as locale resolution and selection.
+/// defined in `locale::utils`, such as [`resolve_locale`][locale::resolve_locale].
 trait Service {
-    /// The data marker used by [`resolve_locale`][locale::resolve_locale] to decide
-    /// which locales are supported by this service.
+    /// The data marker used to decide which locales are supported by this service.
     type LangMarker: DataMarker;
 
     /// The attributes used to resolve the locale.
     const ATTRIBUTES: &'static DataMarkerAttributes = DataMarkerAttributes::empty();
 
-    /// The set of preferences used in the [`Service::resolve`] method to resolve the provided
-    /// locale.
+    /// The set of preferences used to resolve the provided locale.
     type Preferences: ServicePreferences;
 }

--- a/core/engine/src/builtins/intl/mod.rs
+++ b/core/engine/src/builtins/intl/mod.rs
@@ -179,7 +179,7 @@ impl Intl {
     }
 }
 
-trait ServicePreferences: for<'a> From<&'a icu_locale::Locale> {
+trait ServicePreferences: for<'a> From<&'a icu_locale::Locale> + Clone {
     fn validate_extensions(&mut self, id: &LanguageIdentifier, provider: &IntlProvider);
     fn as_unicode(&self) -> unicode::Unicode;
     fn extend(&mut self, other: &Self);

--- a/core/engine/src/builtins/intl/mod.rs
+++ b/core/engine/src/builtins/intl/mod.rs
@@ -26,8 +26,8 @@ use crate::{
 };
 
 use boa_gc::{Finalize, Trace};
-use icu_locale::{LanguageIdentifier, extensions::unicode, preferences::LocalePreferences};
-use icu_provider::{DataMarker, DataMarkerAttributes, DryDataProvider};
+use icu_locale::{LanguageIdentifier, extensions::unicode};
+use icu_provider::{DataMarker, DataMarkerAttributes};
 use static_assertions::const_assert;
 
 pub(crate) mod collator;
@@ -180,12 +180,7 @@ impl Intl {
 }
 
 trait ServicePreferences: for<'a> From<&'a icu_locale::Locale> {
-    fn validate_extensions<M: DataMarker>(
-        &mut self,
-        id: &LanguageIdentifier,
-        provider: &impl DryDataProvider<M>,
-    );
-    fn set_locale(&mut self, locale: LocalePreferences);
+    fn validate_extensions(&mut self, id: &LanguageIdentifier, provider: &IntlProvider);
     fn as_unicode(&self) -> unicode::Unicode;
     fn extend(&mut self, other: &Self);
     fn intersection(&self, other: &Self) -> Self;
@@ -206,22 +201,4 @@ trait Service {
     /// The set of preferences used in the [`Service::resolve`] method to resolve the provided
     /// locale.
     type Preferences: ServicePreferences;
-
-    /// Resolves the final value of `locale` from a set of `options`.
-    ///
-    /// The provided `options` will also be modified with the final values, in case there were
-    /// changes in the resolution algorithm.
-    ///
-    /// # Note
-    ///
-    /// - A correct implementation must ensure `locale` and `options` are both written with the
-    ///   new final values.
-    /// - If the implementor service doesn't contain any `[[RelevantExtensionKeys]]`, this can be
-    ///   skipped.
-    fn resolve(
-        _locale: &mut icu_locale::Locale,
-        _options: &mut Self::Preferences,
-        _provider: &IntlProvider,
-    ) {
-    }
 }

--- a/core/engine/src/builtins/intl/number_format/mod.rs
+++ b/core/engine/src/builtins/intl/number_format/mod.rs
@@ -78,11 +78,6 @@ impl NumberFormat {
     }
 }
 
-#[derive(Debug, Clone)]
-pub(super) struct NumberFormatLocaleOptions {
-    numbering_system: Option<Value>,
-}
-
 impl Service for NumberFormat {
     type LangMarker = DecimalSymbolsV1;
 

--- a/core/engine/src/builtins/intl/number_format/mod.rs
+++ b/core/engine/src/builtins/intl/number_format/mod.rs
@@ -253,7 +253,7 @@ impl NumberFormat {
 
         let mut intl_options = IntlOptions {
             matcher,
-            service_options: {
+            preferences: {
                 let mut prefs = DecimalFormatterPreferences::default();
                 prefs.numbering_system = numbering_system;
                 prefs
@@ -418,7 +418,7 @@ impl NumberFormat {
                 nu: Cell::new(None),
             };
             let formatter = DecimalFormatter::try_new_with_buffer_provider(
-                context.intl_provider().erased_provider(),
+                &inspector,
                 (&locale).into(),
                 options,
             )
@@ -429,7 +429,11 @@ impl NumberFormat {
                 let nu = Value::try_from_str(&nu).ok()?;
                 NumberingSystem::try_from(nu).ok()
             })()
-            .ok_or_else(|| js_error!(TypeError: "invalid numbering system from Intl provider"))?;
+            .ok_or_else(|| {
+                js_error!(
+                    TypeError: "could not obtain resolved numbering system from Intl provider"
+                )
+            })?;
 
             (formatter, nu)
         };

--- a/core/engine/src/builtins/intl/number_format/options.rs
+++ b/core/engine/src/builtins/intl/number_format/options.rs
@@ -9,7 +9,7 @@ use boa_macros::js_str;
 use icu_decimal::{
     DecimalFormatterPreferences, preferences::NumberingSystem, provider::DecimalSymbolsV1,
 };
-use icu_locale::{extensions::unicode::Value, preferences::PreferenceKey};
+use icu_locale::extensions::unicode::Value;
 use icu_provider::{
     DataMarkerAttributes,
     prelude::icu_locale_core::{
@@ -1275,31 +1275,5 @@ impl ServicePreferences for DecimalFormatterPreferences {
         });
     }
 
-    fn as_unicode(&self) -> unicode::Unicode {
-        let mut exts = unicode::Unicode::new();
-
-        if let Some(nu) = self.numbering_system
-            && let Some(value) = nu.unicode_extension_value()
-        {
-            exts.keywords.set(unicode::key!("nu"), value);
-        }
-        exts
-    }
-
-    fn extended(&self, other: &Self) -> Self {
-        let mut result = *self;
-        result.extend(*other);
-        result
-    }
-
-    fn intersection(&self, other: &Self) -> Self {
-        let mut inter = *self;
-        if inter.locale_preferences != other.locale_preferences {
-            inter.locale_preferences = LocalePreferences::default();
-        }
-        if inter.numbering_system != other.numbering_system {
-            inter.numbering_system.take();
-        }
-        inter
-    }
+    impl_service_preferences!(numbering_system);
 }

--- a/core/engine/src/builtins/intl/number_format/options.rs
+++ b/core/engine/src/builtins/intl/number_format/options.rs
@@ -6,7 +6,9 @@ use fixed_decimal::{
 };
 
 use boa_macros::js_str;
-use icu_decimal::{DecimalFormatterPreferences, preferences::NumberingSystem};
+use icu_decimal::{
+    DecimalFormatterPreferences, preferences::NumberingSystem, provider::DecimalSymbolsV1,
+};
 use icu_locale::{extensions::unicode::Value, preferences::PreferenceKey};
 use icu_provider::{
     DataMarkerAttributes,
@@ -26,6 +28,7 @@ use crate::{
         },
         options::{OptionType, ParsableOptionType, get_option},
     },
+    context::icu::IntlProvider,
     js_string,
 };
 
@@ -1265,19 +1268,11 @@ impl RoundingType {
 }
 
 impl ServicePreferences for DecimalFormatterPreferences {
-    fn validate_extensions<M: icu_provider::DataMarker>(
-        &mut self,
-        id: &LanguageIdentifier,
-        provider: &impl icu_provider::DryDataProvider<M>,
-    ) {
+    fn validate_extensions(&mut self, id: &LanguageIdentifier, provider: &IntlProvider) {
         self.numbering_system = self.numbering_system.take().filter(|nu| {
             let attr = DataMarkerAttributes::from_str_or_panic(nu.as_str());
-            validate_extension::<M>(id, attr, provider)
+            validate_extension::<DecimalSymbolsV1>(id, attr, provider)
         });
-    }
-
-    fn set_locale(&mut self, locale: LocalePreferences) {
-        self.locale_preferences = locale
     }
 
     fn as_unicode(&self) -> unicode::Unicode {

--- a/core/engine/src/builtins/intl/number_format/options.rs
+++ b/core/engine/src/builtins/intl/number_format/options.rs
@@ -1291,9 +1291,9 @@ impl ServicePreferences for DecimalFormatterPreferences {
     }
 
     fn intersection(&self, other: &Self) -> Self {
-        let mut inter = self.clone();
+        let mut inter = *self;
         if inter.locale_preferences != other.locale_preferences {
-            inter.locale_preferences = LocalePreferences::default()
+            inter.locale_preferences = LocalePreferences::default();
         }
         if inter.numbering_system != other.numbering_system {
             inter.numbering_system.take();

--- a/core/engine/src/builtins/intl/number_format/options.rs
+++ b/core/engine/src/builtins/intl/number_format/options.rs
@@ -1268,7 +1268,7 @@ impl RoundingType {
 }
 
 impl ServicePreferences for DecimalFormatterPreferences {
-    fn validate_extensions(&mut self, id: &LanguageIdentifier, provider: &IntlProvider) {
+    fn validate(&mut self, id: &LanguageIdentifier, provider: &IntlProvider) {
         self.numbering_system = self.numbering_system.take().filter(|nu| {
             let attr = DataMarkerAttributes::from_str_or_panic(nu.as_str());
             validate_extension::<DecimalSymbolsV1>(id, attr, provider)
@@ -1286,8 +1286,10 @@ impl ServicePreferences for DecimalFormatterPreferences {
         exts
     }
 
-    fn extend(&mut self, other: &Self) {
-        self.extend(*other);
+    fn extended(&self, other: &Self) -> Self {
+        let mut result = *self;
+        result.extend(*other);
+        result
     }
 
     fn intersection(&self, other: &Self) -> Self {

--- a/core/engine/src/builtins/intl/options.rs
+++ b/core/engine/src/builtins/intl/options.rs
@@ -1,10 +1,12 @@
 use std::{fmt, str::FromStr};
 
+use icu_locale::{LanguageIdentifier, extensions::unicode, preferences::LocalePreferences};
+use icu_provider::{DataMarker, DryDataProvider};
 use num_traits::FromPrimitive;
 
 use crate::{
     Context, JsNativeError, JsResult, JsString, JsValue,
-    builtins::{OrdinaryObject, options::ParsableOptionType},
+    builtins::{OrdinaryObject, intl::ServicePreferences, options::ParsableOptionType},
     object::JsObject,
 };
 
@@ -47,6 +49,32 @@ impl FromStr for LocaleMatcher {
 }
 
 impl ParsableOptionType for LocaleMatcher {}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub(super) struct EmptyPreferences;
+
+impl From<&icu_locale::Locale> for EmptyPreferences {
+    fn from(_: &icu_locale::Locale) -> Self {
+        Self
+    }
+}
+
+impl ServicePreferences for EmptyPreferences {
+    fn validate_extensions<M: DataMarker>(
+        &mut self,
+        _: &LanguageIdentifier,
+        _: &impl DryDataProvider<M>,
+    ) {
+    }
+    fn set_locale(&mut self, _: LocalePreferences) {}
+    fn as_unicode(&self) -> unicode::Unicode {
+        unicode::Unicode::new()
+    }
+    fn extend(&mut self, _: &Self) {}
+    fn intersection(&self, _: &Self) -> Self {
+        Self
+    }
+}
 
 /// Abstract operation `GetNumberOption ( options, property, minimum, maximum, fallback )`
 ///

--- a/core/engine/src/builtins/intl/options.rs
+++ b/core/engine/src/builtins/intl/options.rs
@@ -1,12 +1,12 @@
 use std::{fmt, str::FromStr};
 
-use icu_locale::{LanguageIdentifier, extensions::unicode, preferences::LocalePreferences};
-use icu_provider::{DataMarker, DryDataProvider};
+use icu_locale::{LanguageIdentifier, extensions::unicode};
 use num_traits::FromPrimitive;
 
 use crate::{
     Context, JsNativeError, JsResult, JsString, JsValue,
     builtins::{OrdinaryObject, intl::ServicePreferences, options::ParsableOptionType},
+    context::icu::IntlProvider,
     object::JsObject,
 };
 
@@ -60,13 +60,7 @@ impl From<&icu_locale::Locale> for EmptyPreferences {
 }
 
 impl ServicePreferences for EmptyPreferences {
-    fn validate_extensions<M: DataMarker>(
-        &mut self,
-        _: &LanguageIdentifier,
-        _: &impl DryDataProvider<M>,
-    ) {
-    }
-    fn set_locale(&mut self, _: LocalePreferences) {}
+    fn validate_extensions(&mut self, _: &LanguageIdentifier, _: &IntlProvider) {}
     fn as_unicode(&self) -> unicode::Unicode {
         unicode::Unicode::new()
     }

--- a/core/engine/src/builtins/intl/options.rs
+++ b/core/engine/src/builtins/intl/options.rs
@@ -60,11 +60,13 @@ impl From<&icu_locale::Locale> for EmptyPreferences {
 }
 
 impl ServicePreferences for EmptyPreferences {
-    fn validate_extensions(&mut self, _: &LanguageIdentifier, _: &IntlProvider) {}
+    fn validate(&mut self, _: &LanguageIdentifier, _: &IntlProvider) {}
     fn as_unicode(&self) -> unicode::Unicode {
         unicode::Unicode::new()
     }
-    fn extend(&mut self, _: &Self) {}
+    fn extended(&self, _: &Self) -> Self {
+        Self
+    }
     fn intersection(&self, _: &Self) -> Self {
         Self
     }

--- a/core/engine/src/builtins/intl/options.rs
+++ b/core/engine/src/builtins/intl/options.rs
@@ -17,7 +17,7 @@ use crate::{
 #[derive(Debug, Default)]
 pub(super) struct IntlOptions<O> {
     pub(super) matcher: LocaleMatcher,
-    pub(super) service_options: O,
+    pub(super) preferences: O,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]

--- a/core/engine/src/builtins/intl/plural_rules/mod.rs
+++ b/core/engine/src/builtins/intl/plural_rules/mod.rs
@@ -11,8 +11,7 @@ use icu_plurals::{
 use crate::{
     Context, JsArgs, JsData, JsNativeError, JsObject, JsResult, JsString, JsSymbol, JsValue,
     builtins::{
-        Array, BuiltInBuilder, BuiltInConstructor, BuiltInObject, IntrinsicObject,
-        options::get_option,
+        Array, BuiltInBuilder, BuiltInConstructor, BuiltInObject, IntrinsicObject, intl::options::EmptyPreferences, options::get_option
     },
     context::intrinsics::{Intrinsics, StandardConstructor, StandardConstructors},
     js_string,
@@ -43,7 +42,7 @@ pub(crate) struct PluralRules {
 impl Service for PluralRules {
     type LangMarker = PluralsCardinalV1;
 
-    type LocaleOptions = ();
+    type Preferences = EmptyPreferences;
 }
 
 impl IntrinsicObject for PluralRules {

--- a/core/engine/src/builtins/intl/plural_rules/mod.rs
+++ b/core/engine/src/builtins/intl/plural_rules/mod.rs
@@ -11,7 +11,8 @@ use icu_plurals::{
 use crate::{
     Context, JsArgs, JsData, JsNativeError, JsObject, JsResult, JsString, JsSymbol, JsValue,
     builtins::{
-        Array, BuiltInBuilder, BuiltInConstructor, BuiltInObject, IntrinsicObject, intl::options::EmptyPreferences, options::get_option
+        Array, BuiltInBuilder, BuiltInConstructor, BuiltInObject, IntrinsicObject,
+        intl::options::EmptyPreferences, options::get_option,
     },
     context::intrinsics::{Intrinsics, StandardConstructor, StandardConstructors},
     js_string,

--- a/core/engine/src/builtins/intl/segmenter/mod.rs
+++ b/core/engine/src/builtins/intl/segmenter/mod.rs
@@ -4,6 +4,7 @@ use crate::{
     Context, JsArgs, JsData, JsNativeError, JsResult, JsString, JsSymbol, JsValue,
     builtins::{
         BuiltInBuilder, BuiltInConstructor, BuiltInObject, IntrinsicObject,
+        intl::options::EmptyPreferences,
         options::{get_option, get_options_object},
     },
     context::intrinsics::{Intrinsics, StandardConstructor, StandardConstructors},
@@ -98,7 +99,7 @@ impl Service for Segmenter {
     // and replace when segmenters are locale-aware.
     type LangMarker = CollationDiacriticsV1;
 
-    type LocaleOptions = ();
+    type Preferences = EmptyPreferences;
 }
 
 impl IntrinsicObject for Segmenter {


### PR DESCRIPTION
A pending task after migrating to ICU4X 2.0 was to use the newly introduced locale preferences to clean up our Intl implementation. This PR takes care of that by introducing the `ServicePreferences` trait and removing the `Service::resolve` method, which makes the code much more modular overall.

cc @sffc, it might be interesting to see if we can upstream parts of the `ServicePreferences` trait, like `as_unicode` or `intersection`.