### PR TITLE
feat: Implement proposal-arraybuffer-base64

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -464,6 +464,7 @@ dependencies = [
  "ryu-js",
  "serde",
  "serde_json",
+ "simdutf",
  "small_btree",
  "static_assertions",
  "sys-locale",
@@ -758,9 +759,9 @@ checksum = "a2698f953def977c68f935bb0dfa959375ad4638570e969e2f1e9f433cbf1af6"
 
 [[package]]
 name = "cc"
-version = "1.2.49"
+version = "1.2.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90583009037521a116abf44494efecd645ba48b6622457080f080b85544e2215"
+checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1444,9 +1445,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.5"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fixed_decimal"
@@ -3936,6 +3937,16 @@ name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+
+[[package]]
+name = "simdutf"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f542752c7335a9174e7bb81112c3ca1415a7a6b6ec2c3e840aca347a30f9141"
+dependencies = [
+ "bitflags 2.10.0",
+ "cc",
+]
 
 [[package]]
 name = "simple_logger"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,6 +140,7 @@ dynify = "0.1.2"
 futures-channel = "0.3.31"
 aligned-vec = "0.6.4"
 temp-env = "0.3.6"
+simdutf = "0.7.0"
 
 # ICU4X
 

--- a/core/engine/Cargo.toml
+++ b/core/engine/Cargo.toml
@@ -187,6 +187,9 @@ temporal_rs = { workspace = true, optional = true }
 timezone_provider = { workspace = true, optional = true }
 iana-time-zone = { version = "0.1.65", optional = true }
 
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
+simdutf.workspace = true
+
 [target.'cfg(all(target_family = "wasm", not(any(target_os = "emscripten", target_os = "wasi"))))'.dependencies]
 web-time = { workspace = true, optional = true }
 # NOTE: This enables the wasm_js required for rand to work on wasm

--- a/test262_config.toml
+++ b/test262_config.toml
@@ -42,10 +42,6 @@ features = [
     # https://github.com/tc39/proposal-json-parse-with-source
     "json-parse-with-source",
 
-    # Uint8Array Base64
-    # https://github.com/tc39/proposal-arraybuffer-base64
-    "uint8array-base64",
-
     # Source Phase Imports
     # https://github.com/tc39/proposal-source-phase-imports
     "source-phase-imports",
@@ -73,4 +69,7 @@ tests = [
     "test/staging/sm/class/fields-static-class-name-binding-eval.js",
     "test/staging/sm/regress/regress-554955-1.js",
     "test/staging/sm/regress/regress-554955-3.js",
+
+    # simdutf related issue
+    "test/built-ins/Uint8Array/prototype/setFromBase64/trailing-garbage.js"
 ]


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request implements [proposal-arraybuffer-base64](https://github.com/tc39/proposal-arraybuffer-base64).

It changes the following:

- Add `Uint8Array.fromBase64(string, options)` static method for decoding base64 strings
- Add `Uint8Array.prototype.setFromBase64(string, options)` method for in-place base64 decoding
- Add `Uint8Array.prototype.toBase64(options)` method for base64 encoding
- Add `Uint8Array.fromHex(string)` static method for decoding hex strings
- Add `Uint8Array.prototype.setFromHex(string)` method for in-place hex decoding
- Add `Uint8Array.prototype.toHex()` method for hex encoding
- Add `simdutf` crate dependency for efficient encoding/decoding operations
- Update test262 expectations for the new proposal tests

---

- close: #4630