### PR TITLE
fix(ci): ensure codecov runs for internal PRs targeting main

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,7 +24,7 @@ jobs:
     name: Coverage
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    if: ${{ github.ref == 'refs/heads/main' || github.base_ref == 'main' }}
+    if: ${{ github.ref == 'refs/heads/main' || github.event_name == 'pull_request' }}
     steps:
       - name: Set environment
         # Setting `RUSTFLAGS` overrides any flags set on .cargo/config.toml, so we need to


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request fixes/closes #4179.

It changes the following:

- The coverage job was not running for pull requests created from branches within the same repository due to the previous condition:

```yaml
if: ${{ github.ref == 'refs/heads/main' || github.base_ref == 'main' }}
```
- So, now to ensure that this to work for every pr we need to change this to
```yaml
 if: ${{ github.ref == 'refs/heads/main' || github.event_name = 'pull_request' }}
```
- This updates the condition to ensure the coverage job runs for all `pull_request` events as well as pushes to main, so Codecov comments are posted consistently for both internal and fork PRs.