### PR TITLE
Fix RegExp named capture groups to use definition order, not alphabetical

### DIFF
--- a/core/engine/src/builtins/regexp/mod.rs
+++ b/core/engine/src/builtins/regexp/mod.rs
@@ -1222,11 +1222,9 @@ impl RegExp {
         a.create_data_property_or_throw(0, matched_substr, context)
             .expect("this CreateDataPropertyOrThrow call must not fail");
 
-        let mut named_groups = match_value
+        let named_groups = match_value
             .named_groups()
             .collect::<Vec<(&str, Option<Range>)>>();
-        // Strict mode requires groups to be created in a sorted order
-        named_groups.sort_by(|(name_x, _), (name_y, _)| name_x.cmp(name_y));
 
         // Combines:
         // 26. Let groupNames be a new empty List.


### PR DESCRIPTION
Named capture groups in `match.groups` are incorrectly sorted alphabetically instead of appearing in regex definition order.

**Reproduction:**
```js
var m = "2024-01-15".match(/(?<year>\d+)-(?<month>\d+)-(?<day>\d+)/);
Object.keys(m.groups);
// Boa (before):  ["day", "month", "year"]  (alphabetical — wrong)
// V8/SpiderMonkey: ["year", "month", "day"]  (definition order — correct)
```

**Root cause:** `RegExpBuiltinExec` in `regexp/mod.rs` collected named groups from `regress` (which already returns them in definition order) and then explicitly sorted them alphabetically with a comment citing "strict mode." The spec ([22.2.7.3 RegExpBuiltinExec](https://tc39.es/ecma262/#sec-regexpbuiltinexec)) has no such requirement — groups must appear in the order their `GroupName` is defined in the pattern.

**Fix:** Remove the erroneous `.sort_by()` call. The `indices.groups` object inherits the fix since it uses the same list.

This also affects `for...in`, `Object.entries`, `JSON.stringify`, and any code using `match.groups` iteration order.