### PR TITLE
fix(cli): clear WeakRef kept objects after job execution to prevent memory growth

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -809,6 +809,8 @@ impl JobExecutor for Executor {
                     }
                 }
             }
+            context.borrow_mut().clear_kept_objects();
+            future::yield_now().await;
         }
     }
 }


### PR DESCRIPTION
## **Summary**

The CLI executor (`cli/src/main.rs`) was missing a call to `clear_kept_objects()` inside `Executor::run_jobs_async`.

Unlike `SimpleJobExecutor` and the example event loops, the CLI never cleared `Context::kept_alive`, which is used to temporarily root `WeakRef` targets during job execution.

As a result, objects touched via `WeakRef` were permanently retained for the lifetime of the CLI session.

---

## **Problem**

In `Executor::run_jobs_async`, jobs were drained, but kept objects were never cleared:

```rust
{
    let context = &mut context.borrow_mut();
    self.drain_timeout_jobs(context);
    self.drain_generic_jobs(context);

    let jobs = mem::take(&mut *self.promise_jobs.borrow_mut());
    for job in jobs {
        job.call(context)?;
    }
}
// no clear_kept_objects() here
```

By contrast, `SimpleJobExecutor` correctly performs:

```rust
context.borrow_mut().clear_kept_objects();
future::yield_now().await;
```

Because `WeakRef::constructor` and `WeakRef::deref` push objects into `context.kept_alive`, failing to clear this vector keeps all such objects strongly reachable indefinitely.

---

## **Steps to Reproduce**

Run in the CLI:

```js
let refs = [];
for (let i = 0; i < 100000; i++) {
    let obj = { data: new Array(10000).fill(0) };
    refs.push(new WeakRef(obj));
}
```

Expected:

* GC reclaims `obj` instances.
* Memory stabilizes.

Actual (before fix):

* `kept_alive` retains all objects.
* Memory usage grows continuously.
* `WeakRef.deref()` never returns `undefined`.

---

## **Impact**

* Unbounded memory growth in long-running CLI sessions.
* `WeakRef` semantics effectively broken in the CLI.
* GC cannot reclaim objects that should be collectible.
* Potential 100% CPU spin when async jobs are pending (no yield).

This affects the primary user-facing binary (`cargo run --bin boa`).

---

## **Fix**

Add the missing spec-mandated cleanup and yield at the end of each loop iteration:

```rust
context.borrow_mut().clear_kept_objects();
future::yield_now().await;
```

This aligns the CLI executor with:

* `SimpleJobExecutor`
* `smol_event_loop`
* `tokio_event_loop`

---

## **Result**

* `WeakRef` targets become eligible for GC after each job batch.
* Memory stabilizes in long-running CLI sessions.
* `weakRef.deref()` behaves correctly per spec.
* Async jobs no longer risk busy-spinning.
* No behavioral change for scripts not using `WeakRef`.

The CLI executor now conforms to ECMAScript `ClearKeptObjects` semantics and matches the behavior of other executors in the codebase.
