### PR TITLE
Fix RunFile to execute test files only once

### DIFF
--- a/core/runtime/src/lib.rs
+++ b/core/runtime/src/lib.rs
@@ -309,7 +309,6 @@ pub(crate) mod test {
                     if let Err(e) = forward_file(context, &path) {
                         panic!("Uncaught {e} in file {path:?}");
                     }
-                    forward_file(context, &path).expect("failed to run file");
                 }
                 Inner::RunJobs => {
                     if let Err(e) = context.run_jobs() {


### PR DESCRIPTION
Closes #4666 

## Summary
This removes the duplicate `forward_file` call in the runtime test harness so `TestAction::RunFile` runs a file exactly once.

## Changes
- Remove the second `forward_file` invocation in the `RunFile` branch.

## Tests
- cargo fmt -- --check
- cargo clippy --all-features --all-targets