### PR TITLE
ci: actions bot includes tested pr commit hash in the conformance message

### DIFF
--- a/.github/workflows/test262.yml
+++ b/.github/workflows/test262.yml
@@ -66,7 +66,7 @@ jobs:
           echo "comment<<EOF" >> $GITHUB_OUTPUT
           echo "$comment" >> $GITHUB_OUTPUT
           echo "" >> $GITHUB_OUTPUT
-          echo "Tested PR commit: \`${{ github.event.pull_request.head.sha }}\`" >> $GITHUB_OUTPUT
+          echo "Tested PR commit: [\`${{ github.event.pull_request.head.sha }}\`](${{ github.event.pull_request.head.repo.html_url }}/commit/${{ github.event.pull_request.head.sha }})" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Get the PR number


### PR DESCRIPTION
Closes #4760

Took more time than expected because i didnt know trigger conditions of github actions well enough :joy: 

Demo (https://github.com/zhuzhu81998/boa/pull/2):
<img width="1626" height="1438" alt="image" src="https://github.com/user-attachments/assets/816cb3e5-d081-47ed-bbed-2c29b543f808" />
