### PR TITLE
refactor: replace from_utf8_unchecked with safe from_utf8

### DIFF
--- a/core/engine/src/builtins/date/utils.rs
+++ b/core/engine/src/builtins/date/utils.rs
@@ -759,8 +759,7 @@ pub(super) fn parse_date(date: &JsString, hooks: &dyn HostHooks) -> Option<i64> 
             if !s.is_ascii() {
                 return None;
             }
-            // SAFETY: Since all characters are ASCII we can safely convert this into str.
-            Cow::Borrowed(unsafe { str::from_utf8_unchecked(s) })
+            Cow::Borrowed(str::from_utf8(s).expect("s is ASCII, which is always valid UTF-8"))
         }
         JsStrVariant::Utf16(s) => {
             let date = String::from_utf16(s).ok()?;

--- a/core/parser/src/lexer/number.rs
+++ b/core/parser/src/lexer/number.rs
@@ -391,7 +391,8 @@ impl<R> Tokenizer<R> for NumberLiteral {
 
         check_after_numeric_literal(cursor)?;
 
-        let num_str = unsafe { str::from_utf8_unchecked(buf.as_slice()) };
+        let num_str = str::from_utf8(buf.as_slice())
+            .expect("buf only contains ASCII digits and is always valid UTF-8");
         let num = match kind {
             NumericKind::BigInt(base) => {
                 Numeric::BigInt(


### PR DESCRIPTION
Addresses #4181 

- Replaced `from_utf8_unchecked` with safe `from_utf8` in core/parser/src/lexer/number.rs - buf only contains ASCII bytes
- Same in core/engine/src/builtins/date/utils.rs - ASCII is already checked on the line above