### PR TITLE
Fix `Date.prototype.toISOString` formatting year 0 as `-000000` instead of `0000`

### DIFF
--- a/core/engine/src/builtins/date/mod.rs
+++ b/core/engine/src/builtins/date/mod.rs
@@ -1540,9 +1540,9 @@ impl Date {
         // 6. Return a String representation of tv in the Date Time String Format on the UTC time scale,
         //    including all format elements and the UTC offset representation "Z".
         let year = year_from_time(tv);
-        let year = if year.is_positive() && year >= 10000 {
+        let year = if year >= 0 && year >= 10000 {
             js_string!(js_str!("+"), pad_six(year.unsigned_abs(), &mut [0; 6]))
-        } else if year.is_positive() {
+        } else if year >= 0 {
             pad_four(year.unsigned_abs(), &mut [0; 4]).into()
         } else {
             js_string!(js_str!("-"), pad_six(year.unsigned_abs(), &mut [0; 6]))

--- a/core/engine/src/builtins/date/tests.rs
+++ b/core/engine/src/builtins/date/tests.rs
@@ -828,6 +828,14 @@ fn date_proto_to_iso_string() {
 }
 
 #[test]
+fn date_proto_to_iso_string_year_zero() {
+    run_test_actions([TestAction::assert_eq(
+        r#"new Date("0000-06-15T00:00:00Z").toISOString()"#,
+        js_str!("0000-06-15T00:00:00.000Z"),
+    )]);
+}
+
+#[test]
 fn date_proto_to_json() {
     run_test_actions([TestAction::assert_eq(
         "new Date(Date.UTC(2020, 6, 8, 9, 16, 15, 779)).toJSON()",


### PR DESCRIPTION
Fixes #4773

`toISOString()` was producing `-000000` for year 0 because `0i32.is_positive()` is `false` in Rust, causing year 0 to fall into the negative/extended-year branch.

Changed `year.is_positive()` to `year >= 0` so year 0 correctly uses the 4-digit format.

Added a unit test for the fix.