### PR TITLE
fix: handle accessor descriptors in array display

### DIFF
--- a/core/engine/src/value/display.rs
+++ b/core/engine/src/value/display.rs
@@ -152,7 +152,7 @@ fn log_array_to(
                         f.write_str(display)?;
                     }
                     DescriptorKind::Generic => {
-                        f.write_str("undefined")?;
+                        unreachable!("found generic descriptor in array")
                     }
                 }
             } else {


### PR DESCRIPTION
## Summary
Fixes two FIXMEs in `display.rs` where accessor property descriptors (getters/setters) were not handled when displaying arrays.

---

## Problem

- **`length` property** — used `.expect_value()` which panics if the property is an accessor descriptor instead of a data property.
- **Array elements** — used `.value().cloned()` which returns `None` for accessor descriptors, causing getter/seter properties to incorrectly display as `<empty>`.

---

## Changes

- Replaced `.expect_value().as_number()` with:

  ```rust
  .value().and_then(|v| v.as_number())

Closes #4750 
