### PR TITLE
ci: add pull-requests write permission to workflows (Fixes #4105)

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -14,6 +14,8 @@ jobs:
   runBenchmark:
     if: contains(github.event.pull_request.labels.*.name, 'run-benchmark')
     name: run benchmark
+    permissions:
+      pull-requests: write
     runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:

--- a/.github/workflows/test262.yml
+++ b/.github/workflows/test262.yml
@@ -20,6 +20,8 @@ concurrency:
 jobs:
   run_test262:
     name: Run the test262 test suite
+    permissions:
+      pull-requests: write
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:


### PR DESCRIPTION
### Summary
This PR adds the `pull-requests: write` permission to the `runBenchmark` and `run_test262` workflows.
### Fixes
Fixes #4105
### Rationale
Currently, the `criterion-compare-action` and `test262` result comparison step fail to post comments on Pull Requests because the default `GITHUB_TOKEN` permissions are read-only. Explicitly granting `pull-requests: write` allows these actions to report results back to the PR.
