### PR TITLE
docs: fix typos in debugging guide

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -85,13 +85,13 @@ for example `--flowgraph-direction=left-to-right`, the default is `top-to-bottom
 
 Certain debugging actions in JavaScript land are difficult to impossible, like triggering a GC collect.
 
-For such puroposes we have the `$boa` object that contains useful utilities that can be used to debug JavaScript in JavaScript.
+For such purposes we have the `$boa` object that contains useful utilities that can be used to debug JavaScript in JavaScript.
 The debug object becomes available with the `--debug-object` cli flag, It injects the `$boa` debug object in the context as global variable,
 the object is separated into modules `gc`, `function`, `object`, etc.
 
 We can now do `$boa.gc.collect()`, which force triggers a GC collect.
 
-If you want to trace only a particular function (without being flodded by the `--trace` flag, that traces everything),
+If you want to trace only a particular function (without being flooded by the `--trace` flag, that traces everything),
 for that we have the `$boa.function.trace(func, this, ...args)`.
 
 The full documentation of the `$boa` object's modules and functionalities can be found [`here`](./boa_object.md).


### PR DESCRIPTION
This Pull Request fixes/closes #4681.

It changes the following:
- Fixes puroposes -> purposes in docs/debugging.md.
- Fixes flodded -> flooded in docs/debugging.md.