### PR TITLE
feat(error): add Panic variant to EngineError

### DIFF
--- a/core/engine/src/error/mod.rs
+++ b/core/engine/src/error/mod.rs
@@ -335,11 +335,7 @@ pub enum EngineError {
     RuntimeLimit(#[from] RuntimeLimitError),
 
     /// Error thrown when an internal panic condition is encountered.
-    ///
-    /// This error is used to convert panics into recoverable errors that bubble
-    /// up to the host application without crashing the process. It cannot be
-    /// caught from within ECMAScript code.
-    #[error("PanicError: {message}")]
+    #[error("EnginePanic: {message}")]
     Panic {
         /// The original panic message providing context about what went wrong.
         message: String,


### PR DESCRIPTION
Part of #3241

Adds a new `Panic` variant to `EngineError` with a `message: String` field to provide context about the original panic condition.

This variant will be used to convert panics across `boa_engine` intorecoverable errors that bubble up to the host application without crashing the process, and cannot be caught from within ECMAScript code.

`Copy` was removed from `EngineError` since `String` does not implement`Copy`. A manual `unsafe impl Trace` replaces `#[boa_gc(empty_trace)]`
for the same reason.