### PR TITLE
fix: handle BigInt shift by amounts exceeding i32 range

### DIFF
--- a/core/engine/src/builtins/bigint/tests.rs
+++ b/core/engine/src/builtins/bigint/tests.rs
@@ -137,12 +137,17 @@ fn operations() {
             "Maximum BigInt size exceeded",
         ),
         TestAction::assert_eq("8n >> 2n", JsBigInt::from(2)),
-        // TODO: this should return 0n instead of throwing
-        TestAction::assert_native_error(
-            "1000n >> 1000000000000000n",
-            JsNativeErrorKind::Range,
-            "Maximum BigInt size exceeded",
-        ),
+        // Right-shifting by a huge positive amount should return 0n for positive x
+        TestAction::assert_eq("1000n >> 1000000000000000n", JsBigInt::from(0)),
+        // Right-shifting a negative number by a huge positive amount should return -1n
+        TestAction::assert_eq("-1000n >> 1000000000000000n", JsBigInt::from(-1)),
+        // Zero right-shifted by any amount should be 0n
+        TestAction::assert_eq("0n >> 1000000000000000n", JsBigInt::from(0)),
+        // Left-shifting by a huge negative amount (equivalent to right shift)
+        TestAction::assert_eq("1000n << -1000000000000000n", JsBigInt::from(0)),
+        TestAction::assert_eq("-1000n << -1000000000000000n", JsBigInt::from(-1)),
+        // Zero left-shifted by any amount should be 0n
+        TestAction::assert_eq("0n << 1000000000000000n", JsBigInt::from(0)),
     ]);
 }
 


### PR DESCRIPTION
## Description

Fixes #4783

When the shift amount for BigInt `>>` or `<<` operations exceeds the `i32` range, the operations threw `RangeError: Maximum BigInt size exceeded` unconditionally. This was incorrect per the ECMAScript specification.

### Changes

**`core/engine/src/bigint.rs`:**
- **`shift_right`**: When `y.to_i32()` returns `None`:
  - If `x` is `0n`, return `0n`
  - If `y > 0` (huge right shift): return `0n` for non-negative `x`, `-1n` for negative `x`
  - If `y < 0` (equivalent to huge left shift): keep the RangeError
- **`shift_left`**: When `y.to_i32()` returns `None`:
  - If `x` is `0n`, return `0n`
  - If `y < 0` (huge negative = huge right shift): return `0n` for non-negative `x`, `-1n` for negative `x`
  - If `y > 0` (huge positive left shift): keep the RangeError

**`core/engine/src/builtins/bigint/tests.rs`:**
- Replaced the TODO/`assert_native_error` test with correct assertions for `0n`, `-1n`, and `0n` results
- Added tests for negative `x`, zero `x`, and both shift directions

### Spec References
- [§6.1.6.2.9 BigInt::leftShift](https://tc39.es/ecma262/#sec-numeric-types-bigint-leftShift)
- [§6.1.6.2.10 BigInt::signedRightShift](https://tc39.es/ecma262/#sec-numeric-types-bigint-signedRightShift)

### Test Results
All 889 existing tests pass + new tests for the added edge cases.