### PR TITLE
docs: add doctests for JsObject methods

### DIFF
--- a/core/engine/src/object/jsobject.rs
+++ b/core/engine/src/object/jsobject.rs
@@ -305,10 +305,6 @@ impl JsObject {
     }
 
     /// Checks if it's an `Array` object.
-    #[inline]
-    #[must_use]
-    #[track_caller]
-    /// Checks if it's an `Array` object.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
This Pull Request is part of #3952.

It changes the following:
- Adds doctests for `JsObject::is_array`
- Adds doctests for `JsObject::deep_strict_equals`
- Adds doctests for `JsObject::equals`
- Adds doctests for `JsObject::is_callable`
- Adds doctests for `JsObject::is_constructor`