### PR TITLE
Replace `String` Error with Proper `KeywordToBinaryOpError` Type

### DIFF
--- a/core/ast/src/keyword/mod.rs
+++ b/core/ast/src/keyword/mod.rs
@@ -550,16 +550,25 @@ impl Keyword {
     }
 }
 
-// TODO: Should use a proper Error
 impl TryFrom<Keyword> for BinaryOp {
-    type Error = String;
+    type Error = KeywordToBinaryOpError;
 
     fn try_from(value: Keyword) -> Result<Self, Self::Error> {
-        value
-            .as_binary_op()
-            .ok_or_else(|| format!("No binary operation for {value}"))
+        value.as_binary_op().ok_or(KeywordToBinaryOpError)
     }
 }
+
+/// Error returned when a [`Keyword`] cannot be converted into a [`BinaryOp`].
+#[derive(Debug, Clone, Copy)]
+pub struct KeywordToBinaryOpError;
+
+impl fmt::Display for KeywordToBinaryOpError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "keyword is not a binary operator")
+    }
+}
+
+impl error::Error for KeywordToBinaryOpError {}
 
 /// The error type which is returned from parsing a [`str`] into a [`Keyword`].
 #[derive(Debug, Clone, Copy)]


### PR DESCRIPTION
##  What Was Changed

In `mod.rs`, the `TryFrom<Keyword> for BinaryOp` implementation previously used `String` as its error type.

This has been replaced with a dedicated `KeywordToBinaryOpError` struct.

---

##  Why

- Resolves the existing `// TODO: Should use a proper Error` comment.
- Using `String` as an error type is not idiomatic Rust — it does not implement `std::error::Error` and prevents programmatic error handling.
- The new type follows the same pattern as `KeywordError` already defined in the same file.
- Avoids a `format!()` heap allocation on error the new unit struct is zero-cost.

---


##  Impact

All existing callers (`tests.rs`) only use `.is_ok()` / `.is_err()`.

No breaking changes introduced.

---

## Closes #4674 