### PR TITLE
docs(error): document panics in `JsNativeError::with_cause` and `into_opaque`

### DIFF
--- a/core/engine/src/error/mod.rs
+++ b/core/engine/src/error/mod.rs
@@ -1218,6 +1218,10 @@ impl JsNativeError {
     ///
     /// assert!(error.cause().unwrap().as_native().is_some());
     /// ```
+    ///
+    /// # Panics
+    ///
+    /// Panics if `cause` is an uncatchable error (i.e. an engine error).
     #[must_use]
     #[inline]
     pub fn with_cause<V>(mut self, cause: V) -> Self
@@ -1295,6 +1299,13 @@ impl JsNativeError {
     ///     js_string!("error!").into()
     /// )
     /// ```
+    ///
+    /// # Panics
+    ///
+    /// Panics if the error's `cause` or any of the errors in an [`AggregateError`][JsNativeErrorKind::Aggregate]
+    /// is an engine error, as engine errors cannot be converted to opaque JS values.
+    /// Also panics if defining the `errors` property on an `AggregateError` object fails,
+    /// which cannot happen on a newly created object.
     #[inline]
     pub fn into_opaque(self, context: &mut Context) -> JsObject {
         let Self {


### PR DESCRIPTION
Closes part of #3241

Adds `# Panics` documentation sections to two public methods in `JsNativeError`:

- `with_cause`: panics if the provided cause is an uncatchable engine error
- `into_opaque`: panics if the error's cause or any errors in an `AggregateError` 
  is an engine error, and if `define_property_or_throw` fails on a newly created object 
  (which the spec guarantees cannot happen)

These panics were previously undocumented, triggering the `missing_panics_doc` clippy lint.