### PR TITLE
feat(cli): add --time flag to report script execution timing

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -269,7 +269,11 @@ impl Drop for Counters {
         let mut total = Duration::ZERO;
         eprintln!();
         for (name, elapsed) in &counters {
-            eprintln!("{:<width$} {elapsed:.2?}", format!("{name}:"), width = max_width);
+            eprintln!(
+                "{:<width$} {elapsed:.2?}",
+                format!("{name}:"),
+                width = max_width
+            );
             total += *elapsed;
         }
         if counters.len() > 1 {


### PR DESCRIPTION
### Summary

This adds a `--time` flag to the Boa CLI that prints how long parsing and execution took, similar to what other engines offer (V8's `d8 --times`, etc.).

When the flag is passed, timing info is printed to stderr so it doesn't interfere with script output on stdout:
$ boa --time script.js Hello, World!
Execution: 1.56ms


For modules, parsing and execution are measured separately:
$ boa --time -m module.mjs 42
Parsing: 1.82ms Execution: 1.27ms Total: 3.09ms


Without the flag, there's zero overhead — no `Instant::now()` calls and no extra output.

### Changes

All changes are in [cli/src/main.rs](cci:7://file:///Users/nakshatrasharma/Desktop/boa/cli/src/main.rs:0:0-0:0):

- Added `--time` boolean flag to the [Opt](cci:2://file:///Users/nakshatrasharma/Desktop/boa/cli/src/main.rs:97:0-169:1) struct (long flag only, since `-t` is already used by `--trace`)
- Wrapped `context.eval()` in [evaluate_expr](cci:1://file:///Users/nakshatrasharma/Desktop/boa/cli/src/main.rs:302:0-328:1) and [evaluate_file](cci:1://file:///Users/nakshatrasharma/Desktop/boa/cli/src/main.rs:330:0-389:1) with conditional `Instant` measurements using `args.time.then(Instant::now)`
- For the module path, `Module::parse()` and `load_link_evaluate()` are measured separately
- In [evaluate_expr](cci:1://file:///Users/nakshatrasharma/Desktop/boa/cli/src/main.rs:302:0-328:1), `context.run_jobs()` is called unconditionally after eval so async work is always drained regardless of whether timing is enabled

No new dependencies - uses `std::time::Instant` which was already imported (as `Duration`) in the file.

Closes #4709 