### PR TITLE
fix(fetch): don't drop body when cloning a Request with options

### DIFF
--- a/core/runtime/src/fetch/request.rs
+++ b/core/runtime/src/fetch/request.rs
@@ -66,8 +66,9 @@ impl RequestInit {
         request: Option<HttpRequest<Vec<u8>>>,
     ) -> JsResult<HttpRequest<Vec<u8>>> {
         let mut builder = HttpRequest::builder();
+        let mut original_body = None;
         if let Some(r) = request {
-            let (parts, _body) = r.into_parts();
+            let (parts, body) = r.into_parts();
             builder = builder
                 .method(parts.method)
                 .uri(parts.uri)
@@ -75,6 +76,10 @@ impl RequestInit {
 
             for (key, value) in &parts.headers {
                 builder = builder.header(key, value);
+            }
+
+            if !body.is_empty() {
+                original_body = Some(body);
             }
         }
 
@@ -111,7 +116,7 @@ impl RequestInit {
         }
 
         builder
-            .body(request_body.unwrap_or_default())
+            .body(request_body.or(original_body).unwrap_or_default())
             .map_err(|_| js_error!(Error: "Cannot construct request"))
     }
 }

--- a/core/runtime/src/fetch/tests/request.rs
+++ b/core/runtime/src/fetch/tests/request.rs
@@ -47,3 +47,15 @@ fn request_constructor() {
         }),
     ]);
 }
+
+#[test]
+fn request_clone_preserves_body() {
+    let original = http::request::Request::builder()
+        .method("POST")
+        .uri("http://example.com")
+        .body(b"payload".to_vec())
+        .unwrap();
+    let original = JsRequest::from(original);
+    let cloned = JsRequest::create_from_js(Either::Right(original), None).unwrap();
+    assert_eq!(cloned.inner().body().as_slice(), b"payload");
+}


### PR DESCRIPTION
Fixes #4686

When you do `new Request(existingRequest, { headers: {...} })`, the body from the original request gets lost. The issue is in [into_request_builder](cci:1://file:///e:/opensource/boa/core/runtime/src/fetch/request.rs:58:4-120:5) — `into_parts()` was splitting off the body as [_body](cci:1://file:///e:/opensource/boa/core/runtime/src/fetch/tests/request.rs:50:0-60:1) and just ignoring it.

Fix: save the original body and use it if `options.body` wasn't set.