### PR TITLE
Fix OOM in String.replace/replaceAll and add TryIntoJs regression test

### DIFF
--- a/core/engine/tests/macros.rs
+++ b/core/engine/tests/macros.rs
@@ -2,7 +2,7 @@
 
 #![allow(unused_crate_dependencies)]
 
-use boa_engine::value::TryFromJs;
+use boa_engine::value::{TryFromJs, TryIntoJs};
 use boa_engine::{Context, JsResult, JsValue, Source, js_string};
 use boa_string::JsString;
 
@@ -36,4 +36,59 @@ fn try_from_js_derive() {
             c: 60
         }
     );
+}
+
+/// Regression test for #4360: TryIntoJs-derived structs must have Object.prototype in their
+/// prototype chain, ensuring toString() returns "[object Object]" rather than throwing.
+#[test]
+fn try_into_js_has_object_prototype() {
+    #[derive(TryIntoJs)]
+    struct MyStruct {
+        name: String,
+        value: i32,
+    }
+
+    let mut context = Context::default();
+
+    let s = MyStruct {
+        name: "test".to_string(),
+        value: 42,
+    };
+
+    let js_val = s.try_into_js(&mut context).unwrap();
+    let obj = js_val.as_object().expect("should be an object");
+
+    // toString should return "[object Object]" (proves Object.prototype is in the chain)
+    let to_string_result = obj
+        .get(js_string!("toString"), &mut context)
+        .unwrap();
+    assert!(!to_string_result.is_undefined(), "toString should be inherited from Object.prototype");
+
+    let result = context
+        .eval(Source::from_bytes(b"(function(o) { return o.toString(); })"))
+        .unwrap();
+    let func = result.as_callable().unwrap();
+    let string_result = func
+        .call(&JsValue::undefined(), &[js_val.clone()], &mut context)
+        .unwrap();
+    assert_eq!(string_result, JsValue::from(js_string!("[object Object]")));
+
+    // Properties should be accessible
+    let name_val = obj.get(js_string!("name"), &mut context).unwrap();
+    assert_eq!(name_val, JsValue::from(js_string!("test")));
+
+    let value_val = obj.get(js_string!("value"), &mut context).unwrap();
+    assert_eq!(value_val, JsValue::from(42));
+
+    // hasOwnProperty should work (proves Object.prototype is in the chain)
+    let has_own = context
+        .eval(Source::from_bytes(
+            b"(function(o) { return o.hasOwnProperty('name'); })",
+        ))
+        .unwrap();
+    let func = has_own.as_callable().unwrap();
+    let result = func
+        .call(&JsValue::undefined(), &[js_val], &mut context)
+        .unwrap();
+    assert_eq!(result, JsValue::from(true));
 }


### PR DESCRIPTION
## Summary
- Throw `RangeError` when `replace`/`replaceAll`/`RegExp[@@replace]` would produce a string exceeding `MAX_STRING_LENGTH` (`u32::MAX`), preventing OOM crashes
- Add upfront length checks (before the replacement loop) and per-iteration guards (before buffer extensions) in all three code paths
- Add regression test verifying `TryIntoJs`-derived structs have `Object.prototype` in their prototype chain (`toString`, `hasOwnProperty`)

Fixes #4655
Closes #4360

## Test plan
- [x] `replace_all_max_length` — `replaceAll` throws `RangeError` when result exceeds max length
- [x] `replace_regexp_max_length` — regex global replace throws `RangeError`
- [x] `replace_normal_works` — normal replace/replaceAll still work correctly
- [x] `try_into_js_has_object_prototype` — `TryIntoJs` structs have proper prototype chain
- [x] All existing string and regexp tests pass