### PR TITLE
Fix false-positive `ReferenceError: access of uninitialized binding` in class private field initializers

### DIFF
--- a/core/ast/src/scope_analyzer.rs
+++ b/core/ast/src/scope_analyzer.rs
@@ -456,7 +456,9 @@ impl<'ast> VisitorMut<'ast> for BindingEscapeAnalyzer<'_> {
             ClassElement::PrivateFieldDefinition(field)
             | ClassElement::PrivateStaticFieldDefinition(field) => {
                 if let Some(e) = &mut field.initializer {
+                    std::mem::swap(&mut self.scope, &mut field.scope);
                     self.visit_expression_mut(e)?;
+                    std::mem::swap(&mut self.scope, &mut field.scope);
                 }
                 ControlFlow::Continue(())
             }

--- a/core/engine/src/tests/class.rs
+++ b/core/engine/src/tests/class.rs
@@ -118,6 +118,23 @@ fn property_initializer_reference_escaped_variable() {
     ]);
 }
 
+#[test]
+fn private_field_initializer_reference_non_escaped_variable() {
+    run_test_actions([
+        TestAction::run(indoc! {r#"
+            function outer() {
+                let x = 1;
+                class C {
+                    #p = x;
+                    m() { return this.#p; }
+                }
+                return new C().m();
+            }
+        "#}),
+        TestAction::assert_eq("outer()", 1),
+    ]);
+}
+
 // https://github.com/boa-dev/boa/issues/4605
 #[test]
 fn class_boolean_literal_method_names() {


### PR DESCRIPTION
**How to reproduce:**

```js
function outer() {
  let x = 1;
  class C {
    #p = x;
    m() { return this.#p; }
  }
  return new C().m();
}

console.log(outer());
```

Expected: `1`

Before this patch, I got:
`ReferenceError: access of uninitialized binding`

**Additional patterns that trigger the bug:**

```js
// Private static field initializer
function outer() {
  let x = 1;
  class C {
    static #p = x;
    static m() { return this.#p; }
  }
  return C.m();
}
console.log(outer());

// Computed read inside private field initializer
function outer() {
  let obj = { value: 7 };
  class C {
    #p = obj.value;
    m() { return this.#p; }
  }
  return new C().m();
}
console.log(outer());
```

**It changes the following:**

- Fixed `BindingEscapeAnalyzer::visit_class_element_mut` for:
  - `ClassElement::PrivateFieldDefinition`
  - `ClassElement::PrivateStaticFieldDefinition`

- In those branches, the initializer expression is now analyzed inside `field.scope` (swap in/out), as done in the public/static field branches in the same function.

- Why this is correct:
  - Binding escape analysis must run in the scope where the initializer executes.
  - Without entering `field.scope`, captures from outer lexical scopes can be misclassified as non-escaping.
  - That misclassification can produce `local()` + missing register (`Local(None)`), which then incorrectly emits `ThrowNewReferenceError("access of uninitialized binding")`.

this now mirrors the existing pattern used for:
  - `ClassElement::FieldDefinition`
  - `ClassElement::StaticFieldDefinition`

Also I added a regression test:

- `private_field_initializer_reference_non_escaped_variable` in `core/engine/src/tests/class.rs`
