### PR TITLE
Revert commit dc2f73695a786ac7206be84c634c18af19f7e1bd

### DIFF
--- a/core/engine/src/bytecompiler/expression/unary.rs
+++ b/core/engine/src/bytecompiler/expression/unary.rs
@@ -39,12 +39,11 @@ impl ByteCompiler<'_> {
                         let identifier = identifier.to_js_string(self.interner());
                         let binding = self.lexical_scope.get_identifier_reference(identifier);
                         let index = self.get_binding(&binding);
-                        let opcode = if binding.is_lexical() {
-                            BindingAccessOpcode::GetName
-                        } else {
-                            BindingAccessOpcode::GetNameOrUndefined
-                        };
-                        self.emit_binding_access(opcode, &index, dst);
+                        self.emit_binding_access(
+                            BindingAccessOpcode::GetNameOrUndefined,
+                            &index,
+                            dst,
+                        );
                     }
                     expr => self.compile_expr(expr, dst),
                 }


### PR DESCRIPTION
Uhh the original code was already correct; `emit_binding_access` already checks if the binding is lexical or not.
