### PR TITLE
added tests for JsSymbol

### DIFF
--- a/core/engine/src/builtins/symbol/tests.rs
+++ b/core/engine/src/builtins/symbol/tests.rs
@@ -32,3 +32,81 @@ fn symbol_access() {
         TestAction::assert_eq("x['Symbol(Hello)']", JsValue::undefined()),
     ]);
 }
+
+#[test]
+fn symbol_for_and_key_for() {
+    run_test_actions([
+        TestAction::run(indoc! {r#"
+                var s1 = Symbol.for("shared");
+                var s2 = Symbol.for("shared");
+            "#}),
+        // Symbol.for with the same key returns the same symbol
+        TestAction::assert("s1 === s2"),
+        // Symbol.keyFor returns the key for a globally registered symbol
+        TestAction::assert_eq("Symbol.keyFor(s1)", js_str!("shared")),
+        // Symbol.keyFor returns undefined for a non-registered symbol
+        TestAction::assert_eq("Symbol.keyFor(Symbol('local'))", JsValue::undefined()),
+    ]);
+}
+
+#[test]
+fn symbol_description_getter() {
+    run_test_actions([
+        TestAction::assert_eq("Symbol('desc').description", js_str!("desc")),
+        TestAction::assert_eq("Symbol().description", JsValue::undefined()),
+        TestAction::assert_eq("Symbol('').description", js_str!("")),
+    ]);
+}
+
+#[test]
+fn symbol_value_of() {
+    run_test_actions([
+        TestAction::run("var sym = Symbol('vo');"),
+        TestAction::assert("Object(sym).valueOf() === sym"),
+    ]);
+}
+
+#[test]
+fn symbol_to_string() {
+    run_test_actions([
+        TestAction::assert_eq("Symbol('abc').toString()", js_str!("Symbol(abc)")),
+        TestAction::assert_eq("Symbol().toString()", js_str!("Symbol()")),
+    ]);
+}
+
+#[test]
+fn symbol_to_primitive() {
+    run_test_actions([
+        TestAction::run("var sym = Symbol('prim');"),
+        TestAction::assert("sym[Symbol.toPrimitive]('default') === sym"),
+    ]);
+}
+
+#[test]
+fn new_symbol_throws() {
+    run_test_actions([TestAction::assert_native_error(
+        "new Symbol()",
+        crate::JsNativeErrorKind::Type,
+        "Symbol is not a constructor",
+    )]);
+}
+
+#[test]
+fn well_known_symbols_exist() {
+    run_test_actions([
+        TestAction::assert_eq("typeof Symbol.iterator", js_str!("symbol")),
+        TestAction::assert_eq("typeof Symbol.asyncIterator", js_str!("symbol")),
+        TestAction::assert_eq("typeof Symbol.hasInstance", js_str!("symbol")),
+        TestAction::assert_eq("typeof Symbol.isConcatSpreadable", js_str!("symbol")),
+        TestAction::assert_eq("typeof Symbol.match", js_str!("symbol")),
+        TestAction::assert_eq("typeof Symbol.matchAll", js_str!("symbol")),
+        TestAction::assert_eq("typeof Symbol.replace", js_str!("symbol")),
+        TestAction::assert_eq("typeof Symbol.search", js_str!("symbol")),
+        TestAction::assert_eq("typeof Symbol.species", js_str!("symbol")),
+        TestAction::assert_eq("typeof Symbol.split", js_str!("symbol")),
+        TestAction::assert_eq("typeof Symbol.toPrimitive", js_str!("symbol")),
+        TestAction::assert_eq("typeof Symbol.toStringTag", js_str!("symbol")),
+        TestAction::assert_eq("typeof Symbol.unscopables", js_str!("symbol")),
+    ]);
+}
+

--- a/core/engine/src/builtins/symbol/tests.rs
+++ b/core/engine/src/builtins/symbol/tests.rs
@@ -35,6 +35,8 @@ fn symbol_access() {
 
 #[test]
 fn symbol_for_and_key_for() {
+    use crate::Context;
+    use std::thread;
     run_test_actions([
         TestAction::run(indoc! {r#"
                 var s1 = Symbol.for("shared");
@@ -49,8 +51,6 @@ fn symbol_for_and_key_for() {
     ]);
 
     // Test that globally registered symbols are preserved across threads
-    use crate::Context;
-    use std::thread;
 
     let handle = thread::spawn(|| {
         let mut context = Context::default();

--- a/core/engine/src/builtins/symbol/tests.rs
+++ b/core/engine/src/builtins/symbol/tests.rs
@@ -54,9 +54,7 @@ fn symbol_for_and_key_for() {
 
     let handle = thread::spawn(|| {
         let mut context = Context::default();
-        let result = context.eval(crate::Source::from_bytes(
-            r#"Symbol.for("cross_thread")"#,
-        ));
+        let result = context.eval(crate::Source::from_bytes(r#"Symbol.for("cross_thread")"#));
         result
             .unwrap()
             .as_symbol()
@@ -67,9 +65,7 @@ fn symbol_for_and_key_for() {
     let sym_from_thread = handle.join().expect("thread panicked");
 
     let mut context = Context::default();
-    let result = context.eval(crate::Source::from_bytes(
-        r#"Symbol.for("cross_thread")"#,
-    ));
+    let result = context.eval(crate::Source::from_bytes(r#"Symbol.for("cross_thread")"#));
     let sym_from_main = result
         .unwrap()
         .as_symbol()
@@ -142,4 +138,3 @@ fn well_known_symbols_exist() {
         TestAction::assert_eq("typeof Symbol.unscopables", js_str!("symbol")),
     ]);
 }
-

--- a/core/engine/src/symbol.rs
+++ b/core/engine/src/symbol.rs
@@ -483,7 +483,9 @@ mod tests {
     fn new_with_description() {
         let sym = JsSymbol::new(Some(crate::js_string!("foo"))).unwrap();
         assert_eq!(
-            sym.description().as_ref().map(|s| s.to_std_string_escaped()),
+            sym.description()
+                .as_ref()
+                .map(|s| s.to_std_string_escaped()),
             Some(String::from("foo"))
         );
     }
@@ -515,7 +517,10 @@ mod tests {
     #[test]
     fn descriptive_string_with_description() {
         let sym = JsSymbol::new(Some(crate::js_string!("foo"))).unwrap();
-        assert_eq!(sym.descriptive_string().to_std_string_escaped(), "Symbol(foo)");
+        assert_eq!(
+            sym.descriptive_string().to_std_string_escaped(),
+            "Symbol(foo)"
+        );
     }
 
     #[test]
@@ -529,7 +534,10 @@ mod tests {
         let cases = [
             (JsSymbol::async_iterator(), "Symbol.asyncIterator"),
             (JsSymbol::has_instance(), "Symbol.hasInstance"),
-            (JsSymbol::is_concat_spreadable(), "Symbol.isConcatSpreadable"),
+            (
+                JsSymbol::is_concat_spreadable(),
+                "Symbol.isConcatSpreadable",
+            ),
             (JsSymbol::iterator(), "Symbol.iterator"),
             (JsSymbol::r#match(), "Symbol.match"),
             (JsSymbol::match_all(), "Symbol.matchAll"),
@@ -613,8 +621,8 @@ mod tests {
 
     #[test]
     fn hash_consistency() {
-        use std::hash::{Hash, Hasher};
         use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
 
         let sym = JsSymbol::new(Some(crate::js_string!("hashme"))).unwrap();
         let cloned = sym.clone();
@@ -627,7 +635,9 @@ mod tests {
         Hash::hash(&cloned, &mut hasher2);
         let hash2 = hasher2.finish();
 
-        assert_eq!(hash1, hash2, "Hash trait should produce consistent results for equal symbols");
+        assert_eq!(
+            hash1, hash2,
+            "Hash trait should produce consistent results for equal symbols"
+        );
     }
 }
-

--- a/core/engine/src/symbol.rs
+++ b/core/engine/src/symbol.rs
@@ -399,7 +399,8 @@ mod tests {
     use boa_macros::js_str;
 
     use crate::{
-        Context, JsObject, JsValue, TestAction, builtins::Json, run_test_actions, value::TryIntoJs,
+        Context, JsObject, JsValue, TestAction, builtins::Json, run_test_actions, string::JsString,
+        value::TryIntoJs,
     };
 
     use super::JsSymbol;
@@ -485,7 +486,7 @@ mod tests {
         assert_eq!(
             sym.description()
                 .as_ref()
-                .map(|s| s.to_std_string_escaped()),
+                .map(JsString::to_std_string_escaped),
             Some(String::from("foo"))
         );
     }
@@ -553,7 +554,7 @@ mod tests {
             assert_eq!(
                 sym.description()
                     .as_ref()
-                    .map(|s| s.to_std_string_escaped()),
+                    .map(JsString::to_std_string_escaped),
                 Some(String::from(*expected_desc)),
                 "Well-known symbol description mismatch for {expected_desc}"
             );
@@ -579,8 +580,13 @@ mod tests {
         assert_eq!(sym, cloned);
         assert_eq!(sym.hash(), cloned.hash());
         assert_eq!(
-            sym.description().map(|s| s.to_std_string_escaped()),
-            cloned.description().map(|s| s.to_std_string_escaped())
+            sym.description()
+                .as_ref()
+                .map(JsString::to_std_string_escaped),
+            cloned
+                .description()
+                .as_ref()
+                .map(JsString::to_std_string_escaped)
         );
     }
 

--- a/core/engine/src/symbol.rs
+++ b/core/engine/src/symbol.rs
@@ -478,4 +478,156 @@ mod tests {
             ),
         ]);
     }
+
+    #[test]
+    fn new_with_description() {
+        let sym = JsSymbol::new(Some(crate::js_string!("foo"))).unwrap();
+        assert_eq!(
+            sym.description().as_ref().map(|s| s.to_std_string_escaped()),
+            Some(String::from("foo"))
+        );
+    }
+
+    #[test]
+    fn new_without_description() {
+        let sym = JsSymbol::new(None).unwrap();
+        assert!(sym.description().is_none());
+    }
+
+    #[test]
+    fn fn_name_with_description() {
+        let sym = JsSymbol::new(Some(crate::js_string!("hello"))).unwrap();
+        assert_eq!(sym.fn_name().to_std_string_escaped(), "[hello]");
+    }
+
+    #[test]
+    fn fn_name_without_description() {
+        let sym = JsSymbol::new(None).unwrap();
+        assert_eq!(sym.fn_name().to_std_string_escaped(), "");
+    }
+
+    #[test]
+    fn fn_name_well_known() {
+        let sym = JsSymbol::iterator();
+        assert_eq!(sym.fn_name().to_std_string_escaped(), "[Symbol.iterator]");
+    }
+
+    #[test]
+    fn descriptive_string_with_description() {
+        let sym = JsSymbol::new(Some(crate::js_string!("foo"))).unwrap();
+        assert_eq!(sym.descriptive_string().to_std_string_escaped(), "Symbol(foo)");
+    }
+
+    #[test]
+    fn descriptive_string_without_description() {
+        let sym = JsSymbol::new(None).unwrap();
+        assert_eq!(sym.descriptive_string().to_std_string_escaped(), "Symbol()");
+    }
+
+    #[test]
+    fn well_known_symbols_description() {
+        let cases = [
+            (JsSymbol::async_iterator(), "Symbol.asyncIterator"),
+            (JsSymbol::has_instance(), "Symbol.hasInstance"),
+            (JsSymbol::is_concat_spreadable(), "Symbol.isConcatSpreadable"),
+            (JsSymbol::iterator(), "Symbol.iterator"),
+            (JsSymbol::r#match(), "Symbol.match"),
+            (JsSymbol::match_all(), "Symbol.matchAll"),
+            (JsSymbol::replace(), "Symbol.replace"),
+            (JsSymbol::search(), "Symbol.search"),
+            (JsSymbol::species(), "Symbol.species"),
+            (JsSymbol::split(), "Symbol.split"),
+            (JsSymbol::to_primitive(), "Symbol.toPrimitive"),
+            (JsSymbol::to_string_tag(), "Symbol.toStringTag"),
+            (JsSymbol::unscopables(), "Symbol.unscopables"),
+        ];
+        for (sym, expected_desc) in &cases {
+            assert_eq!(
+                sym.description()
+                    .as_ref()
+                    .map(|s| s.to_std_string_escaped()),
+                Some(String::from(*expected_desc)),
+                "Well-known symbol description mismatch for {expected_desc}"
+            );
+        }
+    }
+
+    #[test]
+    fn well_known_symbols_are_equal() {
+        assert_eq!(JsSymbol::iterator(), JsSymbol::iterator());
+        assert_eq!(JsSymbol::async_iterator(), JsSymbol::async_iterator());
+    }
+
+    #[test]
+    fn well_known_symbols_different_from_user() {
+        let user_sym = JsSymbol::new(Some(crate::js_string!("Symbol.iterator"))).unwrap();
+        assert_ne!(user_sym, JsSymbol::iterator());
+    }
+
+    #[test]
+    fn clone_preserves_identity() {
+        let sym = JsSymbol::new(Some(crate::js_string!("cloned"))).unwrap();
+        let cloned = sym.clone();
+        assert_eq!(sym, cloned);
+        assert_eq!(sym.hash(), cloned.hash());
+        assert_eq!(
+            sym.description().map(|s| s.to_std_string_escaped()),
+            cloned.description().map(|s| s.to_std_string_escaped())
+        );
+    }
+
+    #[test]
+    fn clone_well_known_preserves_identity() {
+        let sym = JsSymbol::iterator();
+        let cloned = sym.clone();
+        assert_eq!(sym, cloned);
+    }
+
+    #[test]
+    fn display_formatting() {
+        let sym_with_desc = JsSymbol::new(Some(crate::js_string!("test"))).unwrap();
+        assert_eq!(format!("{sym_with_desc}"), "Symbol(test)");
+
+        let sym_without_desc = JsSymbol::new(None).unwrap();
+        assert_eq!(format!("{sym_without_desc}"), "Symbol()");
+    }
+
+    #[test]
+    fn debug_formatting() {
+        let sym = JsSymbol::new(Some(crate::js_string!("dbg"))).unwrap();
+        let debug_str = format!("{sym:?}");
+        assert!(debug_str.contains("JsSymbol"));
+        assert!(debug_str.contains("hash"));
+        assert!(debug_str.contains("description"));
+    }
+
+    #[test]
+    fn ordering() {
+        let sym_a = JsSymbol::new(None).unwrap();
+        let sym_b = JsSymbol::new(None).unwrap();
+        // sym_a was created first, so it should have a smaller hash
+        assert!(sym_a < sym_b);
+        assert!(sym_b > sym_a);
+        assert_eq!(sym_a.cmp(&sym_a), std::cmp::Ordering::Equal);
+    }
+
+    #[test]
+    fn hash_consistency() {
+        use std::hash::{Hash, Hasher};
+        use std::collections::hash_map::DefaultHasher;
+
+        let sym = JsSymbol::new(Some(crate::js_string!("hashme"))).unwrap();
+        let cloned = sym.clone();
+
+        let mut hasher1 = DefaultHasher::new();
+        Hash::hash(&sym, &mut hasher1);
+        let hash1 = hasher1.finish();
+
+        let mut hasher2 = DefaultHasher::new();
+        Hash::hash(&cloned, &mut hasher2);
+        let hash2 = hasher2.finish();
+
+        assert_eq!(hash1, hash2, "Hash trait should produce consistent results for equal symbols");
+    }
 }
+


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request fixes/closes #3489 .


Summary:- 
This PR adds comprehensive test coverage for `JsSymbol`.

- Rust-level tests ([symbol.rs](https://github.com/boa-dev/boa/blob/main/core/engine/src/symbol.rs)) — `new()`, `description()`,`fn_name()`, `descriptive_string()`.
- `Clone`, `Display`, `Debug`, `PartialEq`, `Ord` and `Hash` trait impls
- JS-level tests ([tests.rs](https://github.com/boa-dev/boa/blob/main/core/engine/src/builtins/symbol/tests.rs)) - `Symbol.for()` / `Symbol.keyFor()`, `Symbol.prototype.description` getter, `valueOf()`, `toString()`, `@@toPrimitive`, `new Symbol()` throws `TypeError`
