### PR TITLE
fix(gc): correct integer division truncation in threshold growth

### DIFF
--- a/core/gc/src/lib.rs
+++ b/core/gc/src/lib.rs
@@ -64,7 +64,7 @@ struct GcConfig {
 impl Default for GcConfig {
     fn default() -> Self {
         Self {
-            // Start at 1MB, the nursary size for V8 is ~1-8MB and SM can be up to 16MB
+            // Start at 1MB, the nursery size for V8 is ~1-8MB and SM can be up to 16MB
             threshold: 1_048_576,
             used_space_percentage: 70,
         }
@@ -192,10 +192,10 @@ impl Allocator {
             // Post collection check
             // If the allocated bytes are still above the threshold, increase the threshold.
             if gc.runtime.bytes_allocated
-                > gc.config.threshold / 100 * gc.config.used_space_percentage
+                > gc.config.threshold * gc.config.used_space_percentage / 100
             {
                 gc.config.threshold =
-                    gc.runtime.bytes_allocated / gc.config.used_space_percentage * 100;
+                    gc.runtime.bytes_allocated * 100 / gc.config.used_space_percentage;
             }
         }
     }


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request fixes/closes #4701.

It changes the following:

- Reorders GC threshold calculations in `manage_state()` to multiply before dividing.
- Avoids precision loss caused by integer division truncation.
- Ensures the GC threshold grows according to the intended percentage calculation.

Previously the code computed:

```rust
gc.config.threshold / 100 * gc.config.used_space_percentage
gc.runtime.bytes_allocated / gc.config.used_space_percentage * 100
```

Since Rust performs integer division first, this truncates values before multiplication.

The calculations are now reordered:
```rust
gc.config.threshold * gc.config.used_space_percentage / 100
gc.runtime.bytes_allocated * 100 / gc.config.used_space_percentage
```

This preserves integer precision and ensures the threshold growth logic behaves as intended.