### PR TITLE
## Console: Improve `%o` / `%O` Object Formatting

### DIFF
--- a/core/runtime/src/console/mod.rs
+++ b/core/runtime/src/console/mod.rs
@@ -182,10 +182,10 @@ fn formatter(data: &[JsValue], context: &mut Context) -> JsResult<String> {
                             let _ = write!(formatted, "{arg:.6}");
                             arg_index += 1;
                         }
-                        /* object, FIXME: how to render this properly? */
+                        /* object: use internals mode for richer inspection */
                         'o' | 'O' => {
                             let arg = data.get_or_undefined(arg_index);
-                            formatted.push_str(&arg.display().to_string());
+                            formatted.push_str(&arg.display().internals(true).to_string());
                             arg_index += 1;
                         }
                         /* string */


### PR DESCRIPTION
### Summary

Updated `%o` / `%O` handling in `console` formatting to use rich object inspection instead of the default `%s`-equivalent output.

This ensures objects are formatted using structured inspection instead of being coerced into string form.

Closes #4761

---

### Changes

**File:** `mod.rs` (lines 185–190)

Replaced:

```rust
arg.display().to_string()
