### PR TITLE
fix: skip npm publish if boa_wasm version already exists

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
 
           if npm view @boa-dev/boa_wasm@$VERSION version > dev/null 2>&1; then
             echo "Version $VERSION already published. Skipping"
-            echo "SKIP_PUBLISH=true" >> $GUTHUB_ENV
+            echo "SKIP_PUBLISH=true" >> $GITHUB_ENV
           fi
 
       - name: Publish to npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Check if the npm version already exists
         run: |
-          VERSION=$(node -p "require('./ffi/wasm/pkg/package.json').version")
+          VERSION=$(jq -r '.version' ./ffi/wasm/pkg/package.json)
 
           if npm view @boa-dev/boa_wasm@$VERSION version > dev/null 2>&1; then
             echo "Version $VERSION already published. Skipping"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,17 @@ jobs:
       - name: Set-up npm config for publishing
         run: npm config set -- '//registry.npmjs.org/:_authToken' "${{ secrets.NPM_TOKEN }}"
 
+      - name: Check if the npm version already exists
+        run: |
+          VERSION=$(node -p "require('./ffi/wasm/pkg/package.json').version")
+
+          if npm view @boa-dev/boa_wasm@$VERSION version > dev/null 2>&1; then
+            echo "Version $VERSION already published. Skipping"
+            echo "SKIP_PUBLISH=true" >> $GUTHUB_ENV
+          fi
+
       - name: Publish to npm
+        if: env.SKIP_PUBLISH != 'true'
         run: npm publish ./ffi/wasm/pkg --access=public
 
   release-binaries:


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request fixes/closes #4065 .

It changes the following:

- Added npm version check using `npm view @boa-dev/boa_wasm@$VERSION`
- Skip `npm publish` step when the version already exists
