### PR TITLE
Fix/4614 textdecoder fatal

### DIFF
--- a/core/runtime/src/text/encodings.rs
+++ b/core/runtime/src/text/encodings.rs
@@ -1,6 +1,6 @@
 pub(crate) mod utf8 {
-    use boa_engine::JsString;
     use boa_engine::string::CodePoint;
+    use boa_engine::{JsResult, JsString, js_error};
 
     pub(crate) fn encode(input: &JsString) -> Vec<u8> {
         input
@@ -12,15 +12,21 @@ pub(crate) mod utf8 {
             .collect()
     }
 
-    pub(crate) fn decode(input: &[u8]) -> JsString {
-        let string = String::from_utf8_lossy(input);
-        JsString::from(string.as_ref())
+    pub(crate) fn decode(input: &[u8], fatal: bool) -> JsResult<JsString> {
+        if fatal {
+            let s = std::str::from_utf8(input)
+                .map_err(|_| js_error!(TypeError: "The encoded data was not valid."))?;
+            Ok(JsString::from(s))
+        } else {
+            let string = String::from_utf8_lossy(input);
+            Ok(JsString::from(string.as_ref()))
+        }
     }
 }
 
 pub(crate) mod utf16le {
     use boa_engine::string::JsStrVariant;
-    use boa_engine::{JsString, js_string};
+    use boa_engine::{JsResult, JsString, js_error, js_string};
 
     pub(crate) fn encode(input: &JsString) -> Vec<u8> {
         match input.as_str().variant() {
@@ -29,28 +35,37 @@ pub(crate) mod utf16le {
         }
     }
 
-    pub(crate) fn decode(mut input: &[u8]) -> JsString {
-        // After this point, input is of even length.
+    pub(crate) fn decode(mut input: &[u8], fatal: bool) -> JsResult<JsString> {
         let dangling = if input.len().is_multiple_of(2) {
             false
         } else {
+            if fatal {
+                return Err(js_error!(TypeError: "The encoded data was not valid."));
+            }
             input = &input[0..input.len() - 1];
             true
         };
 
         let input: &[u16] = bytemuck::cast_slice(input);
 
-        if dangling {
-            JsString::from(&[JsString::from(input), js_string!("\u{FFFD}")])
+        if fatal {
+            let s = String::from_utf16(input)
+                .map_err(|_| js_error!(TypeError: "The encoded data was not valid."))?;
+            Ok(JsString::from(s))
+        } else if dangling {
+            Ok(JsString::from(&[
+                JsString::from(input),
+                js_string!("\u{FFFD}"),
+            ]))
         } else {
-            JsString::from(input)
+            Ok(JsString::from(input))
         }
     }
 }
 
 pub(crate) mod utf16be {
     use boa_engine::string::JsStrVariant;
-    use boa_engine::{JsString, js_string};
+    use boa_engine::{JsResult, JsString, js_error, js_string};
 
     pub(crate) fn encode(input: &JsString) -> Vec<u8> {
         match input.as_str().variant() {
@@ -59,12 +74,14 @@ pub(crate) mod utf16be {
         }
     }
 
-    pub(crate) fn decode(mut input: Vec<u8>) -> JsString {
+    pub(crate) fn decode(mut input: Vec<u8>, fatal: bool) -> JsResult<JsString> {
         let mut input = input.as_mut_slice();
-        // After this point, input is of even length.
         let dangling = if input.len().is_multiple_of(2) {
             false
         } else {
+            if fatal {
+                return Err(js_error!(TypeError: "The encoded data was not valid."));
+            }
             let new_len = input.len() - 1;
             input = &mut input[0..new_len];
             true
@@ -72,15 +89,21 @@ pub(crate) mod utf16be {
 
         let input: &mut [u16] = bytemuck::cast_slice_mut(input);
 
-        // Swap the bytes.
         for b in &mut *input {
             *b = b.swap_bytes();
         }
 
-        if dangling {
-            JsString::from(&[JsString::from(&*input), js_string!("\u{FFFD}")])
+        if fatal {
+            let s = String::from_utf16(input)
+                .map_err(|_| js_error!(TypeError: "The encoded data was not valid."))?;
+            Ok(JsString::from(s))
+        } else if dangling {
+            Ok(JsString::from(&[
+                JsString::from(&*input),
+                js_string!("\u{FFFD}"),
+            ]))
         } else {
-            JsString::from(&*input)
+            Ok(JsString::from(&*input))
         }
     }
 }


### PR DESCRIPTION
This PR implements the [fatal](cci:1://file:///c:/Users/jayan/Desktop/boa/core/runtime/src/text/mod.rs:72:4-78:5) option for `TextDecoder` as per the specification.

### Changes
- Updated `TextDecoder` to store the [fatal](cci:1://file:///c:/Users/jayan/Desktop/boa/core/runtime/src/text/mod.rs:72:4-78:5) flag.
- Updated `TextDecoder` constructor to parse the [fatal](cci:1://file:///c:/Users/jayan/Desktop/boa/core/runtime/src/text/mod.rs:72:4-78:5) option.
- Implemented strict decoding logic in `utf8`, `utf16le`, and `utf16be` decoders.
  - When [fatal](cci:1://file:///c:/Users/jayan/Desktop/boa/core/runtime/src/text/mod.rs:72:4-78:5) is `true`, invalid byte sequences now throw a `TypeError` instead of inserting the replacement character (U+FFFD).

### Tests
- Added test cases in [core/runtime/src/text/tests.rs](cci:7://file:///c:/Users/jayan/Desktop/boa/core/runtime/src/text/tests.rs:0:0-0:0) verifying `fatal: true` behavior.
- Restored the [roundtrip](cci:1://file:///c:/Users/jayan/Desktop/boa/core/runtime/src/text/tests.rs:126:0-150:1) test case.

Fixes #4614