### PR TITLE
Fix script execution to use fresh global environment stack

### DIFF
--- a/core/engine/src/script.rs
+++ b/core/engine/src/script.rs
@@ -18,6 +18,7 @@ use boa_parser::{Parser, Source, source::ReadChar};
 use crate::{
     Context, HostDefined, JsResult, JsString, JsValue, Module, SpannedSourceText,
     bytecompiler::{ByteCompiler, global_declaration_instantiation_context},
+    environments::EnvironmentStack,
     js_string,
     realm::Realm,
     spanned_source_text::SourceText,
@@ -210,15 +211,15 @@ impl Script {
     fn prepare_run(&self, context: &mut Context) -> JsResult<()> {
         let codeblock = self.codeblock(context)?;
 
-        let env_fp = context.vm.frame.environments.len() as u32;
+        let global_env = EnvironmentStack::new(self.inner.realm.environment().clone());
         context.vm.push_frame_with_stack(
             CallFrame::new(
                 codeblock,
                 Some(ActiveRunnable::Script(self.clone())),
-                context.vm.frame.environments.clone(),
+                global_env,
                 self.inner.realm.clone(),
             )
-            .with_env_fp(env_fp)
+            .with_env_fp(0)
             .with_flags(CallFrameFlags::EXIT_EARLY),
             JsValue::undefined(),
             JsValue::null(),


### PR DESCRIPTION
### Problem

When `Script::evaluate()` is called while another execution context is active (e.g., during class field initialization or from within a method), the script incorrectly inherits the caller's environment stack. Since scripts are compiled assuming global scope with binding indices starting at 0, this causes binding index mismatches and incorrect variable resolution.

This affects embedders who call `Context::eval()` from native functions or host hooks during script execution.

**Note:** This does NOT affect JavaScript's `eval()` function, which has its own separate implementation in `builtins/eval/mod.rs` with proper direct/indirect eval semantics per PerformEval.

### Reproduction

This bug manifests in embedding scenarios. For example, in a browser runtime that evaluates inline `<script>` tags:

1. Main script executes and defines a class with field initializers
2. During class instantiation, a native callback triggers `Context::eval()` for another script
3. The second script inherits the class's environment stack instead of getting a fresh global environment
4. Binding indices don't match, causing incorrect variable resolution or panics

### Solution

Per [ScriptEvaluation](https://tc39.es/ecma262/#sec-runtime-semantics-scriptevaluation), a script's execution context should use the realm's global environment, not inherit from the caller:

> Let scriptContext be a new ECMAScript code execution context.
> Set the Function of scriptContext to null.
> Set the Realm of scriptContext to scriptRecord.[[Realm]].
> Set the ScriptOrModule of scriptContext to scriptRecord.
> Set the VariableEnvironment of scriptContext to globalEnv.
> Set the LexicalEnvironment of scriptContext to globalEnv.

This PR creates a fresh `EnvironmentStack` containing only the realm's global environment, with `env_fp` set to 0 to match the compiled binding indices.