### PR TITLE
Allow 'of' as variable name in `let` declarations

### DIFF
--- a/core/parser/src/parser/statement/declaration/lexical.rs
+++ b/core/parser/src/parser/statement/declaration/lexical.rs
@@ -128,7 +128,7 @@ pub(crate) fn allowed_token_after_let(token: Option<&Token>) -> bool {
         Some(
             TokenKind::IdentifierName(_)
                 | TokenKind::Keyword((
-                    Keyword::Await | Keyword::Yield | Keyword::Let | Keyword::Async,
+                    Keyword::Await | Keyword::Yield | Keyword::Let | Keyword::Async | Keyword::Of,
                     _
                 ))
                 | TokenKind::Punctuator(Punctuator::OpenBlock | Punctuator::OpenBracket),


### PR DESCRIPTION
### Problem
The parser rejects `let of = ...` declarations with a syntax error, even though `of` is a contextual keyword (used in `for-of` loops) and NOT a reserved word. Per the ECMAScript specification, `let of = 1;` is valid JavaScript.

### Reproduction

```
cargo run --bin boa -- -e "let of = 1; console.log(of)"
```

- Expected: `1`
- Actual: `SyntaxError: unexpected token 'let', strict reserved word cannot be an identifier`

**With a regex (common in minified code):**

```
cargo run --bin boa -- -e "let of = /^test$/; console.log(typeof of)"
```

- Expected: `object`
- Actual: `SyntaxError`

### Solution

Add `Keyword::Of` to the list of allowed tokens after `let` in `allowed_token_after_let()`.