### PR TITLE
Remove `CompletePromiseCapability` opcode

### DIFF
--- a/core/engine/src/bytecompiler/declaration/declaration_pattern.rs
+++ b/core/engine/src/bytecompiler/declaration/declaration_pattern.rs
@@ -291,12 +291,11 @@ impl ByteCompiler<'_> {
                 self.bytecode.emit_iterator_next();
                 let value = self.register_allocator.alloc();
                 self.bytecode.emit_iterator_done(value.variable());
-                let done = self.jump_if_true(&value);
-                self.bytecode.emit_iterator_value(value.variable());
-                let skip_push = self.jump();
-                self.patch_jump(done);
-                self.bytecode.emit_push_undefined(value.variable());
-                self.patch_jump(skip_push);
+                self.if_else(
+                    &value,
+                    |compiler| compiler.bytecode.emit_push_undefined(value.variable()),
+                    |compiler| compiler.bytecode.emit_iterator_value(value.variable()),
+                );
 
                 if let Some(init) = default_init {
                     let skip = self.emit_jump_if_not_undefined(&value);
@@ -315,12 +314,11 @@ impl ByteCompiler<'_> {
                 self.access_set(Access::Property { access }, |compiler| {
                     compiler.bytecode.emit_iterator_next();
                     compiler.bytecode.emit_iterator_done(value.variable());
-                    let done = compiler.jump_if_true(&value);
-                    compiler.bytecode.emit_iterator_value(value.variable());
-                    let skip_push = compiler.jump();
-                    compiler.patch_jump(done);
-                    compiler.bytecode.emit_push_undefined(value.variable());
-                    compiler.patch_jump(skip_push);
+                    compiler.if_else(
+                        &value,
+                        |compiler| compiler.bytecode.emit_push_undefined(value.variable()),
+                        |compiler| compiler.bytecode.emit_iterator_value(value.variable()),
+                    );
 
                     if let Some(init) = default_init {
                         let skip = compiler.emit_jump_if_not_undefined(&value);
@@ -340,12 +338,11 @@ impl ByteCompiler<'_> {
                 self.bytecode.emit_iterator_next();
                 let value = self.register_allocator.alloc();
                 self.bytecode.emit_iterator_done(value.variable());
-                let done = self.jump_if_true(&value);
-                self.bytecode.emit_iterator_value(value.variable());
-                let skip_push = self.jump();
-                self.patch_jump(done);
-                self.bytecode.emit_push_undefined(value.variable());
-                self.patch_jump(skip_push);
+                self.if_else(
+                    &value,
+                    |compiler| compiler.bytecode.emit_push_undefined(value.variable()),
+                    |compiler| compiler.bytecode.emit_iterator_value(value.variable()),
+                );
 
                 if let Some(init) = default_init {
                     let skip = self.emit_jump_if_not_undefined(&value);

--- a/core/engine/src/bytecompiler/expression/mod.rs
+++ b/core/engine/src/bytecompiler/expression/mod.rs
@@ -43,12 +43,11 @@ impl ByteCompiler<'_> {
 
     fn compile_conditional(&mut self, op: &Conditional, dst: &Register) {
         self.compile_expr(op.condition(), dst);
-        let jelse = self.jump_if_false(dst);
-        self.compile_expr(op.if_true(), dst);
-        let exit = self.jump();
-        self.patch_jump(jelse);
-        self.compile_expr(op.if_false(), dst);
-        self.patch_jump(exit);
+        self.if_else(
+            dst,
+            |compiler| compiler.compile_expr(op.if_true(), dst),
+            |compiler| compiler.compile_expr(op.if_false(), dst),
+        );
     }
 
     fn compile_template_literal(&mut self, template_literal: &TemplateLiteral, dst: &Register) {

--- a/core/engine/src/bytecompiler/function.rs
+++ b/core/engine/src/bytecompiler/function.rs
@@ -184,10 +184,6 @@ impl FunctionCompiler {
         // See: 15.6.2 Runtime Semantics: EvaluateAsyncGeneratorBody: https://tc39.es/ecma262/#sec-runtime-semantics-evaluateasyncgeneratorbody
         if compiler.is_async() && !compiler.is_generator() {
             // 1. Let promiseCapability be ! NewPromiseCapability(%Promise%).
-            //
-            // Note: If the promise capability is already set, then we do nothing.
-            // This is a deviation from the spec, but it allows to set the promise capability by
-            // ExecuteAsyncModule ( module ): <https://tc39.es/ecma262/#sec-execute-async-module>
             compiler.bytecode.emit_create_promise_capability();
 
             // 2. Let declResult be Completion(FunctionDeclarationInstantiation(functionObject, argumentsList)).

--- a/core/engine/src/bytecompiler/jump_control.rs
+++ b/core/engine/src/bytecompiler/jump_control.rs
@@ -12,7 +12,7 @@
 use super::Register;
 use crate::{
     bytecompiler::{ByteCompiler, Label},
-    vm::Handler,
+    vm::{CallFrame, Handler},
 };
 use bitflags::bitflags;
 use boa_interner::Sym;
@@ -149,7 +149,63 @@ impl JumpRecord {
                     //  - 27.7.5.2 AsyncBlockStart ( promiseCapability, asyncBody, asyncContext ): <https://tc39.es/ecma262/#sec-asyncblockstart>
                     //
                     // Note: If there is promise capability resolve or reject it based on pending exception.
-                    (true, false) => compiler.bytecode.emit_complete_promise_capability(),
+                    (true, false) => {
+                        let has_exception = compiler.register_allocator.alloc();
+                        let exception = compiler.register_allocator.alloc();
+
+                        compiler
+                            .bytecode
+                            .emit_maybe_exception(has_exception.variable(), exception.variable());
+
+                        // Pushes `undefined` to the stack, which acts as the
+                        // `this` value of the call.
+                        {
+                            let value = compiler.register_allocator.alloc();
+                            compiler.bytecode.emit_push_undefined(value.variable());
+                            compiler.push_from_register(&value);
+                            compiler.register_allocator.dealloc(value);
+                        }
+
+                        compiler.if_else_with_dealloc(
+                            has_exception,
+                            |compiler| {
+                                // has_exception == true, so we need to call `reject`
+                                // with the current exception.
+
+                                compiler.bytecode.emit_push_from_register(
+                                    (CallFrame::PROMISE_CAPABILITY_REJECT_REGISTER_INDEX as u32)
+                                        .into(),
+                                );
+                                compiler.push_from_register(&exception);
+                                compiler.register_allocator.dealloc(exception);
+                                compiler.bytecode.emit_call(1u8.into());
+                            },
+                            |compiler| {
+                                // has_exception == false, call `resolve` normally.
+
+                                compiler.bytecode.emit_push_from_register(
+                                    (CallFrame::PROMISE_CAPABILITY_RESOLVE_REGISTER_INDEX as u32)
+                                        .into(),
+                                );
+
+                                {
+                                    let value = compiler.register_allocator.alloc();
+                                    compiler
+                                        .bytecode
+                                        .emit_set_register_from_accumulator(value.variable());
+                                    compiler.push_from_register(&value);
+                                    compiler.register_allocator.dealloc(value);
+                                }
+                                compiler.bytecode.emit_call(1u8.into());
+                            },
+                        );
+
+                        // Finally, set the accumulator value to the promise from the
+                        // promise capability
+                        compiler.bytecode.emit_set_accumulator(
+                            (CallFrame::PROMISE_CAPABILITY_PROMISE_REGISTER_INDEX as u32).into(),
+                        );
+                    }
                     (false, false) => {
                         // TODO: We can omit checking for return, when constructing for functions,
                         // that cannot be constructed, like arrow functions.

--- a/core/engine/src/bytecompiler/mod.rs
+++ b/core/engine/src/bytecompiler/mod.rs
@@ -1064,7 +1064,7 @@ impl<'ctx> ByteCompiler<'ctx> {
         true_case: impl FnOnce(&mut ByteCompiler<'_>),
         false_case: impl FnOnce(&mut ByteCompiler<'_>),
     ) {
-        let jump_false = self.jump_if_false(&bool);
+        let jump_false = self.jump_if_false(bool);
 
         // if true, jump to end to avoid running the code for the `else`
         true_case(self);
@@ -1078,7 +1078,7 @@ impl<'ctx> ByteCompiler<'ctx> {
 
     /// Generates the `if-else` pattern.
     ///
-    /// This will also deallocate the `bool` register`.
+    /// This will also deallocate the `bool` register.
     pub(crate) fn if_else_with_dealloc(
         &mut self,
         bool: Register,

--- a/core/engine/src/bytecompiler/mod.rs
+++ b/core/engine/src/bytecompiler/mod.rs
@@ -1058,6 +1058,46 @@ impl<'ctx> ByteCompiler<'ctx> {
         Label { index }
     }
 
+    pub(crate) fn if_else(
+        &mut self,
+        bool: &Register,
+        true_case: impl FnOnce(&mut ByteCompiler<'_>),
+        false_case: impl FnOnce(&mut ByteCompiler<'_>),
+    ) {
+        let jump_false = self.jump_if_false(&bool);
+
+        // if true, jump to end to avoid running the code for the `else`
+        true_case(self);
+        let jump_to_end = self.jump();
+
+        // if false, we should be already at the end so no need to do anything.
+        self.patch_jump(jump_false);
+        false_case(self);
+        self.patch_jump(jump_to_end);
+    }
+
+    /// Generates the `if-else` pattern.
+    ///
+    /// This will also deallocate the `bool` register`.
+    pub(crate) fn if_else_with_dealloc(
+        &mut self,
+        bool: Register,
+        true_case: impl FnOnce(&mut ByteCompiler<'_>),
+        false_case: impl FnOnce(&mut ByteCompiler<'_>),
+    ) {
+        let jump_false = self.jump_if_false(&bool);
+        self.register_allocator.dealloc(bool);
+
+        // if true, jump to end to avoid running the code for the `else`
+        true_case(self);
+        let jump_to_end = self.jump();
+
+        // if false, we should be already at the end so no need to do anything.
+        self.patch_jump(jump_false);
+        false_case(self);
+        self.patch_jump(jump_to_end);
+    }
+
     pub(crate) fn jump_if_false(&mut self, value: &Register) -> Label {
         let index = self.next_opcode_location();
         self.bytecode

--- a/core/engine/src/bytecompiler/statement/if.rs
+++ b/core/engine/src/bytecompiler/statement/if.rs
@@ -5,14 +5,16 @@ impl ByteCompiler<'_> {
     pub(crate) fn compile_if(&mut self, node: &If, use_expr: bool) {
         let value = self.register_allocator.alloc();
         self.compile_expr(node.cond(), &value);
-        let jelse = self.jump_if_false(&value);
-        self.register_allocator.dealloc(value);
-        self.compile_stmt(node.body(), use_expr, true);
-        let exit = self.jump();
-        self.patch_jump(jelse);
-        if let Some(else_body) = node.else_node() {
-            self.compile_stmt(else_body, use_expr, true);
-        }
-        self.patch_jump(exit);
+        self.if_else_with_dealloc(
+            value,
+            |compiler| {
+                compiler.compile_stmt(node.body(), use_expr, true);
+            },
+            |compiler| {
+                if let Some(else_body) = node.else_node() {
+                    compiler.compile_stmt(else_body, use_expr, true);
+                }
+            },
+        );
     }
 }

--- a/core/engine/src/module/source.rs
+++ b/core/engine/src/module/source.rs
@@ -1,4 +1,5 @@
 use std::{
+    borrow::Cow,
     cell::{Cell, RefCell},
     collections::HashSet,
     hash::BuildHasherDefault,
@@ -1442,7 +1443,7 @@ impl SourceTextModule {
 
         // 9. Perform ! module.ExecuteModule(capability).
         // 10. Return unused.
-        self.execute(module_self, Some(&capability), context)
+        self.execute(module_self, Some(capability), context)
             .expect("async modules cannot directly throw");
     }
 
@@ -1566,13 +1567,19 @@ impl SourceTextModule {
         let env = self.code.source.scope().clone();
 
         let spanned_source_text = SpannedSourceText::new_source_only(self.code.source_text.clone());
+        let name = if let Some(path) = &self.code.path {
+            path.to_string_lossy()
+        } else {
+            Cow::Borrowed("<main>")
+        };
+
         let mut compiler = ByteCompiler::new(
-            js_string!("<main>"),
+            js_string!(name),
             true,
             false,
             self.code.source.scope().clone(),
             self.code.source.scope().clone(),
-            true,
+            self.code.has_tla,
             false,
             context.interner_mut(),
             false,
@@ -1580,7 +1587,7 @@ impl SourceTextModule {
             self.code.path.clone().into(),
         );
 
-        compiler.async_handler = Some(compiler.push_handler());
+        compiler.async_handler = self.code.has_tla.then(|| compiler.push_handler());
 
         let mut imports = Vec::new();
 
@@ -1860,7 +1867,7 @@ impl SourceTextModule {
     fn execute(
         &self,
         module_self: &Module,
-        capability: Option<&PromiseCapability>,
+        capability: Option<PromiseCapability>,
         context: &mut Context,
     ) -> JsResult<()> {
         // 1. Let moduleContext be a new ECMAScript code execution context.
@@ -1895,10 +1902,12 @@ impl SourceTextModule {
             .vm
             .push_frame_with_stack(callframe, JsValue::undefined(), JsValue::null());
 
-        context
-            .vm
-            .stack
-            .set_promise_capability(&context.vm.frame, capability);
+        if let Some(capability) = capability {
+            context
+                .vm
+                .stack
+                .set_promise_capability(&context.vm.frame, capability)?;
+        }
 
         // 9. If module.[[HasTLA]] is false, then
         //    a. Assert: capability is not present.

--- a/core/engine/src/module/source.rs
+++ b/core/engine/src/module/source.rs
@@ -1,5 +1,4 @@
 use std::{
-    borrow::Cow,
     cell::{Cell, RefCell},
     collections::HashSet,
     hash::BuildHasherDefault,
@@ -1567,14 +1566,9 @@ impl SourceTextModule {
         let env = self.code.source.scope().clone();
 
         let spanned_source_text = SpannedSourceText::new_source_only(self.code.source_text.clone());
-        let name = if let Some(path) = &self.code.path {
-            path.to_string_lossy()
-        } else {
-            Cow::Borrowed("<main>")
-        };
 
         let mut compiler = ByteCompiler::new(
-            js_string!(name),
+            js_string!("<main>"),
             true,
             false,
             self.code.source.scope().clone(),

--- a/core/engine/src/vm/code_block.rs
+++ b/core/engine/src/vm/code_block.rs
@@ -849,7 +849,6 @@ impl CodeBlock {
             | Instruction::Return
             | Instruction::AsyncGeneratorClose
             | Instruction::CreatePromiseCapability
-            | Instruction::CompletePromiseCapability
             | Instruction::PopEnvironment
             | Instruction::IncrementLoopIteration
             | Instruction::IteratorNext
@@ -917,7 +916,8 @@ impl CodeBlock {
             | Instruction::Reserved57
             | Instruction::Reserved58
             | Instruction::Reserved59
-            | Instruction::Reserved60 => unreachable!("Reserved opcodes are unreachable"),
+            | Instruction::Reserved60
+            | Instruction::Reserved61 => unreachable!("Reserved opcodes are unreachable"),
         }
     }
 }

--- a/core/engine/src/vm/flowgraph/mod.rs
+++ b/core/engine/src/vm/flowgraph/mod.rs
@@ -424,7 +424,6 @@ impl CodeBlock {
                 | Instruction::AsyncGeneratorYield { .. }
                 | Instruction::AsyncGeneratorClose
                 | Instruction::CreatePromiseCapability
-                | Instruction::CompletePromiseCapability
                 | Instruction::GeneratorNext { .. }
                 | Instruction::PushClassField { .. }
                 | Instruction::SuperCallDerived
@@ -515,7 +514,8 @@ impl CodeBlock {
                 | Instruction::Reserved57
                 | Instruction::Reserved58
                 | Instruction::Reserved59
-                | Instruction::Reserved60 => unreachable!("Reserved opcodes are unreachable"),
+                | Instruction::Reserved60
+                | Instruction::Reserved61 => unreachable!("Reserved opcodes are unreachable"),
             }
         }
 

--- a/core/engine/src/vm/mod.rs
+++ b/core/engine/src/vm/mod.rs
@@ -5,7 +5,7 @@
 //! plus an interpreter to execute those instructions
 
 use crate::{
-    Context, JsError, JsNativeError, JsObject, JsResult, JsString, JsValue, Module,
+    Context, JsError, JsExpect, JsNativeError, JsObject, JsResult, JsString, JsValue, Module,
     builtins::promise::{PromiseCapability, ResolvingFunctions},
     environments::EnvironmentStack,
     error::RuntimeLimitError,
@@ -229,53 +229,59 @@ impl Stack {
     pub(crate) fn set_promise_capability(
         &mut self,
         frame: &CallFrame,
-        promise_capability: Option<&PromiseCapability>,
-    ) {
-        debug_assert!(
-            frame.code_block().is_async(),
-            "Only async functions have a promise capability"
-        );
+        promise_capability: PromiseCapability,
+    ) -> JsResult<()> {
+        #[cfg(debug_assertions)]
+        {
+            if !frame.code_block().is_async() {
+                return Err(crate::error::PanicError::new(
+                    "only async functions and modules with a top-level-await \
+                    can have a promise capability",
+                )
+                .into());
+            }
+        }
 
-        self.stack[frame.promise_capability_promise_register_index()] = promise_capability
-            .map(PromiseCapability::promise)
-            .cloned()
-            .map_or_else(JsValue::undefined, Into::into);
-        self.stack[frame.promise_capability_resolve_register_index()] = promise_capability
-            .map(PromiseCapability::resolve)
-            .cloned()
-            .map_or_else(JsValue::undefined, Into::into);
-        self.stack[frame.promise_capability_reject_register_index()] = promise_capability
-            .map(PromiseCapability::reject)
-            .cloned()
-            .map_or_else(JsValue::undefined, Into::into);
+        self.stack[frame.promise_capability_promise_register_index()] =
+            promise_capability.promise.into();
+        self.stack[frame.promise_capability_resolve_register_index()] =
+            promise_capability.functions.resolve.into();
+        self.stack[frame.promise_capability_reject_register_index()] =
+            promise_capability.functions.reject.into();
+
+        Ok(())
     }
 
     /// Get the promise capability for the given frame.
     #[track_caller]
-    pub(crate) fn get_promise_capability(&self, frame: &CallFrame) -> Option<PromiseCapability> {
+    pub(crate) fn get_promise_capability(&self, frame: &CallFrame) -> JsResult<PromiseCapability> {
+        #[cfg(debug_assertions)]
         if !frame.code_block().is_async() {
-            return None;
+            return Err(crate::error::PanicError::new(
+                "cannot get promise capability from non-async code",
+            )
+            .into());
         }
 
         let promise = self
             .stack
             .get(frame.promise_capability_promise_register_index())
-            .expect("stack must have a promise capability")
-            .as_object()?;
+            .and_then(JsValue::as_object)
+            .js_expect("stack must have a promise capability")?;
         let resolve = self
             .stack
             .get(frame.promise_capability_resolve_register_index())
-            .expect("stack must have a resolve function")
-            .as_object()
-            .and_then(JsFunction::from_object)?;
+            .and_then(JsValue::as_object)
+            .and_then(JsFunction::from_object)
+            .js_expect("stack must have a resolve function")?;
         let reject = self
             .stack
             .get(frame.promise_capability_reject_register_index())
-            .expect("stack must have a reject function")
-            .as_object()
-            .and_then(JsFunction::from_object)?;
+            .and_then(JsValue::as_object)
+            .and_then(JsFunction::from_object)
+            .js_expect("stack must have a reject function")?;
 
-        Some(PromiseCapability {
+        Ok(PromiseCapability {
             promise,
             functions: ResolvingFunctions { resolve, reject },
         })

--- a/core/engine/src/vm/opcode/await/mod.rs
+++ b/core/engine/src/vm/opcode/await/mod.rs
@@ -1,6 +1,6 @@
 use super::VaryingOperand;
 use crate::{
-    Context, JsArgs, JsValue,
+    Context, JsArgs, JsExpect, JsResult, JsValue,
     builtins::{
         Promise, async_generator::AsyncGenerator, generator::GeneratorContext,
         promise::PromiseCapability,
@@ -155,89 +155,28 @@ impl Operation for Await {
 /// `CreatePromiseCapability` implements the Opcode Operation for `Opcode::CreatePromiseCapability`
 ///
 /// Operation:
-///  - Create a promise capacity for an async function, if not already set.
+///  - Create a promise capacity for an async function.
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct CreatePromiseCapability;
 
 impl CreatePromiseCapability {
     #[inline(always)]
-    pub(super) fn operation((): (), context: &mut Context) {
-        if context
-            .vm
-            .stack
-            .get_promise_capability(&context.vm.frame)
-            .is_some()
-        {
-            return;
-        }
-
+    pub(super) fn operation((): (), context: &mut Context) -> JsResult<()> {
         let promise_capability = PromiseCapability::new(
             &context.intrinsics().constructors().promise().constructor(),
             context,
         )
-        .expect("cannot fail per spec");
+        .js_expect("cannot fail per spec")?;
 
         context
             .vm
             .stack
-            .set_promise_capability(&context.vm.frame, Some(&promise_capability));
+            .set_promise_capability(&context.vm.frame, promise_capability)
     }
 }
 
 impl Operation for CreatePromiseCapability {
     const NAME: &'static str = "CreatePromiseCapability";
     const INSTRUCTION: &'static str = "INST - CreatePromiseCapability";
-    const COST: u8 = 8;
-}
-
-/// `CompletePromiseCapability` implements the Opcode Operation for `Opcode::CompletePromiseCapability`
-///
-/// Operation:
-///  - Resolves or rejects the promise capability, depending if the pending exception is set.
-#[derive(Debug, Clone, Copy)]
-pub(crate) struct CompletePromiseCapability;
-
-impl CompletePromiseCapability {
-    #[inline(always)]
-    pub(super) fn operation((): (), context: &mut Context) -> ControlFlow<CompletionRecord> {
-        // If the current executing function is an async function we have to resolve/reject it's promise at the end.
-        // The relevant spec section is 3. in [AsyncBlockStart](https://tc39.es/ecma262/#sec-asyncblockstart).
-        let Some(promise_capability) = context.vm.stack.get_promise_capability(&context.vm.frame)
-        else {
-            return if context.vm.pending_exception.is_some() {
-                context.handle_throw()
-            } else {
-                ControlFlow::Continue(())
-            };
-        };
-
-        if let Some(error) = context.vm.pending_exception.take() {
-            let value = match error.into_opaque(context) {
-                Ok(value) => value,
-                Err(err) => return context.handle_error(err),
-            };
-            promise_capability
-                .reject()
-                .call(&JsValue::undefined(), &[value], context)
-                .expect("cannot fail per spec");
-        } else {
-            let return_value = context.vm.get_return_value();
-            promise_capability
-                .resolve()
-                .call(&JsValue::undefined(), &[return_value], context)
-                .expect("cannot fail per spec");
-        }
-
-        context
-            .vm
-            .set_return_value(promise_capability.promise().clone().into());
-
-        ControlFlow::Continue(())
-    }
-}
-
-impl Operation for CompletePromiseCapability {
-    const NAME: &'static str = "CompletePromiseCapability";
-    const INSTRUCTION: &'static str = "INST - CompletePromiseCapability";
     const COST: u8 = 8;
 }

--- a/core/engine/src/vm/opcode/mod.rs
+++ b/core/engine/src/vm/opcode/mod.rs
@@ -1947,11 +1947,6 @@ generate_opcodes! {
     /// Create a promise capacity for an async function, if not already set.
     CreatePromiseCapability,
 
-    /// Resolves or rejects the promise capability of an async function.
-    ///
-    /// If the pending exception is set, reject and rethrow the exception, otherwise resolve.
-    CompletePromiseCapability,
-
     /// Jumps to the specified address if the resume kind is not equal.
     ///
     /// - Operands:
@@ -2238,4 +2233,6 @@ generate_opcodes! {
     Reserved59 => Reserved,
     /// Reserved [`Opcode`].
     Reserved60 => Reserved,
+    /// Reserved [`Opcode`]
+    Reserved61 => Reserved,
 }


### PR DESCRIPTION
This PR removes the complex `CompletePromiseCapability` opcode and replaces it with a manual compilation of the operations.

This also introduces the methods `if_else` and `if_else_with_dealloc`, which cleans up a fair bit of our bytecode compiler code.