### PR TITLE
VaryingOperand now only encodes to U32

### DIFF
--- a/core/engine/src/vm/opcode/args.rs
+++ b/core/engine/src/vm/opcode/args.rs
@@ -1,6 +1,6 @@
 use thin_vec::ThinVec;
 
-use super::{VaryingOperand, VaryingOperandVariant};
+use super::VaryingOperand;
 
 /// A trait for types that can be read from a byte slice.
 ///
@@ -55,31 +55,6 @@ unsafe fn read_unchecked<T: Readable>(bytes: &[u8], offset: usize) -> T {
     unsafe { bytes.as_ptr().add(offset).cast::<T>().read_unaligned() }
 }
 
-/// The opcode argument formats of the vm.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[repr(u8)]
-enum Format {
-    U8,
-    U16,
-    U32,
-}
-
-impl From<Format> for u8 {
-    fn from(value: Format) -> Self {
-        value as u8
-    }
-}
-
-impl From<u8> for Format {
-    fn from(value: u8) -> Self {
-        match value {
-            1 => Self::U16,
-            2 => Self::U32,
-            _ => Self::U8,
-        }
-    }
-}
-
 pub(crate) trait Argument: Sized + std::fmt::Debug {
     /// Encode the argument into a byte slice
     fn encode(self, bytes: &mut Vec<u8>);
@@ -87,14 +62,6 @@ pub(crate) trait Argument: Sized + std::fmt::Debug {
     /// Decode the argument from a byte slice
     /// Returns the decoded argument and the new position after reading
     fn decode(bytes: &[u8], pos: usize) -> (Self, usize);
-}
-
-fn write_format(bytes: &mut Vec<u8>, value: Format) {
-    bytes.push(value.into());
-}
-
-fn write_u8(bytes: &mut Vec<u8>, value: u8) {
-    bytes.push(value);
 }
 
 fn write_i8(bytes: &mut Vec<u8>, value: i8) {
@@ -139,148 +106,48 @@ impl Argument for () {
 
 impl Argument for VaryingOperand {
     fn encode(self, bytes: &mut Vec<u8>) {
-        match self.variant() {
-            VaryingOperandVariant::U8(value) => {
-                write_format(bytes, Format::U8);
-                write_u8(bytes, value);
-            }
-            VaryingOperandVariant::U16(value) => {
-                write_format(bytes, Format::U16);
-                write_u16(bytes, value);
-            }
-            VaryingOperandVariant::U32(value) => {
-                write_format(bytes, Format::U32);
-                write_u32(bytes, value);
-            }
-        }
+        write_u32(bytes, self.value);
     }
 
     fn decode(bytes: &[u8], pos: usize) -> (Self, usize) {
-        let format = Format::from(bytes[pos]);
-        let pos = pos + 1;
-
-        match format {
-            Format::U8 => {
-                let (arg1, pos) = read::<u8>(bytes, pos);
-                (arg1.into(), pos)
-            }
-            Format::U16 => {
-                let (arg1, pos) = read::<u16>(bytes, pos);
-                (arg1.into(), pos)
-            }
-            Format::U32 => {
-                let (arg1, pos) = read::<u32>(bytes, pos);
-                (arg1.into(), pos)
-            }
-        }
+        let (arg1, pos) = read::<u32>(bytes, pos);
+        (arg1.into(), pos)
     }
 }
 
 impl Argument for (VaryingOperand, i8) {
     fn encode(self, bytes: &mut Vec<u8>) {
-        match self.0.variant() {
-            VaryingOperandVariant::U8(value) => {
-                write_format(bytes, Format::U8);
-                write_u8(bytes, value);
-                write_i8(bytes, self.1);
-            }
-            VaryingOperandVariant::U16(value) => {
-                write_format(bytes, Format::U16);
-                write_u16(bytes, value);
-                write_i8(bytes, self.1);
-            }
-            VaryingOperandVariant::U32(value) => {
-                write_format(bytes, Format::U32);
-                write_u32(bytes, value);
-                write_i8(bytes, self.1);
-            }
-        }
+        write_u32(bytes, self.0.value);
+        write_i8(bytes, self.1);
     }
 
     fn decode(bytes: &[u8], pos: usize) -> (Self, usize) {
-        let format = Format::from(bytes[pos]);
-        let pos = pos + 1;
-
-        match format {
-            Format::U8 => {
-                let ((arg1, arg2), pos) = read::<(u8, i8)>(bytes, pos);
-                ((arg1.into(), arg2), pos)
-            }
-            Format::U16 => {
-                assert!(bytes.len() >= pos + 3, "buffer too small to read arguments");
-                let (arg1, arg2) = unsafe {
-                    (
-                        read_unchecked::<u16>(bytes, pos),
-                        read_unchecked::<i8>(bytes, pos + 2),
-                    )
-                };
-                ((arg1.into(), arg2), pos + 3)
-            }
-            Format::U32 => {
-                assert!(bytes.len() >= pos + 5, "buffer too small to read arguments");
-                let (arg1, arg2) = unsafe {
-                    (
-                        read_unchecked::<u32>(bytes, pos),
-                        read_unchecked::<i8>(bytes, pos + 4),
-                    )
-                };
-                ((arg1.into(), arg2), pos + 5)
-            }
-        }
+        assert!(bytes.len() >= pos + 5, "buffer too small to read arguments");
+        let (arg1, arg2) = unsafe {
+            (
+                read_unchecked::<u32>(bytes, pos),
+                read_unchecked::<i8>(bytes, pos + 4),
+            )
+        };
+        ((arg1.into(), arg2), pos + 5)
     }
 }
 
 impl Argument for (VaryingOperand, i16) {
     fn encode(self, bytes: &mut Vec<u8>) {
-        match self.0.variant() {
-            VaryingOperandVariant::U8(value) => {
-                write_format(bytes, Format::U8);
-                write_u8(bytes, value);
-                write_i16(bytes, self.1);
-            }
-            VaryingOperandVariant::U16(value) => {
-                write_format(bytes, Format::U16);
-                write_u16(bytes, value);
-                write_i16(bytes, self.1);
-            }
-            VaryingOperandVariant::U32(value) => {
-                write_format(bytes, Format::U32);
-                write_u32(bytes, value);
-                write_i16(bytes, self.1);
-            }
-        }
+        write_u32(bytes, self.0.value);
+        write_i16(bytes, self.1);
     }
 
     fn decode(bytes: &[u8], pos: usize) -> (Self, usize) {
-        let format = Format::from(bytes[pos]);
-        let pos = pos + 1;
-
-        match format {
-            Format::U8 => {
-                assert!(bytes.len() >= pos + 3, "buffer too small to read arguments");
-                let (arg1, arg2) = unsafe {
-                    (
-                        read_unchecked::<u8>(bytes, pos),
-                        read_unchecked::<i16>(bytes, pos + 1),
-                    )
-                };
-                ((arg1.into(), arg2), pos + 3)
-            }
-            Format::U16 => {
-                let ((arg1, arg2), pos) = read::<(u16, i16)>(bytes, pos);
-                ((arg1.into(), arg2), pos)
-            }
-            Format::U32 => {
-                assert!(bytes.len() >= pos + 6, "buffer too small to read arguments");
-                let (arg1, arg2) = unsafe {
-                    (
-                        read_unchecked::<u32>(bytes, pos),
-                        read_unchecked::<i16>(bytes, pos + 4),
-                    )
-                };
-                ((arg1.into(), arg2), pos + 6)
-            }
-        }
+        assert!(bytes.len() >= pos + 6, "buffer too small to read arguments");
+        let (arg1, arg2) = unsafe {
+            (
+                read_unchecked::<u32>(bytes, pos),
+                read_unchecked::<i16>(bytes, pos + 4),
+            )
+        };
+        ((arg1.into(), arg2), pos + 6)
     }
 }
 
@@ -333,116 +200,26 @@ impl Argument for (VaryingOperand, f64) {
 
 impl Argument for (VaryingOperand, VaryingOperand) {
     fn encode(self, bytes: &mut Vec<u8>) {
-        match (self.0.variant(), self.1.variant()) {
-            (VaryingOperandVariant::U8(lhs), VaryingOperandVariant::U8(rhs)) => {
-                write_format(bytes, Format::U8);
-                write_u8(bytes, lhs);
-                write_u8(bytes, rhs);
-            }
-            (VaryingOperandVariant::U8(lhs), VaryingOperandVariant::U16(rhs)) => {
-                write_format(bytes, Format::U16);
-                write_u16(bytes, lhs.into());
-                write_u16(bytes, rhs);
-            }
-            (VaryingOperandVariant::U16(lhs), VaryingOperandVariant::U8(rhs)) => {
-                write_format(bytes, Format::U16);
-                write_u16(bytes, lhs);
-                write_u16(bytes, rhs.into());
-            }
-            (VaryingOperandVariant::U16(lhs), VaryingOperandVariant::U16(rhs)) => {
-                write_format(bytes, Format::U16);
-                write_u16(bytes, lhs);
-                write_u16(bytes, rhs);
-            }
-            _ => {
-                write_format(bytes, Format::U32);
-                write_u32(bytes, self.0.value);
-                write_u32(bytes, self.1.value);
-            }
-        }
+        write_u32(bytes, self.0.value);
+        write_u32(bytes, self.1.value);
     }
 
     fn decode(bytes: &[u8], pos: usize) -> (Self, usize) {
-        let format = Format::from(bytes[pos]);
-        let pos = pos + 1;
-
-        match format {
-            Format::U8 => {
-                let ((arg1, arg2), pos) = read::<(u8, u8)>(bytes, pos);
-                ((arg1.into(), arg2.into()), pos)
-            }
-            Format::U16 => {
-                let ((arg1, arg2), pos) = read::<(u16, u16)>(bytes, pos);
-                ((arg1.into(), arg2.into()), pos)
-            }
-            Format::U32 => {
-                let ((arg1, arg2), pos) = read::<(u32, u32)>(bytes, pos);
-                ((arg1.into(), arg2.into()), pos)
-            }
-        }
+        let ((arg1, arg2), pos) = read::<(u32, u32)>(bytes, pos);
+        ((arg1.into(), arg2.into()), pos)
     }
 }
 
 impl Argument for (VaryingOperand, VaryingOperand, VaryingOperand) {
     fn encode(self, bytes: &mut Vec<u8>) {
-        match (self.0.variant(), self.1.variant(), self.2.variant()) {
-            (
-                VaryingOperandVariant::U8(lhs),
-                VaryingOperandVariant::U8(mid),
-                VaryingOperandVariant::U8(rhs),
-            ) => {
-                write_format(bytes, Format::U8);
-                write_u8(bytes, lhs);
-                write_u8(bytes, mid);
-                write_u8(bytes, rhs);
-            }
-            (
-                VaryingOperandVariant::U8(lhs),
-                VaryingOperandVariant::U8(mid),
-                VaryingOperandVariant::U16(rhs),
-            ) => {
-                write_format(bytes, Format::U16);
-                write_u16(bytes, lhs.into());
-                write_u16(bytes, mid.into());
-                write_u16(bytes, rhs);
-            }
-            (
-                VaryingOperandVariant::U16(lhs),
-                VaryingOperandVariant::U16(mid),
-                VaryingOperandVariant::U16(rhs),
-            ) => {
-                write_format(bytes, Format::U16);
-                write_u16(bytes, lhs);
-                write_u16(bytes, mid);
-                write_u16(bytes, rhs);
-            }
-            _ => {
-                write_format(bytes, Format::U32);
-                write_u32(bytes, self.0.value);
-                write_u32(bytes, self.1.value);
-                write_u32(bytes, self.2.value);
-            }
-        }
+        write_u32(bytes, self.0.value);
+        write_u32(bytes, self.1.value);
+        write_u32(bytes, self.2.value);
     }
 
     fn decode(bytes: &[u8], pos: usize) -> (Self, usize) {
-        let format = Format::from(bytes[pos]);
-        let pos = pos + 1;
-
-        match format {
-            Format::U8 => {
-                let ((arg1, arg2, arg3), pos) = read::<(u8, u8, u8)>(bytes, pos);
-                ((arg1.into(), arg2.into(), arg3.into()), pos)
-            }
-            Format::U16 => {
-                let ((arg1, arg2, arg3), pos) = read::<(u16, u16, u16)>(bytes, pos);
-                ((arg1.into(), arg2.into(), arg3.into()), pos)
-            }
-            Format::U32 => {
-                let ((arg1, arg2, arg3), pos) = read::<(u32, u32, u32)>(bytes, pos);
-                ((arg1.into(), arg2.into(), arg3.into()), pos)
-            }
-        }
+        let ((arg1, arg2, arg3), pos) = read::<(u32, u32, u32)>(bytes, pos);
+        ((arg1.into(), arg2.into(), arg3.into()), pos)
     }
 }
 
@@ -455,86 +232,15 @@ impl Argument
     )
 {
     fn encode(self, bytes: &mut Vec<u8>) {
-        let format = match (
-            self.0.variant(),
-            self.1.variant(),
-            self.2.variant(),
-            self.3.variant(),
-        ) {
-            (
-                VaryingOperandVariant::U8(_),
-                VaryingOperandVariant::U8(_),
-                VaryingOperandVariant::U8(_),
-                VaryingOperandVariant::U8(_),
-            ) => Format::U8,
-            (VaryingOperandVariant::U16(_), _, _, _)
-            | (_, VaryingOperandVariant::U16(_), _, _)
-            | (_, _, VaryingOperandVariant::U16(_), _)
-            | (_, _, _, VaryingOperandVariant::U16(_))
-                if !matches!(self.0.variant(), VaryingOperandVariant::U32(_))
-                    && !matches!(self.1.variant(), VaryingOperandVariant::U32(_))
-                    && !matches!(self.2.variant(), VaryingOperandVariant::U32(_))
-                    && !matches!(self.3.variant(), VaryingOperandVariant::U32(_)) =>
-            {
-                Format::U16
-            }
-            _ => Format::U32,
-        };
-
-        write_format(bytes, format);
-
-        match format {
-            Format::U8 => {
-                if let (
-                    VaryingOperandVariant::U8(v1),
-                    VaryingOperandVariant::U8(v2),
-                    VaryingOperandVariant::U8(v3),
-                    VaryingOperandVariant::U8(v4),
-                ) = (
-                    self.0.variant(),
-                    self.1.variant(),
-                    self.2.variant(),
-                    self.3.variant(),
-                ) {
-                    write_u8(bytes, v1);
-                    write_u8(bytes, v2);
-                    write_u8(bytes, v3);
-                    write_u8(bytes, v4);
-                }
-            }
-            Format::U16 => {
-                write_u16(bytes, self.0.value as u16);
-                write_u16(bytes, self.1.value as u16);
-                write_u16(bytes, self.2.value as u16);
-                write_u16(bytes, self.3.value as u16);
-            }
-            Format::U32 => {
-                write_u32(bytes, self.0.value);
-                write_u32(bytes, self.1.value);
-                write_u32(bytes, self.2.value);
-                write_u32(bytes, self.3.value);
-            }
-        }
+        write_u32(bytes, self.0.value);
+        write_u32(bytes, self.1.value);
+        write_u32(bytes, self.2.value);
+        write_u32(bytes, self.3.value);
     }
 
     fn decode(bytes: &[u8], pos: usize) -> (Self, usize) {
-        let format = Format::from(bytes[pos]);
-        let pos = pos + 1;
-
-        match format {
-            Format::U8 => {
-                let ((arg1, arg2, arg3, arg4), pos) = read::<(u8, u8, u8, u8)>(bytes, pos);
-                ((arg1.into(), arg2.into(), arg3.into(), arg4.into()), pos)
-            }
-            Format::U16 => {
-                let ((arg1, arg2, arg3, arg4), pos) = read::<(u16, u16, u16, u16)>(bytes, pos);
-                ((arg1.into(), arg2.into(), arg3.into(), arg4.into()), pos)
-            }
-            Format::U32 => {
-                let ((arg1, arg2, arg3, arg4), pos) = read::<(u32, u32, u32, u32)>(bytes, pos);
-                ((arg1.into(), arg2.into(), arg3.into(), arg4.into()), pos)
-            }
-        }
+        let ((arg1, arg2, arg3, arg4), pos) = read::<(u32, u32, u32, u32)>(bytes, pos);
+        ((arg1.into(), arg2.into(), arg3.into(), arg4.into()), pos)
     }
 }
 

--- a/core/engine/src/vm/opcode/mod.rs
+++ b/core/engine/src/vm/opcode/mod.rs
@@ -202,13 +202,6 @@ pub(crate) struct ByteCode {
     pub(crate) bytecode: Box<[u8]>,
 }
 
-/// The enum representation of [`VaryingOperand`] values.
-enum VaryingOperandVariant {
-    U8(u8),
-    U16(u16),
-    U32(u32),
-}
-
 #[derive(Debug, Clone, Copy)]
 /// A varying operand is a value that can be either a u8, u16 or u32.
 pub(crate) struct VaryingOperand {
@@ -219,17 +212,6 @@ impl VaryingOperand {
     /// Create a new [`VaryingOperand`] from a u32 value.
     pub(crate) fn new(value: u32) -> Self {
         Self { value }
-    }
-
-    /// Return the variant of the [`VaryingOperand`].
-    fn variant(self) -> VaryingOperandVariant {
-        if let Ok(value) = u8::try_from(self.value) {
-            VaryingOperandVariant::U8(value)
-        } else if let Ok(value) = u16::try_from(self.value) {
-            VaryingOperandVariant::U16(value)
-        } else {
-            VaryingOperandVariant::U32(self.value)
-        }
     }
 }
 


### PR DESCRIPTION
This simplifies greatly encoding AND decoding of bytecode, which is a bottle neck in many cases.

This improves performance in benchmark by about 5-10%, while increasing memory usage a bit, on my computer.

This should be the start of a new VM refactor where we simplify the VM and its bytecode for something that's more cache friendly.

Main:

```
PROGRESS Richards
RESULT Richards 254
PROGRESS DeltaBlue
RESULT DeltaBlue 249
PROGRESS Encrypt
PROGRESS Decrypt
RESULT Crypto 265
PROGRESS RayTrace
RESULT RayTrace 497
PROGRESS Earley
PROGRESS Boyer
RESULT EarleyBoyer 595
PROGRESS RegExp
RESULT RegExp 83.2
PROGRESS Splay
RESULT Splay 1182
PROGRESS NavierStokes
RESULT NavierStokes 567
SCORE 359
```

PR:

```
PROGRESS Richards
RESULT Richards 267
PROGRESS DeltaBlue
RESULT DeltaBlue 264
PROGRESS Encrypt
PROGRESS Decrypt
RESULT Crypto 300
PROGRESS RayTrace
RESULT RayTrace 529
PROGRESS Earley
PROGRESS Boyer
RESULT EarleyBoyer 645
PROGRESS RegExp
RESULT RegExp 85.3
PROGRESS Splay
RESULT Splay 1166
PROGRESS NavierStokes
RESULT NavierStokes 642
SCORE 383
```