### PR TITLE
[bug]: Fix TimeoutJob key collision and run_jobs infinite loop

### DIFF
--- a/core/runtime/src/interval/tests.rs
+++ b/core/runtime/src/interval/tests.rs
@@ -31,16 +31,13 @@ fn two_zero_delay_timeouts_both_fire() {
 
                 let order = ctx.global_object().get(js_str!("order"), ctx).unwrap();
                 let order = order.as_object().unwrap();
-                let len = order
-                    .get(js_str!("length"), ctx)
-                    .unwrap()
-                    .as_number()
-                    .unwrap() as usize;
-                assert_eq!(len, 2, "both callbacks must fire");
-                let first = order.get(0usize, ctx).unwrap().as_number().unwrap() as u32;
-                let second = order.get(1usize, ctx).unwrap().as_number().unwrap() as u32;
-                assert_eq!(first, 1);
-                assert_eq!(second, 2);
+                assert_eq!(
+                    order.get(js_str!("length"), ctx).unwrap().as_i32(),
+                    Some(2),
+                    "both callbacks must fire"
+                );
+                assert_eq!(order.get(0usize, ctx).unwrap().as_i32(), Some(1));
+                assert_eq!(order.get(1usize, ctx).unwrap().as_i32(), Some(2));
             }),
         ],
         context,


### PR DESCRIPTION
## Summary

This PR fixes two issues in `SimpleJobExecutor` and the CLI `Executor` related to timeout scheduling.

Timeouts were previously stored as:

```rust
timeout_jobs: RefCell<BTreeMap<JsInstant, TimeoutJob>>,
```

This allowed only one job per timestamp. Multiple `setTimeout(..., 0)` calls at the same instant caused silent overwrites via:

```rust
self.timeout_jobs.borrow_mut().insert(now + t.timeout(), t);
```

Additionally, a mismatch between the loop guard (`>= now`) and `split_off(&now)` caused `run_jobs()` to hang when a job was due exactly at `now`.

---

## Impact

* Silent loss of timeout callbacks
* `run_jobs()` infinite loop with `FixedClock`
* CLI REPL could hang
* Affects default `Context` executor

---

## Fix

1. Support multiple jobs per timestamp:

```rust
timeout_jobs: RefCell<BTreeMap<JsInstant, Vec<TimeoutJob>>>,
```

```rust
.entry(now + t.timeout())
.or_default()
.push(t);
```

2. Align due-check with `split_off` semantics (`>` instead of `>=`).

3. Added regression test ensuring two zero-delay timeouts both fire.

---

## Conclusion

This change makes timeout scheduling correct and deterministic, preventing silent job loss and infinite execution loops while preserving existing behavior and passing all current tests.

