### PR TITLE
test(intl): ignore Locale tests blocked by ICU4X limitations

### DIFF
--- a/test262_config.toml
+++ b/test262_config.toml
@@ -81,4 +81,14 @@ tests = [
     "test/intl402/Intl/getCanonicalLocales/unicode-ext-canonicalize-calendar.js",
     "test/intl402/Intl/getCanonicalLocales/unicode-ext-canonicalize-timezone.js",
     "test/intl402/Intl/getCanonicalLocales/transformed-ext-canonical.js",
+    # h24 hour cycle not supported by ICU4X.
+    # TODO: Remove when https://github.com/unicode-org/icu4x/issues/6597 is fixed.
+    "test/intl402/Locale/getters.js",
+    "test/intl402/Locale/constructor-getter-order.js",
+    "test/intl402/Locale/constructor-options-hourcycle-valid.js",
+    # Extension canonicalization not yet supported by ICU4X.
+    # TODO: Remove when https://github.com/unicode-org/icu4x/issues/3483 is fixed.
+    "test/intl402/Locale/prototype/calendar/canonicalize.js",
+    "test/intl402/Locale/constructor-non-iana-canon.js",
+    "test/intl402/Locale/constructor-options-canonicalized.js",
 ]


### PR DESCRIPTION
## Summary
Ignores 6 failing `Intl.Locale` tests that are blocked by upstream ICU4X limitations.

## Changes
- Ignores 3 tests related to `h24` hour cycle support, which ICU4X does not currently implement
- Ignores 3 tests related to Unicode extension value canonicalization (e.g. `islamicc` → `islamic-civil`)

## Related Issues
- https://github.com/unicode-org/icu4x/issues/6597 — h24 hour cycle not supported
- https://github.com/unicode-org/icu4x/issues/3483 — Unicode extension value canonicalization

These tests will be re-enabled once the upstream ICU4X issues are resolved.