### PR TITLE
Standardize WebAssembly abbreviation to Wasm (#4504)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ Boa is an experimental JavaScript lexer, parser and interpreter written in Rust 
 [build_badge]: https://github.com/boa-dev/boa/actions/workflows/rust.yml/badge.svg?event=push&branch=main
 [build_link]: https://github.com/boa-dev/boa/actions/workflows/rust.yml?query=event%3Apush+branch%3Amain
 
-## ⚡️ Live Demo (WASM)
+## ⚡️ Live Demo (Wasm)
 
-Try out the engine now at the live WASM playground [here](https://boajs.dev/playground)!
+Try out the engine now at the live Wasm playground [here](https://boajs.dev/playground)!
 
 Prefer a CLI? Feel free to try out `boa_cli`!
 

--- a/core/engine/src/builtins/array_buffer/mod.rs
+++ b/core/engine/src/builtins/array_buffer/mod.rs
@@ -622,8 +622,8 @@ impl ArrayBuffer {
 
         // TODO: 7. Let hostHandled be ? HostResizeArrayBuffer(O, newByteLength).
         // 8. If hostHandled is handled, return undefined.
-        // Used in engines to handle WASM buffers in a special way, but we don't
-        // have a WASM interpreter in place yet.
+        // Used in engines to handle Wasm buffers in a special way, but we don't
+        // have a Wasm interpreter in place yet.
 
         // 9. Let oldBlock be O.[[ArrayBufferData]].
         // 10. Let newBlock be ? CreateByteDataBlock(newByteLength).

--- a/core/engine/src/builtins/array_buffer/shared.rs
+++ b/core/engine/src/builtins/array_buffer/shared.rs
@@ -324,8 +324,8 @@ impl SharedArrayBuffer {
 
         // TODO: 5. Let hostHandled be ? HostGrowSharedArrayBuffer(O, newByteLength).
         // 6. If hostHandled is handled, return undefined.
-        // Used in engines to handle WASM buffers in a special way, but we don't
-        // have a WASM interpreter in place yet.
+        // Used in engines to handle Wasm buffers in a special way, but we don't
+        // have a Wasm interpreter in place yet.
 
         // 7. Let isLittleEndian be the value of the [[LittleEndian]] field of the surrounding agent's Agent Record.
         // 8. Let byteLengthBlock be O.[[ArrayBufferByteLengthData]].

--- a/core/engine/src/module/loader/mod.rs
+++ b/core/engine/src/module/loader/mod.rs
@@ -357,7 +357,7 @@ impl SimpleModuleLoader {
     pub fn new<P: AsRef<Path>>(root: P) -> JsResult<Self> {
         if cfg!(target_family = "wasm") {
             return Err(JsNativeError::typ()
-                .with_message("cannot resolve a relative path in WASM targets")
+                .with_message("cannot resolve a relative path in Wasm targets")
                 .into());
         }
         let root = root.as_ref();

--- a/core/engine/src/value/inner/nan_boxed.rs
+++ b/core/engine/src/value/inner/nan_boxed.rs
@@ -28,7 +28,7 @@
 //! ALL 32 bits architectures are compatible, of course, as their pointers
 //! are 32 bits.
 //!
-//! WASM with MEMORY64 (which is very rare) follows the pointer structure
+//! Wasm with MEMORY64 (which is very rare) follows the pointer structure
 //! of its host architecture.
 //! For more info, see
 //! <https://spidermonkey.dev/blog/2025/01/15/is-memory64-actually-worth-using.html>

--- a/ffi/wasm/Cargo.toml
+++ b/ffi/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "boa_wasm"
-description = "WASM compatibility layer for the Boa JavaScript engine."
+description = "Wasm compatibility layer for the Boa JavaScript engine."
 keywords = ["javascript", "compiler", "lexer", "parser", "js"]
 categories = ["parser-implementations", "wasm", "compilers"]
 publish = false

--- a/ffi/wasm/README.md
+++ b/ffi/wasm/README.md
@@ -28,7 +28,7 @@ yarn add @boa-dev/boa_wasm
 ```javascript
 import init, { evaluate } from "@boa-dev/boa_wasm";
 
-// Initialize the WASM module
+// Initialize the Wasm module
 await init();
 
 // Evaluate JavaScript code
@@ -93,7 +93,7 @@ Evaluates the given ECMAScript code and returns the result as a string.
 
 ## Features
 
-Boa's WASM build includes:
+Boa's Wasm build includes:
 
 - **Annex B**: Legacy ECMAScript features
 - **Internationalization**: Full Intl API support

--- a/ffi/wasm/src/lib.rs
+++ b/ffi/wasm/src/lib.rs
@@ -1,4 +1,4 @@
-//! An ECMAScript WASM implementation based on `boa_engine`.
+//! An ECMAScript Wasm implementation based on `boa_engine`.
 #![cfg_attr(not(test), forbid(clippy::unwrap_used))]
 #![allow(unused_crate_dependencies)]
 


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request fixes/closes #4504.

It changes the following:

It standardizes WebAssembly abbreviation to "Wasm" instead of "WASM" in the codebase.

Note that I did not touch CHANGELOG.md line 899 which uses "WASM" as I suppose it shouldn't be tempered with.
