### PR TITLE
Remove optional-chain-first-expression.js from test262 ignore list

### DIFF
--- a/test262_config.toml
+++ b/test262_config.toml
@@ -68,7 +68,6 @@ tests = [
     # Should throw an OOM error instead of filling the whole RAM.
     "test/staging/sm/String/replace-math.js",
     # Panics
-    "test/staging/sm/expressions/optional-chain-first-expression.js",
     "test/staging/sm/regress/regress-554955-2.js",
     "test/staging/sm/class/fields-static-class-name-binding-eval.js",
     "test/staging/sm/regress/regress-554955-1.js",


### PR DESCRIPTION
This Pull Request is a maintenance cleanup (no associated issue).

It changes the following:
- Removes `optional-chain-first-expression.js` from the test262 ignore list
- This test was previously ignored due to a panic in Boa's bytecode emitter
- Running it against current main no longer causes a panic, so the ignore entry is no longer needed