### PR TITLE
fix(number): make toExponential spec-compliant (ties-away-from-zero)

### DIFF
--- a/core/engine/src/builtins/number/tests.rs
+++ b/core/engine/src/builtins/number/tests.rs
@@ -35,6 +35,10 @@ fn to_exponential() {
             js_str!("NaN"),
         ),
         TestAction::assert_eq("Number('1.23e+2').toExponential()", js_str!("1.23e+2")),
+        TestAction::assert_eq("Number(1.25).toExponential(1)", js_str!("1.3e+0")),
+        TestAction::assert_eq("Number(-1.25).toExponential(1)", js_str!("-1.3e+0")),
+        TestAction::assert_eq("Number(1.35).toExponential(1)", js_str!("1.4e+0")),
+        TestAction::assert_eq("Number(1.75).toExponential(1)", js_str!("1.8e+0")),
     ]);
 }
 


### PR DESCRIPTION
Rust's `std::fmt` performs IEEE 754 round-half-to-even (banker's rounding),
which diverges from ECMAScript in true tie cases.

Example:

(1.25).toExponential(1)

Expected (Node / ECMAScript):
1.3e+0

Previous Boa output:
1.2e+0
### BEFORE
<img width="591" height="128" alt="Screenshot 2026-03-02 at 10 42 27 AM" src="https://github.com/user-attachments/assets/8f1e54a3-ae14-4961-89db-7a7b1056dd59" />
<img width="763" height="236" alt="Screenshot 2026-03-02 at 10 46 05 AM" src="https://github.com/user-attachments/assets/6a9796eb-f6fd-4c41-b70b-ef2e6744dd8b" />

ECMAScript §21.1.3.26 specifies that if two representations are equally
close, the one with the larger magnitude must be selected.
This corresponds to ties-away-from-zero rounding.

This PR removes reliance on Rust's formatter for precision rounding
and implements explicit ECMAScript-compliant rounding before formatting.

This Pull Request fixes/closes #{issue_num}.

Changes:
- Replace banker’s rounding in `f64_to_exponential_with_precision`
  with ties-away-from-zero rounding
- Ensure correct behavior for both positive and negative values
- Handle carry overflow cases (e.g. 9.99 → 1.00e+1)
- Add regression tests for true tie cases:
  - (1.25).toExponential(1)
  - (-1.25).toExponential(1)

Impact:
### AFTER
<img width="652" height="89" alt="Screenshot 2026-03-02 at 11 38 25 AM" src="https://github.com/user-attachments/assets/ae8db210-7469-455b-a4c2-5953bbf8a4f3" />
<img width="652" height="142" alt="Screenshot 2026-03-02 at 11 38 57 AM" src="https://github.com/user-attachments/assets/60d16264-59e9-48f3-b21f-8d31f64e71e6" />

- Affects only Number.prototype.toExponential
- No VM-level changes
- Improves ECMAScript conformance