### PR TITLE
fixed the panic new Function(...) issue

### DIFF
--- a/core/engine/src/builtins/function/mod.rs
+++ b/core/engine/src/builtins/function/mod.rs
@@ -647,9 +647,12 @@ impl BuiltInFunctionObject {
             false,
             Span::new(function_span_start, function_span_end),
         );
-        if let Err(reason) =
-            function.analyze_scope(strict, context.realm().scope(), context.interner())
-        {
+        if let Err(reason) = function.analyze_scope_with_options(
+            strict,
+            context.realm().scope(),
+            context.interner(),
+            true,
+        ) {
             return Err(js_error!(SyntaxError: "failed to analyze function scope: {}", reason));
         }
 

--- a/core/engine/src/builtins/function/tests.rs
+++ b/core/engine/src/builtins/function/tests.rs
@@ -194,3 +194,39 @@ fn function_constructor_early_errors_super() {
         ),
     ]);
 }
+
+#[test]
+fn function_constructor_nested_scope_indices_regression() {
+    run_test_actions([TestAction::assert_eq(
+        indoc! {r#"
+            (() => {
+                const compiledCode = `
+                    const noop = () => {}
+                    function Counter() {
+                        const [v, setV] = [0, noop]
+
+                        const onClick = () => {
+                            setV(v => v + 1)
+                        }
+
+                        return null
+                    }
+                    return Counter()
+                `;
+
+                const React = {};
+                const f = new Function("React", compiledCode);
+                return f(React);
+            })()
+        "#},
+        JsValue::null(),
+    )]);
+}
+
+#[test]
+fn function_constructor_nested_lexical_capture() {
+    run_test_actions([TestAction::assert_eq(
+        "Function(\"function f(){ const x = 1; return () => x; } return f()()\")()",
+        1,
+    )]);
+}


### PR DESCRIPTION
This Pull Request fixes/closes #4525 

It changes the following:

- Adds root-aware scope index optimization support for function-like nodes, with a root-only force option.
- Adds `FunctionExpression::analyze_scope_with_options(..., force_function_scope: bool)` and keeps `analyze_scope` as a backward-compatible default.
- Updates dynamic `Function` constructor analysis to force root function-scope indexing so runtime env layout matches binding locators.
- Adds regression tests for `new Function(...)` panic reproduction and nested lexical capture behavior.
