### PR TITLE
Share `alreadyCalled` record between `Promise.allSettled` resolve/reject handlers

### DIFF
--- a/core/engine/src/builtins/promise/mod.rs
+++ b/core/engine/src/builtins/promise/mod.rs
@@ -873,10 +873,12 @@ impl Promise {
             let next_promise =
                 promise_resolve.call(&constructor.clone().into(), &[next], context)?;
 
+            // h. Let alreadyCalled be the Record { [[Value]]: false }.
+            let already_called = Rc::new(Cell::new(false));
+
             // e. Let stepsFulfilled be the algorithm steps defined in Promise.allSettled Resolve Element Functions.
             // f. Let lengthFulfilled be the number of non-optional parameters of the function definition in Promise.allSettled Resolve Element Functions.
             // g. Let onFulfilled be CreateBuiltinFunction(stepsFulfilled, lengthFulfilled, "", « [[AlreadyCalled]], [[Index]], [[Values]], [[Capability]], [[RemainingElements]] »).
-            // h. Let alreadyCalled be the Record { [[Value]]: false }.
             // i. Set onFulfilled.[[AlreadyCalled]] to alreadyCalled.
             // j. Set onFulfilled.[[Index]] to index.
             // k. Set onFulfilled.[[Values]] to values.
@@ -951,7 +953,7 @@ impl Promise {
                         Ok(JsValue::undefined())
                     },
                     ResolveRejectElementCaptures {
-                        already_called: Rc::new(Cell::new(false)),
+                        already_called: already_called.clone(),
                         index,
                         values: values.clone(),
                         capability: result_capability.functions.resolve.clone(),
@@ -1041,7 +1043,7 @@ impl Promise {
                         Ok(JsValue::undefined())
                     },
                     ResolveRejectElementCaptures {
-                        already_called: Rc::new(Cell::new(false)),
+                        already_called,
                         index,
                         values: values.clone(),
                         capability: result_capability.functions.resolve.clone(),


### PR DESCRIPTION
Fixes #4777

The `onFulfilled` and `onRejected` handlers in `perform_promise_all_settled` each created their own `Rc::new(Cell::new(false))` for `alreadyCalled`. Per spec (§27.2.4.5.4 step h), both must share a single record so at most one handler fires per element.

Creates the `Rc` once before both closures and clones it into each.