### PR TITLE
2 low hanging fruits improvements for performance

### DIFF
--- a/core/engine/src/value/operations.rs
+++ b/core/engine/src/value/operations.rs
@@ -665,6 +665,229 @@ impl JsValue {
             AbstractRelation::True | AbstractRelation::Undefined => Ok(false),
         }
     }
+
+    // ==== Numeric Fast Paths ====
+    //
+    // These methods provide optimized paths for binary operations at the opcode
+    // handler level. They use `self.0.as_integer32()` and `self.as_number_cheap()`
+    // (pure bit operations) instead of `variant()`, which avoids cloning pointer
+    // types (Object, String, Symbol, BigInt) for non-numeric values.
+    //
+    // Returns `Some(result)` if both operands are numeric, `None` otherwise
+    // (caller should fall back to the full method with type coercion).
+
+    /// Converts the value to a number if possible, using fast bit operations. This is
+    /// used for the fast operations to allow mixed i32/f64 values.
+    #[inline(always)]
+    fn as_number_cheap(&self) -> Option<f64> {
+        if let Some(i) = self.0.as_integer32() {
+            Some(f64::from(i))
+        } else {
+            self.0.as_float64()
+        }
+    }
+
+    /// Fast path for the binary `+` operator (numeric only).
+    #[inline(always)]
+    #[allow(clippy::float_cmp)]
+    pub(crate) fn add_fast(&self, other: &Self) -> Option<Self> {
+        if let (Some(x), Some(y)) = (self.0.as_integer32(), other.0.as_integer32()) {
+            return Some(
+                x.checked_add(y)
+                    .map_or_else(|| Self::new(f64::from(x) + f64::from(y)), Self::new),
+            );
+        }
+        let x = self.as_number_cheap()?;
+        let y = other.as_number_cheap()?;
+        Some(Self::new(x + y))
+    }
+
+    /// Fast path for the binary `-` operator.
+    #[inline(always)]
+    pub(crate) fn sub_fast(&self, other: &Self) -> Option<Self> {
+        if let (Some(x), Some(y)) = (self.0.as_integer32(), other.0.as_integer32()) {
+            return Some(
+                x.checked_sub(y)
+                    .map_or_else(|| Self::new(f64::from(x) - f64::from(y)), Self::new),
+            );
+        }
+        let x = self.as_number_cheap()?;
+        let y = other.as_number_cheap()?;
+        Some(Self::new(x - y))
+    }
+
+    /// Fast path for the binary `*` operator.
+    #[inline(always)]
+    pub(crate) fn mul_fast(&self, other: &Self) -> Option<Self> {
+        if let (Some(x), Some(y)) = (self.0.as_integer32(), other.0.as_integer32()) {
+            return Some(
+                x.checked_mul(y)
+                    .filter(|v| *v != 0 || i32::min(x, y) >= 0)
+                    .map_or_else(|| Self::new(f64::from(x) * f64::from(y)), Self::new),
+            );
+        }
+        let x = self.as_number_cheap()?;
+        let y = other.as_number_cheap()?;
+        Some(Self::new(x * y))
+    }
+
+    /// Fast path for the binary `/` operator.
+    #[inline(always)]
+    #[allow(clippy::float_cmp)]
+    pub(crate) fn div_fast(&self, other: &Self) -> Option<Self> {
+        if let (Some(x), Some(y)) = (self.0.as_integer32(), other.0.as_integer32()) {
+            return Some(
+                x.checked_div(y)
+                    .filter(|div| y * div == x)
+                    .map_or_else(|| Self::new(f64::from(x) / f64::from(y)), Self::new),
+            );
+        }
+        let x = self.as_number_cheap()?;
+        let y = other.as_number_cheap()?;
+        Some(Self::new(x / y))
+    }
+
+    /// Fast path for the binary `%` operator.
+    #[inline(always)]
+    pub(crate) fn rem_fast(&self, other: &Self) -> Option<Self> {
+        if let (Some(x), Some(y)) = (self.0.as_integer32(), other.0.as_integer32()) {
+            if y == 0 {
+                return Some(Self::nan());
+            }
+            return Some(match x % y {
+                rem if rem == 0 && x < 0 => Self::new(-0.0),
+                rem => Self::new(rem),
+            });
+        }
+        let x = self.as_number_cheap()?;
+        let y = other.as_number_cheap()?;
+        Some(Self::new((x % y).copysign(x)))
+    }
+
+    /// Fast path for the binary `**` operator.
+    #[inline(always)]
+    #[allow(clippy::float_cmp)]
+    pub(crate) fn pow_fast(&self, other: &Self) -> Option<Self> {
+        if let (Some(x), Some(y)) = (self.0.as_integer32(), other.0.as_integer32()) {
+            return Some(
+                u32::try_from(y)
+                    .ok()
+                    .and_then(|y| x.checked_pow(y))
+                    .map_or_else(|| Self::new(f64::from(x).powi(y)), Self::new),
+            );
+        }
+        let x = self.as_number_cheap()?;
+        let y = other.as_number_cheap()?;
+        if x.abs() == 1.0 && y.is_infinite() {
+            Some(Self::nan())
+        } else {
+            Some(Self::new(x.powf(y)))
+        }
+    }
+
+    /// Fast path for the binary `&` operator (i32 only).
+    #[inline(always)]
+    pub(crate) fn bitand_fast(&self, other: &Self) -> Option<Self> {
+        let x = self.0.as_integer32()?;
+        let y = other.0.as_integer32()?;
+        Some(Self::new(x & y))
+    }
+
+    /// Fast path for the binary `|` operator (i32 only).
+    #[inline(always)]
+    pub(crate) fn bitor_fast(&self, other: &Self) -> Option<Self> {
+        let x = self.0.as_integer32()?;
+        let y = other.0.as_integer32()?;
+        Some(Self::new(x | y))
+    }
+
+    /// Fast path for the binary `^` operator (i32 only).
+    #[inline(always)]
+    pub(crate) fn bitxor_fast(&self, other: &Self) -> Option<Self> {
+        let x = self.0.as_integer32()?;
+        let y = other.0.as_integer32()?;
+        Some(Self::new(x ^ y))
+    }
+
+    /// Fast path for the binary `<<` operator (i32 only).
+    #[inline(always)]
+    pub(crate) fn shl_fast(&self, other: &Self) -> Option<Self> {
+        let x = self.0.as_integer32()?;
+        let y = other.0.as_integer32()?;
+        Some(Self::new(x.wrapping_shl(y as u32)))
+    }
+
+    /// Fast path for the binary `>>` operator (i32 only).
+    #[inline(always)]
+    pub(crate) fn shr_fast(&self, other: &Self) -> Option<Self> {
+        let x = self.0.as_integer32()?;
+        let y = other.0.as_integer32()?;
+        Some(Self::new(x.wrapping_shr(y as u32)))
+    }
+
+    /// Fast path for the binary `>>>` operator (i32 only).
+    #[inline(always)]
+    pub(crate) fn ushr_fast(&self, other: &Self) -> Option<Self> {
+        let x = self.0.as_integer32()?;
+        let y = other.0.as_integer32()?;
+        Some(Self::new((x as u32).wrapping_shr(y as u32)))
+    }
+
+    /// Fast path for the `<` operator.
+    #[inline(always)]
+    pub(crate) fn lt_fast(&self, other: &Self) -> Option<Self> {
+        if let (Some(x), Some(y)) = (self.0.as_integer32(), other.0.as_integer32()) {
+            return Some(Self::new(x < y));
+        }
+        let x = self.as_number_cheap()?;
+        let y = other.as_number_cheap()?;
+        Some(Self::new(x < y))
+    }
+
+    /// Fast path for the `<=` operator.
+    #[inline(always)]
+    pub(crate) fn le_fast(&self, other: &Self) -> Option<Self> {
+        if let (Some(x), Some(y)) = (self.0.as_integer32(), other.0.as_integer32()) {
+            return Some(Self::new(x <= y));
+        }
+        let x = self.as_number_cheap()?;
+        let y = other.as_number_cheap()?;
+        Some(Self::new(x <= y))
+    }
+
+    /// Fast path for the `>` operator.
+    #[inline(always)]
+    pub(crate) fn gt_fast(&self, other: &Self) -> Option<Self> {
+        if let (Some(x), Some(y)) = (self.0.as_integer32(), other.0.as_integer32()) {
+            return Some(Self::new(x > y));
+        }
+        let x = self.as_number_cheap()?;
+        let y = other.as_number_cheap()?;
+        Some(Self::new(x > y))
+    }
+
+    /// Fast path for the `>=` operator.
+    #[inline(always)]
+    pub(crate) fn ge_fast(&self, other: &Self) -> Option<Self> {
+        if let (Some(x), Some(y)) = (self.0.as_integer32(), other.0.as_integer32()) {
+            return Some(Self::new(x >= y));
+        }
+        let x = self.as_number_cheap()?;
+        let y = other.as_number_cheap()?;
+        Some(Self::new(x >= y))
+    }
+
+    /// Fast path for the `==` operator (numeric only).
+    #[inline(always)]
+    #[allow(clippy::float_cmp)]
+    pub(crate) fn equals_fast(&self, other: &Self) -> Option<Self> {
+        if let (Some(x), Some(y)) = (self.0.as_integer32(), other.0.as_integer32()) {
+            return Some(Self::new(x == y));
+        }
+        let x = self.as_number_cheap()?;
+        let y = other.as_number_cheap()?;
+        Some(Self::new(x == y))
+    }
 }
 
 /// The result of the [Abstract Relational Comparison][arc].

--- a/core/engine/src/value/operations.rs
+++ b/core/engine/src/value/operations.rs
@@ -678,7 +678,7 @@ impl JsValue {
 
     /// Converts the value to a number if possible, using fast bit operations. This is
     /// used for the fast operations to allow mixed i32/f64 values.
-    #[inline(always)]
+    #[inline]
     fn as_number_cheap(&self) -> Option<f64> {
         if let Some(i) = self.0.as_integer32() {
             Some(f64::from(i))
@@ -688,7 +688,7 @@ impl JsValue {
     }
 
     /// Fast path for the binary `+` operator (numeric only).
-    #[inline(always)]
+    #[inline]
     #[allow(clippy::float_cmp)]
     pub(crate) fn add_fast(&self, other: &Self) -> Option<Self> {
         if let (Some(x), Some(y)) = (self.0.as_integer32(), other.0.as_integer32()) {
@@ -703,7 +703,7 @@ impl JsValue {
     }
 
     /// Fast path for the binary `-` operator.
-    #[inline(always)]
+    #[inline]
     pub(crate) fn sub_fast(&self, other: &Self) -> Option<Self> {
         if let (Some(x), Some(y)) = (self.0.as_integer32(), other.0.as_integer32()) {
             return Some(
@@ -717,7 +717,7 @@ impl JsValue {
     }
 
     /// Fast path for the binary `*` operator.
-    #[inline(always)]
+    #[inline]
     pub(crate) fn mul_fast(&self, other: &Self) -> Option<Self> {
         if let (Some(x), Some(y)) = (self.0.as_integer32(), other.0.as_integer32()) {
             return Some(
@@ -732,7 +732,7 @@ impl JsValue {
     }
 
     /// Fast path for the binary `/` operator.
-    #[inline(always)]
+    #[inline]
     #[allow(clippy::float_cmp)]
     pub(crate) fn div_fast(&self, other: &Self) -> Option<Self> {
         if let (Some(x), Some(y)) = (self.0.as_integer32(), other.0.as_integer32()) {
@@ -748,7 +748,7 @@ impl JsValue {
     }
 
     /// Fast path for the binary `%` operator.
-    #[inline(always)]
+    #[inline]
     pub(crate) fn rem_fast(&self, other: &Self) -> Option<Self> {
         if let (Some(x), Some(y)) = (self.0.as_integer32(), other.0.as_integer32()) {
             if y == 0 {
@@ -765,7 +765,7 @@ impl JsValue {
     }
 
     /// Fast path for the binary `**` operator.
-    #[inline(always)]
+    #[inline]
     #[allow(clippy::float_cmp)]
     pub(crate) fn pow_fast(&self, other: &Self) -> Option<Self> {
         if let (Some(x), Some(y)) = (self.0.as_integer32(), other.0.as_integer32()) {
@@ -786,7 +786,7 @@ impl JsValue {
     }
 
     /// Fast path for the binary `&` operator (i32 only).
-    #[inline(always)]
+    #[inline]
     pub(crate) fn bitand_fast(&self, other: &Self) -> Option<Self> {
         let x = self.0.as_integer32()?;
         let y = other.0.as_integer32()?;
@@ -794,7 +794,7 @@ impl JsValue {
     }
 
     /// Fast path for the binary `|` operator (i32 only).
-    #[inline(always)]
+    #[inline]
     pub(crate) fn bitor_fast(&self, other: &Self) -> Option<Self> {
         let x = self.0.as_integer32()?;
         let y = other.0.as_integer32()?;
@@ -802,7 +802,7 @@ impl JsValue {
     }
 
     /// Fast path for the binary `^` operator (i32 only).
-    #[inline(always)]
+    #[inline]
     pub(crate) fn bitxor_fast(&self, other: &Self) -> Option<Self> {
         let x = self.0.as_integer32()?;
         let y = other.0.as_integer32()?;
@@ -810,7 +810,7 @@ impl JsValue {
     }
 
     /// Fast path for the binary `<<` operator (i32 only).
-    #[inline(always)]
+    #[inline]
     pub(crate) fn shl_fast(&self, other: &Self) -> Option<Self> {
         let x = self.0.as_integer32()?;
         let y = other.0.as_integer32()?;
@@ -818,7 +818,7 @@ impl JsValue {
     }
 
     /// Fast path for the binary `>>` operator (i32 only).
-    #[inline(always)]
+    #[inline]
     pub(crate) fn shr_fast(&self, other: &Self) -> Option<Self> {
         let x = self.0.as_integer32()?;
         let y = other.0.as_integer32()?;
@@ -826,7 +826,7 @@ impl JsValue {
     }
 
     /// Fast path for the binary `>>>` operator (i32 only).
-    #[inline(always)]
+    #[inline]
     pub(crate) fn ushr_fast(&self, other: &Self) -> Option<Self> {
         let x = self.0.as_integer32()?;
         let y = other.0.as_integer32()?;
@@ -834,7 +834,7 @@ impl JsValue {
     }
 
     /// Fast path for the `<` operator.
-    #[inline(always)]
+    #[inline]
     pub(crate) fn lt_fast(&self, other: &Self) -> Option<Self> {
         if let (Some(x), Some(y)) = (self.0.as_integer32(), other.0.as_integer32()) {
             return Some(Self::new(x < y));
@@ -845,7 +845,7 @@ impl JsValue {
     }
 
     /// Fast path for the `<=` operator.
-    #[inline(always)]
+    #[inline]
     pub(crate) fn le_fast(&self, other: &Self) -> Option<Self> {
         if let (Some(x), Some(y)) = (self.0.as_integer32(), other.0.as_integer32()) {
             return Some(Self::new(x <= y));
@@ -856,7 +856,7 @@ impl JsValue {
     }
 
     /// Fast path for the `>` operator.
-    #[inline(always)]
+    #[inline]
     pub(crate) fn gt_fast(&self, other: &Self) -> Option<Self> {
         if let (Some(x), Some(y)) = (self.0.as_integer32(), other.0.as_integer32()) {
             return Some(Self::new(x > y));
@@ -867,7 +867,7 @@ impl JsValue {
     }
 
     /// Fast path for the `>=` operator.
-    #[inline(always)]
+    #[inline]
     pub(crate) fn ge_fast(&self, other: &Self) -> Option<Self> {
         if let (Some(x), Some(y)) = (self.0.as_integer32(), other.0.as_integer32()) {
             return Some(Self::new(x >= y));
@@ -878,7 +878,7 @@ impl JsValue {
     }
 
     /// Fast path for the `==` operator (numeric only).
-    #[inline(always)]
+    #[inline]
     #[allow(clippy::float_cmp)]
     pub(crate) fn equals_fast(&self, other: &Self) -> Option<Self> {
         if let (Some(x), Some(y)) = (self.0.as_integer32(), other.0.as_integer32()) {

--- a/core/engine/src/vm/mod.rs
+++ b/core/engine/src/vm/mod.rs
@@ -429,7 +429,7 @@ impl Vm {
     }
 
     #[track_caller]
-    #[inline(always)]
+    #[inline]
     pub(crate) fn set_register(&mut self, index: usize, value: JsValue) {
         let actual = self.frame.rp as usize + index;
         debug_assert!(
@@ -446,7 +446,7 @@ impl Vm {
     }
 
     #[track_caller]
-    #[inline(always)]
+    #[inline]
     pub(crate) fn get_register(&self, index: usize) -> &JsValue {
         let actual = self.frame.rp as usize + index;
         debug_assert!(

--- a/core/engine/src/vm/mod.rs
+++ b/core/engine/src/vm/mod.rs
@@ -429,16 +429,35 @@ impl Vm {
     }
 
     #[track_caller]
+    #[inline(always)]
     pub(crate) fn set_register(&mut self, index: usize, value: JsValue) {
-        self.stack.stack[self.frame.rp as usize + index] = value;
+        let actual = self.frame.rp as usize + index;
+        debug_assert!(
+            actual < self.stack.stack.len(),
+            "register index out of bounds: index {actual}, len {}",
+            self.stack.stack.len()
+        );
+        // SAFETY: Register indices are determined by the bytecode compiler and are
+        // guaranteed to be within the stack bounds for well-formed bytecode. The
+        // debug_assert above catches any compiler bugs during development.
+        unsafe {
+            *self.stack.stack.get_unchecked_mut(actual) = value;
+        }
     }
 
     #[track_caller]
+    #[inline(always)]
     pub(crate) fn get_register(&self, index: usize) -> &JsValue {
-        self.stack
-            .stack
-            .get(self.frame.rp as usize + index)
-            .expect("registers must be initialized")
+        let actual = self.frame.rp as usize + index;
+        debug_assert!(
+            actual < self.stack.stack.len(),
+            "register index out of bounds: index {actual}, len {}",
+            self.stack.stack.len()
+        );
+        // SAFETY: Register indices are determined by the bytecode compiler and are
+        // guaranteed to be within the stack bounds for well-formed bytecode. The
+        // debug_assert above catches any compiler bugs during development.
+        unsafe { self.stack.stack.get_unchecked(actual) }
     }
 
     /// Retrieves the VM frame.

--- a/core/engine/src/vm/opcode/binary_ops/macro_defined.rs
+++ b/core/engine/src/vm/opcode/binary_ops/macro_defined.rs
@@ -13,7 +13,7 @@ macro_rules! implement_bin_ops {
         pub(crate) struct $name;
 
         impl $name {
-            #[inline(always)]
+            #[inline]
             pub(crate) fn operation(
                 (dst, lhs, rhs): (VaryingOperand, VaryingOperand, VaryingOperand),
                 context: &mut Context,

--- a/core/engine/src/vm/opcode/binary_ops/macro_defined.rs
+++ b/core/engine/src/vm/opcode/binary_ops/macro_defined.rs
@@ -1,10 +1,10 @@
 use crate::{
-    Context, JsResult,
+    Context, JsResult, JsValue,
     vm::opcode::{Operation, VaryingOperand},
 };
 
 macro_rules! implement_bin_ops {
-    ($name:ident, $op:ident, $doc_string:literal) => {
+    ($name:ident, $op:ident, $doc_string:literal $(, $fast_fn: ident)?) => {
         #[doc= concat!("`", stringify!($name), "` implements the `OpCode` Operation for `Opcode::", stringify!($name), "`\n")]
         #[doc= "\n"]
         #[doc="Operation:\n"]
@@ -18,8 +18,20 @@ macro_rules! implement_bin_ops {
                 (dst, lhs, rhs): (VaryingOperand, VaryingOperand, VaryingOperand),
                 context: &mut Context,
             ) -> JsResult<()> {
-                let lhs = context.vm.get_register(lhs.into()).clone();
-                let rhs = context.vm.get_register(rhs.into()).clone();
+                let lhs = context.vm.get_register(lhs.into());
+                let rhs = context.vm.get_register(rhs.into());
+
+                $(
+                // Fast path: try numeric operation without cloning.
+                if let Some(value) = JsValue::$fast_fn(lhs, rhs) {
+                    context.vm.set_register(dst.into(), value.into());
+                    return Ok(());
+                }
+                )?
+
+                // Slow path: clone and use full method with type coercion.
+                let lhs = lhs.clone();
+                let rhs = rhs.clone();
                 let value = lhs.$op(&rhs, context)?;
                 context.vm.set_register(dst.into(), value.into());
                 Ok(())
@@ -34,21 +46,26 @@ macro_rules! implement_bin_ops {
     };
 }
 
-implement_bin_ops!(Add, add, "Binary `+` operator.");
-implement_bin_ops!(Sub, sub, "Binary `-` operator.");
-implement_bin_ops!(Mul, mul, "Binary `*` operator.");
-implement_bin_ops!(Div, div, "Binary `/` operator.");
-implement_bin_ops!(Pow, pow, "Binary `**` operator.");
-implement_bin_ops!(Mod, rem, "Binary `%` operator.");
-implement_bin_ops!(BitAnd, bitand, "Binary `&` operator.");
-implement_bin_ops!(BitOr, bitor, "Binary `|` operator.");
-implement_bin_ops!(BitXor, bitxor, "Binary `^` operator.");
-implement_bin_ops!(ShiftLeft, shl, "Binary `<<` operator.");
-implement_bin_ops!(ShiftRight, shr, "Binary `>>` operator.");
-implement_bin_ops!(UnsignedShiftRight, ushr, "Binary `>>>` operator.");
-implement_bin_ops!(Eq, equals, "Binary `==` operator.");
-implement_bin_ops!(GreaterThan, gt, "Binary `>` operator.");
-implement_bin_ops!(GreaterThanOrEq, ge, "Binary `>=` operator.");
-implement_bin_ops!(LessThan, lt, "Binary `<` operator.");
-implement_bin_ops!(LessThanOrEq, le, "Binary `<=` operator.");
+implement_bin_ops!(Add, add, "Binary `+` operator.", add_fast);
+implement_bin_ops!(Sub, sub, "Binary `-` operator.", sub_fast);
+implement_bin_ops!(Mul, mul, "Binary `*` operator.", mul_fast);
+implement_bin_ops!(Div, div, "Binary `/` operator.", div_fast);
+implement_bin_ops!(Pow, pow, "Binary `**` operator.", pow_fast);
+implement_bin_ops!(Mod, rem, "Binary `%` operator.", rem_fast);
+implement_bin_ops!(BitAnd, bitand, "Binary `&` operator.", bitand_fast);
+implement_bin_ops!(BitOr, bitor, "Binary `|` operator.", bitor_fast);
+implement_bin_ops!(BitXor, bitxor, "Binary `^` operator.", bitxor_fast);
+implement_bin_ops!(ShiftLeft, shl, "Binary `<<` operator.", shl_fast);
+implement_bin_ops!(ShiftRight, shr, "Binary `>>` operator.", shr_fast);
+implement_bin_ops!(
+    UnsignedShiftRight,
+    ushr,
+    "Binary `>>>` operator.",
+    ushr_fast
+);
+implement_bin_ops!(Eq, equals, "Binary `==` operator.", equals_fast);
+implement_bin_ops!(GreaterThan, gt, "Binary `>` operator.", gt_fast);
+implement_bin_ops!(GreaterThanOrEq, ge, "Binary `>=` operator.", ge_fast);
+implement_bin_ops!(LessThan, lt, "Binary `<` operator.", lt_fast);
+implement_bin_ops!(LessThanOrEq, le, "Binary `<=` operator.", le_fast);
 implement_bin_ops!(InstanceOf, instance_of, "Binary `instanceof` operator.");


### PR DESCRIPTION
1. The `get_register` and `set_register` don't need to double check, since bytecode should always be correct on stack indices. We still double check in debug to prevent regressions.
2. binary operators now have an optimized path for integers and floats.

Results:

```
PROGRESS Richards
RESULT Richards 242
PROGRESS DeltaBlue
RESULT DeltaBlue 247
PROGRESS Encrypt
PROGRESS Decrypt
RESULT Crypto 248
PROGRESS RayTrace
RESULT RayTrace 481
PROGRESS Earley
PROGRESS Boyer
RESULT EarleyBoyer 588
PROGRESS RegExp
RESULT RegExp 82.0
PROGRESS Splay
RESULT Splay 831
PROGRESS NavierStokes
RESULT NavierStokes 547
SCORE 334
```

Results on main:
```
PROGRESS Richards
RESULT Richards 222
PROGRESS DeltaBlue
RESULT DeltaBlue 234
PROGRESS Encrypt
PROGRESS Decrypt
RESULT Crypto 203
PROGRESS RayTrace
RESULT RayTrace 471
PROGRESS Earley
PROGRESS Boyer
RESULT EarleyBoyer 571
PROGRESS RegExp
RESULT RegExp 81.9
PROGRESS Splay
RESULT Splay 798
PROGRESS NavierStokes
RESULT NavierStokes 463
SCORE 310
```

Will format these results into a table upon request.