### PR TITLE
doctests for JsObject methods

### DIFF
--- a/core/engine/src/object/jsobject.rs
+++ b/core/engine/src/object/jsobject.rs
@@ -266,13 +266,21 @@ impl JsObject {
     /// # Examples
     ///
     /// ```
-    /// # use boa_engine::JsObject;
+    /// # use boa_engine::{JsObject, JsData, Trace, Finalize};
     /// # use boa_engine::builtins::object::OrdinaryObject;
+    /// #[derive(Debug, Trace, Finalize, JsData)]
+    /// struct CustomStruct;
+    ///
     /// let obj = JsObject::from_proto_and_data(None, OrdinaryObject);
     ///
     /// // Downcast consumes the object on success.
     /// let typed = obj.downcast::<OrdinaryObject>();
     /// assert!(typed.is_ok());
+    ///
+    /// // Downcast fails for a wrong type, returning the original object.
+    /// let obj = JsObject::from_proto_and_data(None, OrdinaryObject);
+    /// let result = obj.downcast::<CustomStruct>();
+    /// assert!(result.is_err());
     /// ```
     pub fn downcast<T: NativeObject>(self) -> Result<JsObject<T>, Self> {
         if self.is::<T>() {
@@ -311,12 +319,18 @@ impl JsObject {
     /// # Examples
     ///
     /// ```
-    /// # use boa_engine::JsObject;
+    /// # use boa_engine::{JsObject, JsData, Trace, Finalize};
     /// # use boa_engine::builtins::object::OrdinaryObject;
+    /// #[derive(Debug, Trace, Finalize, JsData)]
+    /// struct CustomStruct;
+    ///
     /// let obj = JsObject::from_proto_and_data(None, OrdinaryObject);
     ///
     /// // Downcast ref succeeds for the correct type.
     /// assert!(obj.downcast_ref::<OrdinaryObject>().is_some());
+    ///
+    /// // Returns `None` for a wrong type.
+    /// assert!(obj.downcast_ref::<CustomStruct>().is_none());
     /// ```
     #[must_use]
     #[track_caller]
@@ -342,12 +356,18 @@ impl JsObject {
     /// # Examples
     ///
     /// ```
-    /// # use boa_engine::JsObject;
+    /// # use boa_engine::{JsObject, JsData, Trace, Finalize};
     /// # use boa_engine::builtins::object::OrdinaryObject;
+    /// #[derive(Debug, Trace, Finalize, JsData)]
+    /// struct CustomStruct;
+    ///
     /// let obj = JsObject::from_proto_and_data(None, OrdinaryObject);
     ///
     /// // Downcast mut succeeds for the correct type.
     /// assert!(obj.downcast_mut::<OrdinaryObject>().is_some());
+    ///
+    /// // Returns `None` for a wrong type.
+    /// assert!(obj.downcast_mut::<CustomStruct>().is_none());
     /// ```
     #[must_use]
     #[track_caller]
@@ -372,11 +392,15 @@ impl JsObject {
     /// # Examples
     ///
     /// ```
-    /// # use boa_engine::JsObject;
+    /// # use boa_engine::{JsObject, JsData, Trace, Finalize};
     /// # use boa_engine::builtins::object::OrdinaryObject;
+    /// #[derive(Debug, Trace, Finalize, JsData)]
+    /// struct CustomStruct;
+    ///
     /// let obj = JsObject::from_proto_and_data(None, OrdinaryObject);
     ///
     /// assert!(obj.is::<OrdinaryObject>());
+    /// assert!(!obj.is::<CustomStruct>());
     /// ```
     #[inline]
     #[must_use]


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request fixes/closes #3954 .

Summary:- Added `# Examples` documentation with runnable code examples to 21 `public` methods on `JsObject` in `core/engine/src/object/jsobject.rs`.

All 21 doctests pass via `cargo test --doc -p boa_engine -- jsobject`.
