### PR TITLE
vm: add polymorphic inline cache for property access

### DIFF
--- a/core/engine/src/object/shape/mod.rs
+++ b/core/engine/src/object/shape/mod.rs
@@ -235,7 +235,6 @@ impl From<SharedShape> for Shape {
 pub(crate) enum WeakShape {
     Unique(WeakUniqueShape),
     Shared(WeakSharedShape),
-    None,
 }
 
 impl WeakShape {
@@ -248,7 +247,6 @@ impl WeakShape {
         match self {
             WeakShape::Shared(shape) => shape.to_addr_usize(),
             WeakShape::Unique(shape) => shape.to_addr_usize(),
-            WeakShape::None => 0,
         }
     }
 
@@ -261,7 +259,6 @@ impl WeakShape {
         match self {
             WeakShape::Shared(shape) => Some(shape.upgrade()?.into()),
             WeakShape::Unique(shape) => Some(shape.upgrade()?.into()),
-            WeakShape::None => None,
         }
     }
 }

--- a/core/engine/src/vm/code_block.rs
+++ b/core/engine/src/vm/code_block.rs
@@ -634,7 +634,7 @@ impl CodeBlock {
                 let ic = &self.ic[u32::from(*ic_index) as usize];
                 format!(
                     "dst:{dst}, value:{value}, shape:0x{:x}]",
-                    ic.shape.borrow().to_addr_usize(),
+                    ic.first_shape_addr(),
                 )
             }
             Instruction::GetPropertyByName {
@@ -646,7 +646,7 @@ impl CodeBlock {
                 format!(
                     "dst:{dst}, value:{value}, ic:[name:{}, shape:0x{:x}]",
                     ic.name.to_std_string_escaped(),
-                    ic.shape.borrow().to_addr_usize(),
+                    ic.first_shape_addr(),
                 )
             }
             Instruction::GetPropertyByNameWithThis {
@@ -659,7 +659,7 @@ impl CodeBlock {
                 format!(
                     "dst:{dst}, receiver:{receiver}, value:{value}, ic:[name:{}, shape:0x{:x}]",
                     ic.name.to_std_string_escaped(),
-                    ic.shape.borrow().to_addr_usize(),
+                    ic.first_shape_addr(),
                 )
             }
             Instruction::SetPropertyByName {
@@ -670,7 +670,7 @@ impl CodeBlock {
                 let ic = &self.ic[u32::from(*ic_index) as usize];
                 format!(
                     "object:{object}, value:{value}, ic:shape:0x{:x}",
-                    ic.shape.borrow().to_addr_usize(),
+                    ic.first_shape_addr(),
                 )
             }
             Instruction::SetPropertyByNameWithThis {
@@ -682,7 +682,7 @@ impl CodeBlock {
                 let ic = &self.ic[u32::from(*ic_index) as usize];
                 format!(
                     "object:{object}, receiver:{receiver}, value:{value}, ic:shape:0x{:x}",
-                    ic.shape.borrow().to_addr_usize(),
+                    ic.first_shape_addr(),
                 )
             }
             Instruction::GetPropertyByValue {

--- a/core/engine/src/vm/inline_cache/mod.rs
+++ b/core/engine/src/vm/inline_cache/mod.rs
@@ -94,10 +94,9 @@ impl InlineCache {
         if let Some(entry) = entries
             .iter()
             .find(|entry| entry.shape.to_addr_usize() == target_addr)
+            && let Some(shape) = entry.shape.upgrade()
         {
-            if let Some(shape) = entry.shape.upgrade() {
-                return Some((shape, entry.slot));
-            }
+            return Some((shape, entry.slot));
         }
 
         None

--- a/core/engine/src/vm/inline_cache/mod.rs
+++ b/core/engine/src/vm/inline_cache/mod.rs
@@ -103,6 +103,22 @@ impl InlineCache {
         None
     }
 
+    /// Returns the address of the first cached shape.
+    ///
+    /// This is only used for VM disassembly/debug output.
+    pub(crate) fn first_shape_addr(&self) -> usize {
+        if self.megamorphic.get() {
+            return 0;
+        }
+
+        let mut entries = self.entries.borrow_mut();
+        entries.retain(|entry| entry.shape.to_addr_usize() != 0);
+        entries
+            .first()
+            .map(|entry| entry.shape.to_addr_usize())
+            .unwrap_or_default()
+    }
+
     #[cfg(test)]
     pub(crate) fn is_megamorphic(&self) -> bool {
         self.megamorphic.get()

--- a/core/engine/src/vm/inline_cache/mod.rs
+++ b/core/engine/src/vm/inline_cache/mod.rs
@@ -11,6 +11,8 @@ use crate::{
 #[cfg(test)]
 mod tests;
 
+const PIC_CAPACITY: usize = 4;
+
 /// An inline cache entry for a property access.
 #[derive(Clone, Debug, Trace, Finalize)]
 pub(crate) struct InlineCache {
@@ -23,39 +25,200 @@ pub(crate) struct InlineCache {
     /// The [`Slot`] of the property.
     #[unsafe_ignore_trace]
     pub(crate) slot: Cell<Slot>,
+
+    /// Additional PIC entries beyond the primary `shape`/`slot` entry.
+    pub(crate) secondary_shapes: GcRefCell<[WeakShape; PIC_CAPACITY - 1]>,
+
+    /// [`Slot`] values for additional PIC entries.
+    #[unsafe_ignore_trace]
+    pub(crate) secondary_slots: [Cell<Slot>; PIC_CAPACITY - 1],
+
+    /// Number of active entries in `secondary_shapes` / `secondary_slots`.
+    #[unsafe_ignore_trace]
+    pub(crate) secondary_len: Cell<u8>,
+
+    /// A site is megamorphic when we observe more distinct shapes than the PIC capacity.
+    #[unsafe_ignore_trace]
+    pub(crate) megamorphic: Cell<bool>,
 }
 
 impl InlineCache {
-    pub(crate) const fn new(name: JsString) -> Self {
+    pub(crate) fn new(name: JsString) -> Self {
         Self {
             name,
             shape: GcRefCell::new(WeakShape::None),
             slot: Cell::new(Slot::new()),
+            secondary_shapes: GcRefCell::new(std::array::from_fn(|_| WeakShape::None)),
+            secondary_slots: std::array::from_fn(|_| Cell::new(Slot::new())),
+            secondary_len: Cell::new(0),
+            megamorphic: Cell::new(false),
         }
     }
 
+    fn remove_secondary_entry(
+        &self,
+        index: usize,
+        secondary_len: usize,
+        secondary_shapes: &mut [WeakShape; PIC_CAPACITY - 1],
+    ) {
+        for i in index..(secondary_len - 1) {
+            secondary_shapes[i] = secondary_shapes[i + 1].clone();
+            self.secondary_slots[i].set(self.secondary_slots[i + 1].get());
+        }
+
+        let last = secondary_len - 1;
+        secondary_shapes[last] = WeakShape::None;
+        self.secondary_slots[last].set(Slot::new());
+    }
+
+    fn transition_to_megamorphic(
+        &self,
+        secondary_shapes: &mut [WeakShape; PIC_CAPACITY - 1],
+    ) {
+        self.megamorphic.set(true);
+        *self.shape.borrow_mut() = WeakShape::None;
+        self.slot.set(Slot::new());
+        for i in 0..(PIC_CAPACITY - 1) {
+            secondary_shapes[i] = WeakShape::None;
+            self.secondary_slots[i].set(Slot::new());
+        }
+        self.secondary_len.set(0);
+    }
+
     pub(crate) fn set(&self, shape: &Shape, slot: Slot) {
-        *self.shape.borrow_mut() = shape.into();
-        self.slot.set(slot);
+        if self.megamorphic.get() {
+            return;
+        }
+
+        let target_addr = shape.to_addr_usize();
+
+        {
+            let mut primary = self.shape.borrow_mut();
+            let primary_addr = primary.to_addr_usize();
+            if primary_addr == target_addr {
+                self.slot.set(slot);
+                return;
+            }
+
+            if primary_addr == 0 {
+                *primary = shape.into();
+                self.slot.set(slot);
+                return;
+            }
+        }
+
+        let mut secondary_shapes = self.secondary_shapes.borrow_mut();
+        let mut secondary_len = usize::from(self.secondary_len.get());
+
+        let mut i = 0;
+        while i < secondary_len {
+            let secondary_addr = secondary_shapes[i].to_addr_usize();
+            if secondary_addr == 0 {
+                self.remove_secondary_entry(i, secondary_len, &mut secondary_shapes);
+                secondary_len -= 1;
+                self.secondary_len.set(secondary_len as u8);
+                continue;
+            }
+
+            if secondary_addr == target_addr {
+                self.secondary_slots[i].set(slot);
+                return;
+            }
+
+            i += 1;
+        }
+
+        if secondary_len < (PIC_CAPACITY - 1) {
+            secondary_shapes[secondary_len] = shape.into();
+            self.secondary_slots[secondary_len].set(slot);
+            self.secondary_len.set((secondary_len + 1) as u8);
+            return;
+        }
+
+        self.transition_to_megamorphic(&mut secondary_shapes);
     }
 
     pub(crate) fn slot(&self) -> Slot {
         self.slot.get()
     }
 
-    /// Returns true, if the [`InlineCache`]'s shape matches with the given shape.
-    ///
-    /// Otherwise we reset the internal weak reference to [`WeakShape::None`],
-    /// so it can be deallocated by the GC.
-    pub(crate) fn match_or_reset(&self, shape: &Shape) -> Option<(Shape, Slot)> {
-        let mut old = self.shape.borrow_mut();
-
-        let old_upgraded = old.upgrade();
-        if old_upgraded.as_ref().map_or(0, Shape::to_addr_usize) == shape.to_addr_usize() {
-            return old_upgraded.map(|shape| (shape, self.slot()));
+    /// Returns the cached `(shape, slot)` if this PIC contains a matching shape.
+    pub(crate) fn match_shape(&self, shape: &Shape) -> Option<(Shape, Slot)> {
+        if self.megamorphic.get() {
+            return None;
         }
 
-        *old = WeakShape::None;
+        let target_addr = shape.to_addr_usize();
+
+        {
+            let mut primary = self.shape.borrow_mut();
+            let primary_addr = primary.to_addr_usize();
+            if primary_addr == target_addr {
+                if let Some(shape) = primary.upgrade() {
+                    return Some((shape, self.slot()));
+                }
+                *primary = WeakShape::None;
+            } else if primary_addr == 0 {
+                *primary = WeakShape::None;
+            }
+        }
+
+        let mut secondary_shapes = self.secondary_shapes.borrow_mut();
+        let mut secondary_len = usize::from(self.secondary_len.get());
+
+        let mut i = 0;
+        while i < secondary_len {
+            let secondary_addr = secondary_shapes[i].to_addr_usize();
+            if secondary_addr == 0 {
+                self.remove_secondary_entry(i, secondary_len, &mut secondary_shapes);
+                secondary_len -= 1;
+                self.secondary_len.set(secondary_len as u8);
+                continue;
+            }
+
+            if secondary_addr == target_addr {
+                if let Some(shape) = secondary_shapes[i].upgrade() {
+                    return Some((shape, self.secondary_slots[i].get()));
+                }
+
+                self.remove_secondary_entry(i, secondary_len, &mut secondary_shapes);
+                secondary_len -= 1;
+                self.secondary_len.set(secondary_len as u8);
+                continue;
+            }
+
+            i += 1;
+        }
+
         None
+    }
+
+    #[cfg(test)]
+    pub(crate) fn is_megamorphic(&self) -> bool {
+        self.megamorphic.get()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn entry_count(&self) -> usize {
+        usize::from(self.shape.borrow().to_addr_usize() != 0) + usize::from(self.secondary_len.get())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn contains_shape(&self, shape: &Shape) -> bool {
+        let target_addr = shape.to_addr_usize();
+
+        if self.shape.borrow().to_addr_usize() == target_addr {
+            return true;
+        }
+
+        let secondary_len = usize::from(self.secondary_len.get());
+        let secondary_shapes = self.secondary_shapes.borrow();
+        for i in 0..secondary_len {
+            if secondary_shapes[i].to_addr_usize() == target_addr {
+                return true;
+            }
+        }
+
+        false
     }
 }

--- a/core/engine/src/vm/inline_cache/tests.rs
+++ b/core/engine/src/vm/inline_cache/tests.rs
@@ -6,8 +6,7 @@ use crate::{
     builtins::{OrdinaryObject, function::OrdinaryFunction},
     js_string,
     object::{
-        ObjectInitializer,
-        internal_methods::InternalMethodPropertyContext,
+        ObjectInitializer, internal_methods::InternalMethodPropertyContext,
         shape::slot::SlotAttributes,
     },
     property::{Attribute, PropertyDescriptor, PropertyKey},

--- a/core/engine/src/vm/inline_cache/tests.rs
+++ b/core/engine/src/vm/inline_cache/tests.rs
@@ -8,7 +8,7 @@ use crate::{
     object::{
         ObjectInitializer,
         internal_methods::InternalMethodPropertyContext,
-        shape::{WeakShape, slot::SlotAttributes},
+        shape::slot::SlotAttributes,
     },
     property::{Attribute, PropertyDescriptor, PropertyKey},
     vm::CodeBlock,
@@ -331,7 +331,6 @@ fn set_property_by_name_set_inline_cache_on_property_load() -> JsResult<()> {
     let (function, code) = get_codeblock(&function).unwrap();
 
     assert_eq!(code.ic.len(), 1);
-    assert_eq!(code.ic[0].shape.borrow().clone(), WeakShape::None);
     assert_eq!(code.ic[0].entry_count(), 0);
     assert!(!code.ic[0].is_megamorphic());
 
@@ -342,8 +341,8 @@ fn set_property_by_name_set_inline_cache_on_property_load() -> JsResult<()> {
 
     function.call(&JsValue::undefined(), &[o.clone().into()], context)?;
 
-    assert_eq!(code.ic[0].shape.borrow().clone(), WeakShape::from(&o_shape));
     assert_eq!(code.ic[0].entry_count(), 1);
+    assert!(code.ic[0].contains_shape(&o_shape));
     assert!(!code.ic[0].is_megamorphic());
 
     Ok(())
@@ -356,7 +355,6 @@ fn get_property_by_name_set_inline_cache_on_property_load() -> JsResult<()> {
     let (function, code) = get_codeblock(&function).unwrap();
 
     assert_eq!(code.ic.len(), 1);
-    assert_eq!(code.ic[0].shape.borrow().clone(), WeakShape::None);
     assert_eq!(code.ic[0].entry_count(), 0);
     assert!(!code.ic[0].is_megamorphic());
 
@@ -367,8 +365,8 @@ fn get_property_by_name_set_inline_cache_on_property_load() -> JsResult<()> {
 
     function.call(&JsValue::undefined(), &[o.clone().into()], context)?;
 
-    assert_eq!(code.ic[0].shape.borrow().clone(), WeakShape::from(&o_shape));
     assert_eq!(code.ic[0].entry_count(), 1);
+    assert!(code.ic[0].contains_shape(&o_shape));
     assert!(!code.ic[0].is_megamorphic());
 
     Ok(())

--- a/core/engine/src/vm/inline_cache/tests.rs
+++ b/core/engine/src/vm/inline_cache/tests.rs
@@ -332,6 +332,7 @@ fn set_property_by_name_set_inline_cache_on_property_load() -> JsResult<()> {
     assert_eq!(code.ic.len(), 1);
     assert_eq!(code.ic[0].entry_count(), 0);
     assert!(!code.ic[0].is_megamorphic());
+    assert_eq!(code.ic[0].first_shape_addr(), 0);
 
     let o = ObjectInitializer::new(context)
         .property(js_string!("test"), 0, Attribute::all())
@@ -343,6 +344,7 @@ fn set_property_by_name_set_inline_cache_on_property_load() -> JsResult<()> {
     assert_eq!(code.ic[0].entry_count(), 1);
     assert!(code.ic[0].contains_shape(&o_shape));
     assert!(!code.ic[0].is_megamorphic());
+    assert_eq!(code.ic[0].first_shape_addr(), o_shape.to_addr_usize());
 
     Ok(())
 }
@@ -356,6 +358,7 @@ fn get_property_by_name_set_inline_cache_on_property_load() -> JsResult<()> {
     assert_eq!(code.ic.len(), 1);
     assert_eq!(code.ic[0].entry_count(), 0);
     assert!(!code.ic[0].is_megamorphic());
+    assert_eq!(code.ic[0].first_shape_addr(), 0);
 
     let o = ObjectInitializer::new(context)
         .property(js_string!("test"), 0, Attribute::all())
@@ -367,6 +370,7 @@ fn get_property_by_name_set_inline_cache_on_property_load() -> JsResult<()> {
     assert_eq!(code.ic[0].entry_count(), 1);
     assert!(code.ic[0].contains_shape(&o_shape));
     assert!(!code.ic[0].is_megamorphic());
+    assert_eq!(code.ic[0].first_shape_addr(), o_shape.to_addr_usize());
 
     Ok(())
 }
@@ -446,11 +450,13 @@ fn property_by_name_pic_transitions_to_megamorphic() -> JsResult<()> {
 
     assert_eq!(code.ic[0].entry_count(), 4);
     assert!(!code.ic[0].is_megamorphic());
+    assert_ne!(code.ic[0].first_shape_addr(), 0);
 
     function.call(&JsValue::undefined(), &[o5.into()], context)?;
 
     assert!(code.ic[0].is_megamorphic());
     assert_eq!(code.ic[0].entry_count(), 0);
+    assert_eq!(code.ic[0].first_shape_addr(), 0);
 
     Ok(())
 }

--- a/core/engine/src/vm/opcode/get/name.rs
+++ b/core/engine/src/vm/opcode/get/name.rs
@@ -60,7 +60,7 @@ impl GetNameGlobal {
             let ic = &context.vm.frame().code_block().ic[usize::from(ic_index)];
 
             let object_borrowed = object.borrow();
-            if let Some((shape, slot)) = ic.match_or_reset(object_borrowed.shape()) {
+            if let Some((shape, slot)) = ic.match_shape(object_borrowed.shape()) {
                 let mut result = if slot.attributes.contains(SlotAttributes::PROTOTYPE) {
                     let prototype = shape.prototype().expect("prototype should have value");
                     let prototype = prototype.borrow();

--- a/core/engine/src/vm/opcode/get/property.rs
+++ b/core/engine/src/vm/opcode/get/property.rs
@@ -39,7 +39,7 @@ fn get_by_name<const LENGTH: bool>(
 
     let ic = &context.vm.frame().code_block().ic[usize::from(index)];
     let object_borrowed = object.borrow();
-    if let Some((shape, slot)) = ic.match_or_reset(object_borrowed.shape()) {
+    if let Some((shape, slot)) = ic.match_shape(object_borrowed.shape()) {
         let mut result = if slot.attributes.contains(SlotAttributes::PROTOTYPE) {
             let prototype = shape.prototype().expect("prototype should have value");
             let prototype = prototype.borrow();

--- a/core/engine/src/vm/opcode/set/property.rs
+++ b/core/engine/src/vm/opcode/set/property.rs
@@ -24,7 +24,7 @@ fn set_by_name(
     let ic = &context.vm.frame().code_block().ic[usize::from(index)];
 
     let object_borrowed = object.borrow();
-    if let Some((shape, slot)) = ic.match_or_reset(object_borrowed.shape()) {
+    if let Some((shape, slot)) = ic.match_shape(object_borrowed.shape()) {
         let slot_index = slot.index as usize;
 
         if slot.attributes.is_accessor_descriptor() {


### PR DESCRIPTION
This Pull Request fixes/closes #4656.

It changes the following:

- Replaces the monomorphic property inline cache with a 4-entry polymorphic inline cache (PIC) in `core/engine/src/vm/inline_cache/mod.rs`.
- Adds megamorphic fallback when more than 4 distinct shapes are observed at the same access site.
- Updates property/name opcode fast paths to use PIC matching (`GetPropertyByName`, `SetPropertyByName`, `GetNameGlobal`).
- Adds VM inline-cache tests for polymorphic caching and megamorphic transition behavior.