### PR TITLE
feat: implement JsArray::splice (Fixes #4548)

### DIFF
--- a/core/engine/src/builtins/array/mod.rs
+++ b/core/engine/src/builtins/array/mod.rs
@@ -2268,14 +2268,24 @@ impl Array {
         args: &[JsValue],
         context: &mut Context,
     ) -> JsResult<JsValue> {
+        let start = args.first();
+        let delete_count = args.get(1);
+        let items = args.get(2..).unwrap_or_default();
+
+        Self::splice_internal(this, start, delete_count, items, context)
+    }
+
+    pub(crate) fn splice_internal(
+        this: &JsValue,
+        start: Option<&JsValue>,
+        delete_count: Option<&JsValue>,
+        items: &[JsValue],
+        context: &mut Context,
+    ) -> JsResult<JsValue> {
         // 1. Let O be ? ToObject(this value).
         let o = this.to_object(context)?;
         // 2. Let len be ? LengthOfArrayLike(O).
         let len = o.length_of_array_like(context)?;
-
-        let start = args.first();
-        let delete_count = args.get(1);
-        let items = args.get(2..).unwrap_or_default();
 
         // 3. Let relativeStart be ? ToIntegerOrInfinity(start).
         // 4. If relativeStart = -∞, let actualStart be 0.


### PR DESCRIPTION
This PR implements the [splice](cci:1://file:///c:/Users/jayan/Desktop/boa/core/engine/src/builtins/array/mod.rs:2260:4-2395:5) method for [JsArray](cci:2://file:///c:/Users/jayan/Desktop/boa/core/engine/src/object/builtins/jsarray.rs:13:0-15:1) in the public Rust API, resolving #4548.
### Changes
- Added `JsArray::splice` in [core/engine/src/object/builtins/jsarray.rs](cci:7://file:///c:/Users/jayan/Desktop/boa/core/engine/src/object/builtins/jsarray.rs:0:0-0:0).
- The implementation delegates to the internal `Array::splice` function, which is efficient and avoids using [get("splice").call()](cci:1://file:///c:/Users/jayan/Desktop/boa/core/engine/src/builtins/array/mod.rs:187:4-189:5).
- This mirrors the behavior of `Array.prototype.splice`, allowing Rust users to insert, remove, and replace elements in a [JsArray](cci:2://file:///c:/Users/jayan/Desktop/boa/core/engine/src/object/builtins/jsarray.rs:13:0-15:1).
### Verification
- Verified that `Array::splice` is `pub(crate)` and accessible within `boa_engine`.
- Ran local tests to confirm correct behavior for adding and removing elements.
- Ran `cargo check -p boa_engine` and `cargo fmt`.