### PR TITLE
feat: Headers iterator implementation

### DIFF
--- a/core/runtime/src/fetch/tests/headers.rs
+++ b/core/runtime/src/fetch/tests/headers.rs
@@ -1,0 +1,101 @@
+//! Tests for the Headers class
+
+use super::TestFetcher;
+use crate::test::{TestAction, run_test_actions};
+use boa_engine::js_str;
+
+#[test]
+fn headers_is_iterable() {
+    run_test_actions([
+        TestAction::inspect_context(|ctx| {
+            let fetcher = TestFetcher::default();
+            crate::fetch::register(fetcher, None, ctx).expect("failed to register fetch");
+        }),
+        TestAction::run(indoc::indoc! {r#"
+            const headers = new Headers([['x', 'y'], ['a', 'b']]);
+            const result = [...headers];
+            globalThis.testResult = result.length === 2 && result[0][0] === 'x' && result[0][1] === 'y' && result[1][0] === 'a' && result[1][1] === 'b';
+        "#}),
+        TestAction::inspect_context(|ctx| {
+            let result = ctx.global_object().get(js_str!("testResult"), ctx).unwrap();
+            assert_eq!(result.to_boolean(), true);
+        }),
+    ]);
+}
+
+#[test]
+fn headers_can_be_used_with_map() {
+    run_test_actions([
+        TestAction::inspect_context(|ctx| {
+            let fetcher = TestFetcher::default();
+            crate::fetch::register(fetcher, None, ctx).expect("failed to register fetch");
+        }),
+        TestAction::run(indoc::indoc! {r#"
+            const headers = new Headers([['x', 'y']]);
+            const map = new Map(headers);
+            globalThis.testResult = map.get('x') === 'y';
+        "#}),
+        TestAction::inspect_context(|ctx| {
+            let result = ctx.global_object().get(js_str!("testResult"), ctx).unwrap();
+            assert_eq!(result.to_boolean(), true);
+        }),
+    ]);
+}
+
+#[test]
+fn headers_entries_returns_iterator() {
+    run_test_actions([
+        TestAction::inspect_context(|ctx| {
+            let fetcher = TestFetcher::default();
+            crate::fetch::register(fetcher, None, ctx).expect("failed to register fetch");
+        }),
+        TestAction::run(indoc::indoc! {r#"
+            const headers = new Headers([['x', 'y']]);
+            const iterator = headers.entries();
+            const first = iterator.next();
+            globalThis.testResult = !first.done && first.value[0] === 'x' && first.value[1] === 'y';
+        "#}),
+        TestAction::inspect_context(|ctx| {
+            let result = ctx.global_object().get(js_str!("testResult"), ctx).unwrap();
+            assert_eq!(result.to_boolean(), true);
+        }),
+    ]);
+}
+
+#[test]
+fn headers_keys_returns_iterator() {
+    run_test_actions([
+        TestAction::inspect_context(|ctx| {
+            let fetcher = TestFetcher::default();
+            crate::fetch::register(fetcher, None, ctx).expect("failed to register fetch");
+        }),
+        TestAction::run(indoc::indoc! {r#"
+            const headers = new Headers([['x', 'y'], ['a', 'b']]);
+            const keys = [...headers.keys()];
+            globalThis.testResult = keys.length === 2 && keys[0] === 'x' && keys[1] === 'a';
+        "#}),
+        TestAction::inspect_context(|ctx| {
+            let result = ctx.global_object().get(js_str!("testResult"), ctx).unwrap();
+            assert_eq!(result.to_boolean(), true);
+        }),
+    ]);
+}
+
+#[test]
+fn headers_values_returns_iterator() {
+    run_test_actions([
+        TestAction::inspect_context(|ctx| {
+            let fetcher = TestFetcher::default();
+            crate::fetch::register(fetcher, None, ctx).expect("failed to register fetch");
+        }),
+        TestAction::run(indoc::indoc! {r#"
+            const headers = new Headers([['x', 'y'], ['a', 'b']]);
+            const values = [...headers.values()];
+            globalThis.testResult = values.length === 2 && values[0] === 'y' && values[1] === 'b';
+        "#}),
+        TestAction::inspect_context(|ctx| {
+            let result = ctx.global_object().get(js_str!("testResult"), ctx).unwrap();
+            assert_eq!(result.to_boolean(), true);
+        }),
+    ]);
+}

--- a/core/runtime/src/fetch/tests/mod.rs
+++ b/core/runtime/src/fetch/tests/mod.rs
@@ -14,6 +14,8 @@ mod e2e;
 mod request;
 #[cfg(test)]
 mod response;
+#[cfg(test)]
+mod headers;
 
 /// A [`crate::fetch::Fetcher`] implementation for tests. Maps a URL to a response,
 /// and record requests received for later use.


### PR DESCRIPTION
This Pull Request fixes/closes #4611.

It changes the following:

- Made `Headers` objects iterable by implementing `entries()`, `keys()`, and `values()` methods that return proper iterators
- Added `Symbol.iterator` to the Headers prototype, pointing to the `entries` method
- Now `[...new Headers([['x','y']])]` and `new Map(new Headers([['x','y']]))` work as expected

The implementation uses array iterators under the hood since creating custom iterators would require access to private engine APIs. This is a pragmatic approach that works well for Headers objects which typically have a small number of entries.

