### PR TITLE
Add test for response constructor with body and status

### DIFF
--- a/core/runtime/src/fetch/tests/response.rs
+++ b/core/runtime/src/fetch/tests/response.rs
@@ -157,6 +157,29 @@ fn response_getter() {
 }
 
 #[test]
+fn response_constructor_with_body_and_status() {
+    run_test_actions([
+        TestAction::harness(),
+        TestAction::inspect_context(|ctx| register(&[], ctx)),
+        TestAction::run(
+            r#"
+                globalThis.response = (async () => {
+                    const response = new Response('Hello World', { status: 404 });
+                    assertEq(response.status, 404);
+                    assertEq(response.type, "default");
+                    const text = await response.text();
+                    assertEq(text, "Hello World");
+                })();
+            "#,
+        ),
+        TestAction::inspect_context(|ctx| {
+            let response = ctx.global_object().get(js_str!("response"), ctx).unwrap();
+            response.as_promise().unwrap().await_blocking(ctx).unwrap();
+        }),
+    ]);
+}
+
+#[test]
 fn response_redirect_default_status() {
     run_test_actions([
         TestAction::harness(),

--- a/core/runtime/src/fetch/tests/response.rs
+++ b/core/runtime/src/fetch/tests/response.rs
@@ -464,3 +464,26 @@ fn response_clone_preserves_status() {
         }),
     ]);
 }
+
+#[test]
+fn response_constructor_with_body_and_status() {
+    run_test_actions([
+        TestAction::harness(),
+        TestAction::inspect_context(|ctx| register(&[], ctx)),
+        TestAction::run(
+            r#"
+                globalThis.response = (async () => {
+                    const response = new Response('Hello World', { status: 404 });
+                    assertEq(response.status, 404);
+                    assertEq(response.type, "default");
+                    const text = await response.text();
+                    assertEq(text, "Hello World");
+                })();
+            "#,
+        ),
+        TestAction::inspect_context(|ctx| {
+            let response = ctx.global_object().get(js_str!("response"), ctx).unwrap();
+            response.as_promise().unwrap().await_blocking(ctx).unwrap();
+        }),
+    ]);
+}


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request fixes/closes #4547 .

Summary :- The `Response` constructor was a dummy implementation that completely ignored its `body` and `options` parameters, always creating an empty response with status 200. The constructor now properly parses the `body` argument, reads `status` and `headers` from the options object, validates the status code and returns `JsResult<Self>` to handle errors .
Also added the "hello world" test mentioned in the issue for testing.
