### PR TITLE
fix(string): ensure separator is an object before calling Symbol.split

### DIFF
--- a/core/engine/src/builtins/string/mod.rs
+++ b/core/engine/src/builtins/string/mod.rs
@@ -1915,12 +1915,14 @@ impl String {
 
         // 2. If separator is neither undefined nor null, then
         if !separator.is_null_or_undefined() {
-            // a. Let splitter be ? GetMethod(separator, @@split).
-            let splitter = separator.get_method(JsSymbol::split(), context)?;
-            // b. If splitter is not undefined, then
-            if let Some(splitter) = splitter {
-                // i. Return ? Call(splitter, separator, « O, limit »).
-                return splitter.call(separator, &[this.clone(), limit.clone()], context);
+            if let Some(separator_obj) = separator.as_object() {
+                // a. Let splitter be ? GetMethod(separator, @@split).
+                let splitter = separator_obj.get_method(JsSymbol::split(), context)?;
+                // b. If splitter is not undefined, then
+                if let Some(splitter) = splitter {
+                    // i. Return ? Call(splitter, separator, « O, limit »).
+                    return splitter.call(separator, &[this.clone(), limit.clone()], context);
+                }
             }
         }
 

--- a/core/engine/src/builtins/string/mod.rs
+++ b/core/engine/src/builtins/string/mod.rs
@@ -1470,6 +1470,7 @@ impl String {
         // 2. If regexp is neither undefined nor null, then
         let regexp = args.get_or_undefined(0);
         if !regexp.is_null_or_undefined() {
+            if regexp.is_object() {
             // a. Let matcher be ? GetMethod(regexp, @@match).
             let matcher = regexp.get_method(JsSymbol::r#match(), context)?;
             // b. If matcher is not undefined, then
@@ -1478,7 +1479,7 @@ impl String {
                 return matcher.call(regexp, std::slice::from_ref(o), context);
             }
         }
-
+    }
         // 3. Let S be ? ToString(O).
         let s = o.to_string(context)?;
 
@@ -2055,6 +2056,7 @@ impl String {
         // 2. If regexp is neither undefined nor null, then
         let regexp = args.get_or_undefined(0);
         if !regexp.is_null_or_undefined() {
+            if regexp.is_object() {
             // a. Let isRegExp be ? IsRegExp(regexp).
             // b. If isRegExp is true, then
             if let Some(regexp) = RegExp::is_reg_exp(regexp, context)? {
@@ -2080,6 +2082,7 @@ impl String {
                 return matcher.call(regexp, std::slice::from_ref(o), context);
             }
         }
+    }
 
         // 3. Let S be ? ToString(O).
         let s = o.to_string(context)?;
@@ -2197,6 +2200,7 @@ impl String {
         // 2. If regexp is neither undefined nor null, then
         let regexp = args.get_or_undefined(0);
         if !regexp.is_null_or_undefined() {
+            if regexp.is_object() {
             // a. Let searcher be ? GetMethod(regexp, @@search).
             let searcher = regexp.get_method(JsSymbol::search(), context)?;
             // b. If searcher is not undefined, then
@@ -2205,6 +2209,7 @@ impl String {
                 return searcher.call(regexp, std::slice::from_ref(o), context);
             }
         }
+    }
 
         // 3. Let string be ? ToString(O).
         let string = o.to_string(context)?;


### PR DESCRIPTION
This Pull Request fixes #4663

**Changes:**
- Added a check to ensure the separator is an Object before looking for the @@split method.
- This prevents the engine from calling custom split functions added to primitive prototypes (like BigInt.prototype).
- Updated the logic in `core/engine/src/builtins/string/mod.rs`

**Validation:**
- I ran the official Test262 suite for String.prototype.split.
- Before fix: 116/120 tests passed (4 failed).
- After fix: 120/120 tests passed (100% conformance).

**Test Results Screenshot:**
<img width="733" height="233" alt="image" src="https://github.com/user-attachments/assets/734f16f1-79be-4bed-8484-53b44150826b" />
I have expanded the fix to include other string methods that were also incorrectly accessing Symbol methods on primitive separators.