### PR TITLE
Specialize get_type() without using as_variant

### DIFF
--- a/core/engine/src/value/inner/legacy.rs
+++ b/core/engine/src/value/inner/legacy.rs
@@ -2,7 +2,7 @@
 //! interface as the `NanBoxedValue` type, but using an enum instead of
 //! a 64-bits float.
 
-use crate::{JsBigInt, JsObject, JsSymbol};
+use crate::{JsBigInt, JsObject, JsSymbol, value::Type};
 use boa_engine::JsVariant;
 use boa_gc::{Finalize, Trace, custom_trace};
 use boa_string::JsString;
@@ -170,6 +170,22 @@ impl EnumBasedValue {
     #[inline]
     pub(crate) const fn is_string(&self) -> bool {
         matches!(self, Self::String(_))
+    }
+
+    /// Returns the [`Type`] of this value without cloning the inner value.
+    #[must_use]
+    #[inline]
+    pub(crate) const fn get_type(&self) -> Type {
+        match self {
+            Self::Float64(_) | Self::Integer32(_) => Type::Number,
+            Self::String(_) => Type::String,
+            Self::Boolean(_) => Type::Boolean,
+            Self::Symbol(_) => Type::Symbol,
+            Self::Null => Type::Null,
+            Self::Undefined => Type::Undefined,
+            Self::BigInt(_) => Type::BigInt,
+            Self::Object(_) => Type::Object,
+        }
     }
 
     /// Returns the value as an f64 if it is a float.

--- a/core/engine/src/value/type.rs
+++ b/core/engine/src/value/type.rs
@@ -1,5 +1,4 @@
 use super::JsValue;
-use crate::JsVariant;
 
 /// Possible types of values as defined at <https://tc39.es/ecma262/#sec-typeof-operator>.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -37,16 +36,8 @@ impl JsValue {
     ///
     /// Check [`JsValue::type_of`] if you need to call the `typeof` operator.
     #[must_use]
+    #[inline]
     pub fn get_type(&self) -> Type {
-        match self.variant() {
-            JsVariant::Float64(_) | JsVariant::Integer32(_) => Type::Number,
-            JsVariant::String(_) => Type::String,
-            JsVariant::Boolean(_) => Type::Boolean,
-            JsVariant::Symbol(_) => Type::Symbol,
-            JsVariant::Null => Type::Null,
-            JsVariant::Undefined => Type::Undefined,
-            JsVariant::BigInt(_) => Type::BigInt,
-            JsVariant::Object(_) => Type::Object,
-        }
+        self.0.get_type()
     }
 }


### PR DESCRIPTION
as_variant() sometimes clones the value, but to get the type we only need the kind bits (MASK_KIND). This means it' simpler and faster where get_type() is used (all equality checkers for example).

Benchmarks from PR:
```
PROGRESS Richards
RESULT Richards 238
PROGRESS DeltaBlue
RESULT DeltaBlue 235
PROGRESS Encrypt
PROGRESS Decrypt
RESULT Crypto 243
PROGRESS RayTrace
RESULT RayTrace 479
PROGRESS Earley
PROGRESS Boyer
RESULT EarleyBoyer 582
PROGRESS RegExp
RESULT RegExp 81.0
PROGRESS Splay
RESULT Splay 846
PROGRESS NavierStokes
RESULT NavierStokes 546
SCORE 330
```