### PR TITLE
regexp: mitigate ReDoS on ASCII inputs with PikeVM path

### DIFF
--- a/core/engine/src/builtins/regexp/mod.rs
+++ b/core/engine/src/builtins/regexp/mod.rs
@@ -43,9 +43,9 @@ pub struct RegExp {
     /// Regex matcher.
     matcher: Regex,
 
-    /// Non-optimized matcher used by the PikeVM executor on ASCII inputs.
+    /// Non-optimized matcher used by the `PikeVM` executor on ASCII inputs.
     ///
-    /// The PikeVM backend in `regress` does not support optimized bytecode.
+    /// The `PikeVM` backend in `regress` does not support optimized bytecode.
     pikevm_matcher: Regex,
 
     flags: RegExpFlags,
@@ -1169,7 +1169,7 @@ impl RegExp {
             // Use PikeVM for ASCII inputs to avoid pathological backtracking behavior.
             (true | false, JsStrVariant::Latin1(latin1)) if latin1.is_ascii() => {
                 if let Ok(input) = std::str::from_utf8(latin1) {
-                    regress::backends::find::<regress::backends::PikeVMExecutor>(
+                    regress::backends::find::<regress::backends::PikeVMExecutor<'_, '_>>(
                         &rx.pikevm_matcher,
                         input,
                         last_index as usize,
@@ -1190,9 +1190,12 @@ impl RegExp {
             (true | false, JsStrVariant::Utf16(input))
                 if input.iter().all(|code_unit| *code_unit <= 0x7F) =>
             {
-                let input = input.iter().map(|code_unit| *code_unit as u8).collect::<Vec<_>>();
+                let input = input
+                    .iter()
+                    .map(|code_unit| *code_unit as u8)
+                    .collect::<Vec<_>>();
                 if let Ok(input) = std::str::from_utf8(&input) {
-                    regress::backends::find::<regress::backends::PikeVMExecutor>(
+                    regress::backends::find::<regress::backends::PikeVMExecutor<'_, '_>>(
                         &rx.pikevm_matcher,
                         input,
                         last_index as usize,

--- a/core/engine/src/builtins/regexp/tests.rs
+++ b/core/engine/src/builtins/regexp/tests.rs
@@ -1,6 +1,6 @@
 use crate::{
-    JsNativeErrorKind, JsValue, TestAction, js_string, native_function::NativeFunctionObject,
-    run_test_actions,
+    JsNativeErrorKind, JsString, JsValue, TestAction, js_string,
+    native_function::NativeFunctionObject, property::Attribute, run_test_actions,
 };
 use boa_macros::js_str;
 use indoc::indoc;
@@ -132,6 +132,25 @@ fn redos_regression_ascii_nested_quantifier() {
     run_test_actions([
         TestAction::run(r"var re = new RegExp('(a+)+$');"),
         TestAction::assert("re.test('a'.repeat(25) + '!') === false"),
+    ]);
+}
+
+#[test]
+fn redos_regression_ascii_nested_quantifier_utf16_input() {
+    run_test_actions([
+        TestAction::inspect_context(|context| {
+            let mut utf16_input = vec![u16::from(b'a'); 25];
+            utf16_input.push(u16::from(b'!'));
+            context
+                .register_global_property(
+                    js_string!("ascii_utf16_input"),
+                    JsString::from(utf16_input.as_slice()),
+                    Attribute::all(),
+                )
+                .unwrap();
+        }),
+        TestAction::run(r"var re = new RegExp('(a+)+$');"),
+        TestAction::assert("re.test(ascii_utf16_input) === false"),
     ]);
 }
 

--- a/core/engine/src/builtins/regexp/tests.rs
+++ b/core/engine/src/builtins/regexp/tests.rs
@@ -128,6 +128,14 @@ fn last_index() {
 }
 
 #[test]
+fn redos_regression_ascii_nested_quantifier() {
+    run_test_actions([
+        TestAction::run(r"var re = new RegExp('(a+)+$');"),
+        TestAction::assert("re.test('a'.repeat(25) + '!') === false"),
+    ]);
+}
+
+#[test]
 fn exec() {
     run_test_actions([
         TestAction::run_harness(),


### PR DESCRIPTION
This Pull Request mitigates #4643.

It changes the following:
- Adds a dedicated non-optimized `regress::Regex` matcher for PikeVM execution in `RegExp` objects.
- Uses PikeVM matching for ASCII inputs in `RegExpBuiltinExec`, avoiding pathological backtracking in common ReDoS cases such as `(a+)+$`.
- Keeps existing UTF-16/UCS-2 backtracking paths for non-ASCII inputs to preserve current encoding semantics.
- Adds a regression test covering the nested-quantifier ASCII case.

Notes:
- This is a mitigation path inside Boa while the broader backtracking-budget API is still blocked in `regress`.