### PR TITLE
no redundant allocation in text decoder via `ArrayBuffer::data()`

### DIFF
--- a/core/runtime/src/text/mod.rs
+++ b/core/runtime/src/text/mod.rs
@@ -134,7 +134,7 @@ impl TextDecoder {
         let strip_bom = !self.ignore_bom;
 
         let Some(data) = array_buffer.data() else {
-            return Err(js_error!(TypeError: "Detached ArrayBuffer"));
+            return Err(js_error!(TypeError: "cannot decode a detached ArrayBuffer"));
         };
 
         Ok(match self.encoding {


### PR DESCRIPTION
This Pull Request fixes #4362 .

Following the suggestion from @HalidOdat in #4358 .

Note that for `Utf16Be`, the `decode` function does in place swapping and thus requires mutability.