### PR TITLE
feat(runtime): implement console.table()

### DIFF
--- a/core/runtime/src/console/tests.rs
+++ b/core/runtime/src/console/tests.rs
@@ -339,6 +339,83 @@ fn console_namespace_object_class_string() {
 }
 
 #[test]
+fn console_table_array_of_primitives() {
+    let mut context = Context::default();
+    let logger = RecordingLogger::default();
+    Console::register_with_logger(logger.clone(), &mut context).unwrap();
+
+    run_test_actions_with(
+        [TestAction::run(indoc! {r#"
+            console.table(["foo", "bar", "baz"]);
+        "#})],
+        &mut context,
+    );
+
+    let logs = logger.log.borrow().clone();
+    assert!(logs.contains("(index)"), "missing (index) header");
+    assert!(logs.contains("Values"), "missing Values header");
+    assert!(logs.contains("foo"), "missing foo");
+    assert!(logs.contains("bar"), "missing bar");
+    assert!(logs.contains("0"), "missing index 0");
+}
+
+#[test]
+fn console_table_array_of_objects() {
+    let mut context = Context::default();
+    let logger = RecordingLogger::default();
+    Console::register_with_logger(logger.clone(), &mut context).unwrap();
+
+    run_test_actions_with(
+        [TestAction::run(indoc! {r#"
+            console.table([{ a: 1, b: "foo" }, { a: 2, b: "bar" }]);
+        "#})],
+        &mut context,
+    );
+
+    let logs = logger.log.borrow().clone();
+    assert!(logs.contains("(index)"), "missing (index) header");
+    assert!(logs.contains("a"), "missing column a");
+    assert!(logs.contains("b"), "missing column b");
+    assert!(logs.contains("foo"), "missing foo");
+    assert!(logs.contains("1"), "missing value 1");
+}
+
+#[test]
+fn console_table_with_properties_filter() {
+    let mut context = Context::default();
+    let logger = RecordingLogger::default();
+    Console::register_with_logger(logger.clone(), &mut context).unwrap();
+
+    run_test_actions_with(
+        [TestAction::run(indoc! {r#"
+            console.table([{ a: 1, b: "foo" }, { a: 2, b: "bar" }], ["a"]);
+        "#})],
+        &mut context,
+    );
+
+    let logs = logger.log.borrow().clone();
+    assert!(logs.contains("a"), "missing column a");
+    assert!(!logs.contains("foo"), "column b should be filtered out");
+}
+
+#[test]
+fn console_table_non_object_fallback() {
+    let mut context = Context::default();
+    let logger = RecordingLogger::default();
+    Console::register_with_logger(logger.clone(), &mut context).unwrap();
+
+    run_test_actions_with(
+        [TestAction::run(indoc! {r#"
+            console.table("just a string");
+        "#})],
+        &mut context,
+    );
+
+    let logs = logger.log.borrow().clone();
+    assert!(logs.contains("just a string"), "should fall back to log");
+}
+
+#[test]
 fn trace_with_stack_trace() {
     let mut context = Context::default();
     let logger = RecordingLogger::default();


### PR DESCRIPTION
## Summary

Implements `console.table(tabularData, properties?)` per the [WHATWG console spec](https://console.spec.whatwg.org/#table).

### Behaviour
- Renders an ASCII box-drawing table with an `(index)` column plus one column per object property
- Arrays of primitives use a `Values` column
- The optional `properties` argument filters which columns are shown
- Falls back to `console.log` behaviour when `tabularData` is not an object
- Uses `Object.keys()` to enumerate only enumerable own properties (correctly excludes e.g. `Array.prototype.length`)

### Example
```js
console.table([{name: "Alice", age: 30}, {name: "Bob", age: 25}])
```
```
┌─────────┬───────┬─────┐
│ (index) │ name  │ age │
├─────────┼───────┼─────┤
│    0    │ Alice │ 30  │
│    1    │  Bob  │ 25  │
└─────────┴───────┴─────┘
```

## Test plan
- [x] `console_table_array_of_primitives`
- [x] `console_table_array_of_objects`
- [x] `console_table_with_properties_filter`
- [x] `console_table_non_object_fallback`
