### PR TITLE
Reject `Date.parse` hour 24 with non-zero minutes/seconds/ms

### DIFF
--- a/core/engine/src/builtins/date/tests.rs
+++ b/core/engine/src/builtins/date/tests.rs
@@ -896,3 +896,16 @@ fn date_json() {
         js_string!(r#"{"date":"2020-07-08T09:16:15.779Z"}"#),
     )]);
 }
+
+#[test]
+fn date_parse_hour24_validation() {
+    run_test_actions([
+        // 24:00:00.000 is valid (midnight end-of-day)
+        TestAction::assert("!isNaN(Date.parse('2024-01-01T24:00:00Z'))"),
+        TestAction::assert("!isNaN(Date.parse('2024-01-01T24:00:00.000Z'))"),
+        // hour 24 with non-zero minutes/seconds/ms must be NaN
+        TestAction::assert("isNaN(Date.parse('2024-01-01T24:30:00Z'))"),
+        TestAction::assert("isNaN(Date.parse('2024-01-01T24:00:01Z'))"),
+        TestAction::assert("isNaN(Date.parse('2024-01-01T24:00:00.001Z'))"),
+    ]);
+}

--- a/core/engine/src/builtins/date/utils.rs
+++ b/core/engine/src/builtins/date/utils.rs
@@ -910,6 +910,11 @@ impl<'a> DateParser<'a> {
             return None;
         }
 
+        // Hour 24 is only valid as 24:00:00.000
+        if self.hour == 24 && (self.minute != 0 || self.second != 0 || self.millisecond != 0) {
+            return None;
+        }
+
         let date = make_date(
             make_day(self.year.into(), (self.month - 1).into(), self.day.into()),
             make_time(
@@ -928,6 +933,11 @@ impl<'a> DateParser<'a> {
 
     fn finish_local(&mut self) -> Option<i64> {
         if self.input.peek().is_some() {
+            return None;
+        }
+
+        // Hour 24 is only valid as 24:00:00.000
+        if self.hour == 24 && (self.minute != 0 || self.second != 0 || self.millisecond != 0) {
             return None;
         }
 


### PR DESCRIPTION
Fixes #4779

`Date.parse` accepted strings like `"2024-01-01T24:30:00Z"` instead of returning `NaN`. Per spec, hour 24 is only valid as `24:00:00.000`.

Added validation in `finish()` and `finish_local()` to reject hour 24 when minute, second, or millisecond is non-zero. Added tests.