### PR TITLE
feat(vm): implement polymorphic inline cache (PIC) for property access

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -512,6 +512,7 @@ dependencies = [
 name = "boa_gc"
 version = "1.0.0-dev"
 dependencies = [
+ "arrayvec",
  "boa_macros",
  "boa_string",
  "either",

--- a/core/engine/Cargo.toml
+++ b/core/engine/Cargo.toml
@@ -94,7 +94,7 @@ native-backtrace = []
 [dependencies]
 tag_ptr.workspace = true
 boa_interner.workspace = true
-boa_gc = { workspace = true, features = ["thin-vec", "boa_string"] }
+boa_gc = { workspace = true, features = ["thin-vec", "boa_string", "arrayvec"] }
 boa_macros.workspace = true
 boa_ast.workspace = true
 boa_parser.workspace = true

--- a/core/engine/src/object/shape/mod.rs
+++ b/core/engine/src/object/shape/mod.rs
@@ -235,23 +235,10 @@ impl From<SharedShape> for Shape {
 pub(crate) enum WeakShape {
     Unique(WeakUniqueShape),
     Shared(WeakSharedShape),
-    None,
+    // None,
 }
 
 impl WeakShape {
-    /// Return location in memory of the [`Shape`].
-    ///
-    /// Returns `0` if the shape has been freed.
-    #[inline]
-    #[must_use]
-    pub(crate) fn to_addr_usize(&self) -> usize {
-        match self {
-            WeakShape::Shared(shape) => shape.to_addr_usize(),
-            WeakShape::Unique(shape) => shape.to_addr_usize(),
-            WeakShape::None => 0,
-        }
-    }
-
     /// Return location in memory of the [`Shape`].
     ///
     /// Returns `0` if the shape has been freed.
@@ -261,7 +248,7 @@ impl WeakShape {
         match self {
             WeakShape::Shared(shape) => Some(shape.upgrade()?.into()),
             WeakShape::Unique(shape) => Some(shape.upgrade()?.into()),
-            WeakShape::None => None,
+            // WeakShape::None => None,
         }
     }
 }

--- a/core/engine/src/object/shape/mod.rs
+++ b/core/engine/src/object/shape/mod.rs
@@ -235,10 +235,18 @@ impl From<SharedShape> for Shape {
 pub(crate) enum WeakShape {
     Unique(WeakUniqueShape),
     Shared(WeakSharedShape),
-    // None,
 }
 
 impl WeakShape {
+    /// Return location in memory of the [`Shape`].
+    ///
+    /// Returns `0` if the shape has been freed.
+    #[inline]
+    #[must_use]
+    pub(crate) fn to_addr_usize(&self) -> usize {
+        self.upgrade().as_ref().map_or(0, Shape::to_addr_usize)
+    }
+
     /// Return location in memory of the [`Shape`].
     ///
     /// Returns `0` if the shape has been freed.
@@ -248,7 +256,6 @@ impl WeakShape {
         match self {
             WeakShape::Shared(shape) => Some(shape.upgrade()?.into()),
             WeakShape::Unique(shape) => Some(shape.upgrade()?.into()),
-            // WeakShape::None => None,
         }
     }
 }

--- a/core/engine/src/object/shape/shared_shape/mod.rs
+++ b/core/engine/src/object/shape/shared_shape/mod.rs
@@ -480,18 +480,6 @@ pub(crate) struct WeakSharedShape {
 }
 
 impl WeakSharedShape {
-    /// Return location in memory of the [`WeakSharedShape`].
-    ///
-    /// Returns `0` if the inner [`SharedShape`] has been freed.
-    #[inline]
-    #[must_use]
-    pub(crate) fn to_addr_usize(&self) -> usize {
-        self.inner.upgrade().map_or(0, |inner| {
-            let ptr: *const _ = inner.as_ref();
-            ptr as usize
-        })
-    }
-
     /// Upgrade returns a [`SharedShape`] pointer for the internal value if the pointer is still live,
     /// or [`None`] if the value was already garbage collected.
     #[inline]

--- a/core/engine/src/object/shape/unique_shape.rs
+++ b/core/engine/src/object/shape/unique_shape.rs
@@ -247,18 +247,6 @@ pub(crate) struct WeakUniqueShape {
 }
 
 impl WeakUniqueShape {
-    /// Return location in memory of the [`WeakUniqueShape`].
-    ///
-    /// Returns `0` if the inner [`UniqueShape`] has been freed.
-    #[inline]
-    #[must_use]
-    pub(crate) fn to_addr_usize(&self) -> usize {
-        self.inner.upgrade().map_or(0, |inner| {
-            let ptr: *const _ = inner.as_ref();
-            ptr as usize
-        })
-    }
-
     /// Upgrade returns a [`UniqueShape`] pointer for the internal value if the pointer is still live,
     /// or [`None`] if the value was already garbage collected.
     #[inline]

--- a/core/engine/src/vm/code_block.rs
+++ b/core/engine/src/vm/code_block.rs
@@ -634,7 +634,7 @@ impl CodeBlock {
                 let ic = &self.ic[u32::from(*ic_index) as usize];
                 format!(
                     "dst:{dst}, value:{value}, shape:0x{:x}]",
-                    ic.shape.borrow().to_addr_usize(),
+                    ic.first_shape_addr(),
                 )
             }
             Instruction::GetPropertyByName {
@@ -646,7 +646,7 @@ impl CodeBlock {
                 format!(
                     "dst:{dst}, value:{value}, ic:[name:{}, shape:0x{:x}]",
                     ic.name.to_std_string_escaped(),
-                    ic.shape.borrow().to_addr_usize(),
+                    ic.first_shape_addr(),
                 )
             }
             Instruction::GetPropertyByNameWithThis {
@@ -659,7 +659,7 @@ impl CodeBlock {
                 format!(
                     "dst:{dst}, receiver:{receiver}, value:{value}, ic:[name:{}, shape:0x{:x}]",
                     ic.name.to_std_string_escaped(),
-                    ic.shape.borrow().to_addr_usize(),
+                    ic.first_shape_addr(),
                 )
             }
             Instruction::SetPropertyByName {
@@ -670,7 +670,7 @@ impl CodeBlock {
                 let ic = &self.ic[u32::from(*ic_index) as usize];
                 format!(
                     "object:{object}, value:{value}, ic:shape:0x{:x}",
-                    ic.shape.borrow().to_addr_usize(),
+                    ic.first_shape_addr(),
                 )
             }
             Instruction::SetPropertyByNameWithThis {
@@ -682,7 +682,7 @@ impl CodeBlock {
                 let ic = &self.ic[u32::from(*ic_index) as usize];
                 format!(
                     "object:{object}, receiver:{receiver}, value:{value}, ic:shape:0x{:x}",
-                    ic.shape.borrow().to_addr_usize(),
+                    ic.first_shape_addr(),
                 )
             }
             Instruction::GetPropertyByValue {

--- a/core/engine/src/vm/code_block.rs
+++ b/core/engine/src/vm/code_block.rs
@@ -630,24 +630,14 @@ impl CodeBlock {
                 dst,
                 value,
                 ic_index,
-            } => {
-                let ic = &self.ic[u32::from(*ic_index) as usize];
-                format!(
-                    "dst:{dst}, value:{value}, ic:[shapes:{}]",
-                    ic.shapes_display(),
-                )
             }
-            Instruction::GetPropertyByName {
+            | Instruction::GetPropertyByName {
                 dst,
                 value,
                 ic_index,
             } => {
                 let ic = &self.ic[u32::from(*ic_index) as usize];
-                format!(
-                    "dst:{dst}, value:{value}, ic:[name:{}, shapes:{}]",
-                    ic.name.to_std_string_escaped(),
-                    ic.shapes_display(),
-                )
+                format!("dst:{dst}, value:{value}, ic:{ic}",)
             }
             Instruction::GetPropertyByNameWithThis {
                 dst,
@@ -656,11 +646,7 @@ impl CodeBlock {
                 ic_index,
             } => {
                 let ic = &self.ic[u32::from(*ic_index) as usize];
-                format!(
-                    "dst:{dst}, receiver:{receiver}, value:{value}, ic:[name:{}, shapes:{}]",
-                    ic.name.to_std_string_escaped(),
-                    ic.shapes_display(),
-                )
+                format!("dst:{dst}, receiver:{receiver}, value:{value}, ic:{ic}",)
             }
             Instruction::SetPropertyByName {
                 value,
@@ -668,10 +654,7 @@ impl CodeBlock {
                 ic_index,
             } => {
                 let ic = &self.ic[u32::from(*ic_index) as usize];
-                format!(
-                    "object:{object}, value:{value}, ic:[shapes:{}]",
-                    ic.shapes_display(),
-                )
+                format!("object:{object}, value:{value}, ic:{ic}",)
             }
             Instruction::SetPropertyByNameWithThis {
                 value,
@@ -680,10 +663,7 @@ impl CodeBlock {
                 ic_index,
             } => {
                 let ic = &self.ic[u32::from(*ic_index) as usize];
-                format!(
-                    "object:{object}, receiver:{receiver}, value:{value}, ic:[shapes:{}]",
-                    ic.shapes_display(),
-                )
+                format!("object:{object}, receiver:{receiver}, value:{value}, ic:{ic}")
             }
             Instruction::GetPropertyByValue {
                 dst,

--- a/core/engine/src/vm/code_block.rs
+++ b/core/engine/src/vm/code_block.rs
@@ -633,8 +633,8 @@ impl CodeBlock {
             } => {
                 let ic = &self.ic[u32::from(*ic_index) as usize];
                 format!(
-                    "dst:{dst}, value:{value}, shape:0x{:x}]",
-                    ic.first_shape_addr(),
+                    "dst:{dst}, value:{value}, ic:[shapes:{}]",
+                    ic.shapes_display(),
                 )
             }
             Instruction::GetPropertyByName {
@@ -644,9 +644,9 @@ impl CodeBlock {
             } => {
                 let ic = &self.ic[u32::from(*ic_index) as usize];
                 format!(
-                    "dst:{dst}, value:{value}, ic:[name:{}, shape:0x{:x}]",
+                    "dst:{dst}, value:{value}, ic:[name:{}, shapes:{}]",
                     ic.name.to_std_string_escaped(),
-                    ic.first_shape_addr(),
+                    ic.shapes_display(),
                 )
             }
             Instruction::GetPropertyByNameWithThis {
@@ -657,9 +657,9 @@ impl CodeBlock {
             } => {
                 let ic = &self.ic[u32::from(*ic_index) as usize];
                 format!(
-                    "dst:{dst}, receiver:{receiver}, value:{value}, ic:[name:{}, shape:0x{:x}]",
+                    "dst:{dst}, receiver:{receiver}, value:{value}, ic:[name:{}, shapes:{}]",
                     ic.name.to_std_string_escaped(),
-                    ic.first_shape_addr(),
+                    ic.shapes_display(),
                 )
             }
             Instruction::SetPropertyByName {
@@ -669,8 +669,8 @@ impl CodeBlock {
             } => {
                 let ic = &self.ic[u32::from(*ic_index) as usize];
                 format!(
-                    "object:{object}, value:{value}, ic:shape:0x{:x}",
-                    ic.first_shape_addr(),
+                    "object:{object}, value:{value}, ic:[shapes:{}]",
+                    ic.shapes_display(),
                 )
             }
             Instruction::SetPropertyByNameWithThis {
@@ -681,8 +681,8 @@ impl CodeBlock {
             } => {
                 let ic = &self.ic[u32::from(*ic_index) as usize];
                 format!(
-                    "object:{object}, receiver:{receiver}, value:{value}, ic:shape:0x{:x}",
-                    ic.first_shape_addr(),
+                    "object:{object}, receiver:{receiver}, value:{value}, ic:[shapes:{}]",
+                    ic.shapes_display(),
                 )
             }
             Instruction::GetPropertyByValue {

--- a/core/engine/src/vm/inline_cache/mod.rs
+++ b/core/engine/src/vm/inline_cache/mod.rs
@@ -28,7 +28,7 @@ pub(crate) struct PicEntries(pub(crate) ArrayVec<PicEntry, PIC_CAPACITY>);
 
 unsafe impl BoaTrace for PicEntries {
     custom_trace!(this, mark, {
-        for entry in this.0.iter() {
+        for entry in &this.0 {
             mark(entry);
         }
     });
@@ -74,7 +74,9 @@ impl InlineCache {
         // If the shape already exists, update its slot.
         // This handles cases where property transitions preserve the shape but change the slot.
         for entry in &mut entries.0.iter_mut() {
-            if let Some(upgraded) = entry.shape.upgrade() && upgraded.to_addr_usize() == shape_addr {
+            if let Some(upgraded) = entry.shape.upgrade()
+                && upgraded.to_addr_usize() == shape_addr
+            {
                 entry.slot = slot;
                 return;
             }

--- a/core/engine/src/vm/inline_cache/mod.rs
+++ b/core/engine/src/vm/inline_cache/mod.rs
@@ -1,6 +1,7 @@
+use arrayvec::ArrayVec;
 use std::cell::Cell;
 
-use boa_gc::GcRefCell;
+use boa_gc::{GcRefCell, Trace as BoaTrace, custom_trace};
 use boa_macros::{Finalize, Trace};
 
 use crate::{
@@ -11,51 +12,123 @@ use crate::{
 #[cfg(test)]
 mod tests;
 
-/// An inline cache entry for a property access.
+pub(crate) const PIC_CAPACITY: usize = 4;
+
+/// A cached shape-to-slot mapping for a polymorphic inline cache.
 #[derive(Clone, Debug, Trace, Finalize)]
+pub(crate) struct PicEntry {
+    /// A weak reference is kept to the shape to avoid the shape preventing deallocation.
+    pub(crate) shape: WeakShape,
+    #[unsafe_ignore_trace]
+    pub(crate) slot: Slot,
+}
+
+#[derive(Clone, Debug, Finalize)]
+pub(crate) struct PicEntries(pub(crate) ArrayVec<PicEntry, PIC_CAPACITY>);
+
+unsafe impl BoaTrace for PicEntries {
+    custom_trace!(this, mark, {
+        for entry in this.0.iter() {
+            mark(entry);
+        }
+    });
+}
+
+/// An inline cache entry for a property access.
+#[derive(Clone, Debug, Finalize)]
 pub(crate) struct InlineCache {
     /// The property that is accessed.
     pub(crate) name: JsString,
 
-    /// A pointer is kept to the shape to avoid the shape from being deallocated.
-    pub(crate) shape: GcRefCell<WeakShape>,
+    /// Multiple cached shape-to-slot entries.
+    pub(crate) entries: GcRefCell<PicEntries>,
 
-    /// The [`Slot`] of the property.
-    #[unsafe_ignore_trace]
-    pub(crate) slot: Cell<Slot>,
+    /// Whether this access site has seen too many shapes and should no longer be cached.
+    pub(crate) megamorphic: Cell<bool>,
+}
+
+unsafe impl BoaTrace for InlineCache {
+    custom_trace!(this, mark, {
+        mark(&this.name);
+        mark(&this.entries);
+    });
 }
 
 impl InlineCache {
-    pub(crate) const fn new(name: JsString) -> Self {
+    pub(crate) fn new(name: JsString) -> Self {
         Self {
             name,
-            shape: GcRefCell::new(WeakShape::None),
-            slot: Cell::new(Slot::new()),
+            entries: GcRefCell::new(PicEntries(ArrayVec::new())),
+            megamorphic: Cell::new(false),
         }
     }
 
     pub(crate) fn set(&self, shape: &Shape, slot: Slot) {
-        *self.shape.borrow_mut() = shape.into();
-        self.slot.set(slot);
+        if self.megamorphic.get() {
+            return;
+        }
+
+        let mut entries = self.entries.borrow_mut();
+        let shape_addr = shape.to_addr_usize();
+
+        // If the shape already exists, update its slot.
+        // This handles cases where property transitions preserve the shape but change the slot.
+        for entry in &mut entries.0.iter_mut() {
+            if let Some(upgraded) = entry.shape.upgrade() && upgraded.to_addr_usize() == shape_addr {
+                entry.slot = slot;
+                return;
+            }
+        }
+
+        // Add a new entry if there's space.
+        if entries.0.len() < PIC_CAPACITY {
+            entries.0.push(PicEntry {
+                shape: shape.into(),
+                slot,
+            });
+        } else {
+            // Polymorphic cache is full, transition to megamorphic.
+            self.megamorphic.set(true);
+            entries.0.clear();
+        }
     }
 
-    pub(crate) fn slot(&self) -> Slot {
-        self.slot.get()
-    }
-
-    /// Returns true, if the [`InlineCache`]'s shape matches with the given shape.
+    /// Returns the cached `(Shape, Slot)` if a matching shape exists in the inline cache.
     ///
     /// Otherwise we reset the internal weak reference to [`WeakShape::None`],
     /// so it can be deallocated by the GC.
     pub(crate) fn match_or_reset(&self, shape: &Shape) -> Option<(Shape, Slot)> {
-        let mut old = self.shape.borrow_mut();
-
-        let old_upgraded = old.upgrade();
-        if old_upgraded.as_ref().map_or(0, Shape::to_addr_usize) == shape.to_addr_usize() {
-            return old_upgraded.map(|shape| (shape, self.slot()));
+        if self.megamorphic.get() {
+            return None;
         }
 
-        *old = WeakShape::None;
-        None
+        let mut entries = self.entries.borrow_mut();
+        let mut i = 0;
+        let mut result = None;
+        let shape_addr = shape.to_addr_usize();
+
+        while i < entries.0.len() {
+            if let Some(upgraded) = entries.0[i].shape.upgrade() {
+                if upgraded.to_addr_usize() == shape_addr {
+                    result = Some((upgraded, entries.0[i].slot));
+                    break;
+                }
+                i += 1;
+            } else {
+                // Opportunistically clean up stale weak shapes.
+                entries.0.remove(i);
+            }
+        }
+
+        result
+    }
+
+    pub(crate) fn first_shape_addr(&self) -> usize {
+        self.entries
+            .borrow()
+            .0
+            .first()
+            .and_then(|e| e.shape.upgrade())
+            .map_or(0, |s| s.to_addr_usize())
     }
 }

--- a/core/engine/src/vm/inline_cache/tests.rs
+++ b/core/engine/src/vm/inline_cache/tests.rs
@@ -6,8 +6,7 @@ use crate::{
     builtins::{OrdinaryObject, function::OrdinaryFunction},
     js_string,
     object::{
-        ObjectInitializer,
-        internal_methods::InternalMethodPropertyContext,
+        ObjectInitializer, internal_methods::InternalMethodPropertyContext,
         shape::slot::SlotAttributes,
     },
     property::{Attribute, PropertyDescriptor, PropertyKey},
@@ -331,7 +330,7 @@ fn set_property_by_name_set_inline_cache_on_property_load() -> JsResult<()> {
     let (function, code) = get_codeblock(&function).unwrap();
 
     assert_eq!(code.ic.len(), 1);
-    assert_eq!(code.ic[0].entries.borrow().0.len(), 0);
+    assert_eq!(code.ic[0].entries.borrow().len(), 0);
 
     let o = ObjectInitializer::new(context)
         .property(js_string!("test"), 0, Attribute::all())
@@ -340,9 +339,9 @@ fn set_property_by_name_set_inline_cache_on_property_load() -> JsResult<()> {
 
     function.call(&JsValue::undefined(), &[o.clone().into()], context)?;
 
-    assert_eq!(code.ic[0].entries.borrow().0.len(), 1);
+    assert_eq!(code.ic[0].entries.borrow().len(), 1);
     assert_eq!(
-        code.ic[0].entries.borrow().0[0]
+        code.ic[0].entries.borrow()[0]
             .shape
             .upgrade()
             .unwrap()
@@ -360,7 +359,7 @@ fn get_property_by_name_set_inline_cache_on_property_load() -> JsResult<()> {
     let (function, code) = get_codeblock(&function).unwrap();
 
     assert_eq!(code.ic.len(), 1);
-    assert_eq!(code.ic[0].entries.borrow().0.len(), 0);
+    assert_eq!(code.ic[0].entries.borrow().len(), 0);
 
     let o = ObjectInitializer::new(context)
         .property(js_string!("test"), 0, Attribute::all())
@@ -369,9 +368,9 @@ fn get_property_by_name_set_inline_cache_on_property_load() -> JsResult<()> {
 
     function.call(&JsValue::undefined(), &[o.clone().into()], context)?;
 
-    assert_eq!(code.ic[0].entries.borrow().0.len(), 1);
+    assert_eq!(code.ic[0].entries.borrow().len(), 1);
     assert_eq!(
-        code.ic[0].entries.borrow().0[0]
+        code.ic[0].entries.borrow()[0]
             .shape
             .upgrade()
             .unwrap()
@@ -389,7 +388,7 @@ fn test_polymorphic_inline_cache() -> JsResult<()> {
     let (function, code) = get_codeblock(&function).unwrap();
 
     assert_eq!(code.ic.len(), 1);
-    assert_eq!(code.ic[0].entries.borrow().0.len(), 0);
+    assert_eq!(code.ic[0].entries.borrow().len(), 0);
     assert!(!code.ic[0].megamorphic.get());
 
     let shapes = vec![
@@ -414,7 +413,7 @@ fn test_polymorphic_inline_cache() -> JsResult<()> {
         function.call(&JsValue::undefined(), &[o.clone().into()], context)?;
     }
 
-    assert_eq!(code.ic[0].entries.borrow().0.len(), 4);
+    assert_eq!(code.ic[0].entries.borrow().len(), 4);
     assert!(!code.ic[0].megamorphic.get());
 
     Ok(())
@@ -452,7 +451,7 @@ fn test_megamorphic_inline_cache() -> JsResult<()> {
         function.call(&JsValue::undefined(), &[o.clone().into()], context)?;
     }
 
-    assert_eq!(code.ic[0].entries.borrow().0.len(), 0);
+    assert_eq!(code.ic[0].entries.borrow().len(), 0);
     assert!(code.ic[0].megamorphic.get());
 
     // Regression check: repeated miss should remain empty
@@ -461,7 +460,7 @@ fn test_megamorphic_inline_cache() -> JsResult<()> {
         .property(js_string!("test"), 1, Attribute::all())
         .build();
     function.call(&JsValue::undefined(), &[o6.clone().into()], context)?;
-    assert_eq!(code.ic[0].entries.borrow().0.len(), 0);
+    assert_eq!(code.ic[0].entries.borrow().len(), 0);
     assert!(code.ic[0].megamorphic.get());
 
     Ok(())

--- a/core/engine/src/vm/inline_cache/tests.rs
+++ b/core/engine/src/vm/inline_cache/tests.rs
@@ -8,7 +8,7 @@ use crate::{
     object::{
         ObjectInitializer,
         internal_methods::InternalMethodPropertyContext,
-        shape::{WeakShape, slot::SlotAttributes},
+        shape::slot::SlotAttributes,
     },
     property::{Attribute, PropertyDescriptor, PropertyKey},
     vm::CodeBlock,

--- a/core/engine/src/vm/opcode/get/name.rs
+++ b/core/engine/src/vm/opcode/get/name.rs
@@ -60,7 +60,7 @@ impl GetNameGlobal {
             let ic = &context.vm.frame().code_block().ic[usize::from(ic_index)];
 
             let object_borrowed = object.borrow();
-            if let Some((shape, slot)) = ic.match_or_reset(object_borrowed.shape()) {
+            if let Some((shape, slot)) = ic.get(object_borrowed.shape()) {
                 let mut result = if slot.attributes.contains(SlotAttributes::PROTOTYPE) {
                     let prototype = shape.prototype().expect("prototype should have value");
                     let prototype = prototype.borrow();

--- a/core/engine/src/vm/opcode/get/property.rs
+++ b/core/engine/src/vm/opcode/get/property.rs
@@ -39,7 +39,7 @@ fn get_by_name<const LENGTH: bool>(
 
     let ic = &context.vm.frame().code_block().ic[usize::from(index)];
     let object_borrowed = object.borrow();
-    if let Some((shape, slot)) = ic.match_or_reset(object_borrowed.shape()) {
+    if let Some((shape, slot)) = ic.get(object_borrowed.shape()) {
         let mut result = if slot.attributes.contains(SlotAttributes::PROTOTYPE) {
             let prototype = shape.prototype().expect("prototype should have value");
             let prototype = prototype.borrow();

--- a/core/engine/src/vm/opcode/set/property.rs
+++ b/core/engine/src/vm/opcode/set/property.rs
@@ -24,7 +24,7 @@ fn set_by_name(
     let ic = &context.vm.frame().code_block().ic[usize::from(index)];
 
     let object_borrowed = object.borrow();
-    if let Some((shape, slot)) = ic.match_or_reset(object_borrowed.shape()) {
+    if let Some((shape, slot)) = ic.get(object_borrowed.shape()) {
         let slot_index = slot.index as usize;
 
         if slot.attributes.is_accessor_descriptor() {

--- a/core/gc/Cargo.toml
+++ b/core/gc/Cargo.toml
@@ -19,6 +19,8 @@ icu = ["dep:icu_locale_core"]
 boa_string = ["dep:boa_string"]
 # Enable default implementations of trace and finalize for the `either` crate
 either = ["dep:either"]
+# Enable default implementations of trace and finalize for the arrayvec crate
+arrayvec = ["dep:arrayvec"]
 
 [dependencies]
 boa_macros.workspace = true
@@ -28,6 +30,7 @@ boa_string = { workspace = true, optional = true }
 either = { workspace = true, optional = true }
 thin-vec = { workspace = true, optional = true }
 icu_locale_core = { workspace = true, optional = true }
+arrayvec = { workspace = true, optional = true }
 
 [lints]
 workspace = true

--- a/core/gc/src/trace.rs
+++ b/core/gc/src/trace.rs
@@ -365,6 +365,19 @@ unsafe impl<T: Trace> Trace for thin_vec::ThinVec<T> {
     });
 }
 
+#[cfg(feature = "arrayvec")]
+impl<T: Trace, const N: usize> Finalize for arrayvec::ArrayVec<T, N> {}
+
+#[cfg(feature = "arrayvec")]
+// SAFETY: All the inner elements of the `ArrayVec` are correctly marked.
+unsafe impl<T: Trace, const N: usize> Trace for arrayvec::ArrayVec<T, N> {
+    custom_trace!(this, mark, {
+        for e in this {
+            mark(e);
+        }
+    });
+}
+
 impl<T: Trace> Finalize for Option<T> {}
 // SAFETY: The inner value of the `Option` is correctly marked.
 unsafe impl<T: Trace> Trace for Option<T> {


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request fixes/closes #4656.

Currently Boa uses a **monomorphic inline cache** for property access sites, storing a single `(Shape → Slot)` mapping. When the shape does not match, the cache is reset, which causes frequent cache invalidation when accessing the same property across objects with different shapes.

This PR upgrades the inline cache to a **polymorphic inline cache (PIC)** to better support polymorphic property access patterns commonly seen in JavaScript.

It changes the following:

- Replace the monomorphic inline cache with a **polymorphic inline cache (PIC)** that stores multiple `(Shape → Slot)` mappings per access site using a small fixed-capacity cache (`PIC_CAPACITY = 4`).
- Add support for a **megamorphic state**, where the cache is disabled after observing too many shapes to avoid unnecessary overhead.
- Update inline cache lookup and insertion logic to support multiple cached shapes and opportunistic cleanup of stale weak shape references.
- Update disassembly output to correctly display the cached shape information for PIC.
- Add tests covering **polymorphic** and **megamorphic** inline cache behavior.

This change reduces inline cache thrashing for polymorphic property access patterns and aligns Boa's inline cache design more closely with modern JavaScript engines.