### PR TITLE
Implement getter for Context.instructions_remaining

### DIFF
--- a/core/engine/src/context/mod.rs
+++ b/core/engine/src/context/mod.rs
@@ -446,7 +446,7 @@ impl Context {
         self.vm.frame.realm.intrinsics()
     }
 
-    /// Returns the amount of remaining instructions to br executed
+    /// Returns the amount of remaining instructions to be executed
     #[cfg(feature = "fuzz")]
     #[inline]
     #[must_use]

--- a/core/engine/src/context/mod.rs
+++ b/core/engine/src/context/mod.rs
@@ -446,6 +446,14 @@ impl Context {
         self.vm.frame.realm.intrinsics()
     }
 
+    /// Returns the amount of remaining instructions to br executed
+    #[cfg(feature = "fuzz")]
+    #[inline]
+    #[must_use]
+    pub fn instructions_remaining(&self) -> usize { 
+        self.instructions_remaining
+    }
+
     /// Returns the currently active realm.
     #[inline]
     #[must_use]

--- a/core/engine/src/context/mod.rs
+++ b/core/engine/src/context/mod.rs
@@ -450,7 +450,7 @@ impl Context {
     #[cfg(feature = "fuzz")]
     #[inline]
     #[must_use]
-    pub fn instructions_remaining(&self) -> usize { 
+    pub fn instructions_remaining(&self) -> usize {
         self.instructions_remaining
     }
 


### PR DESCRIPTION
This implements `Context.instructions_remaining()`
for reading the remaining instruction budget of the Context, without the need for pointer arithmetic to access the field otherwise.

​This would be useful for cases where we want to monitor engine usage in a remote service for billing purposes