### PR TITLE
Add read-only register with `undefined`

### DIFF
--- a/core/engine/src/bytecompiler/declarations.rs
+++ b/core/engine/src/bytecompiler/declarations.rs
@@ -2,7 +2,7 @@ use super::{BindingAccessOpcode, ToJsString};
 use crate::{
     Context, JsNativeError, JsResult, SpannedSourceText,
     bytecompiler::{ByteCompiler, FunctionCompiler, FunctionSpec, NodeKind},
-    vm::opcode::BindingOpcode,
+    vm::{CallFrame, opcode::BindingOpcode},
 };
 use boa_ast::{
     Script,
@@ -714,11 +714,14 @@ impl ByteCompiler<'_> {
                     // ii. If bindingExists is false, then
                     // i. Perform ! varEnv.CreateMutableBinding(F, true).
                     // ii. Perform ! varEnv.InitializeBinding(F, undefined).
+
+                    use crate::vm::CallFrame;
                     let index = self.insert_binding(binding);
-                    let value = self.register_allocator.alloc();
-                    self.bytecode.emit_push_undefined(value.variable());
-                    self.emit_binding_access(BindingAccessOpcode::DefInitVar, &index, &value);
-                    self.register_allocator.dealloc(value);
+                    self.emit_binding_access(
+                        BindingAccessOpcode::DefInitVar,
+                        &index,
+                        &CallFrame::undefined_register(),
+                    );
                 }
             }
         }
@@ -900,10 +903,11 @@ impl ByteCompiler<'_> {
             // 2. Perform ! varEnv.CreateMutableBinding(vn, true).
             // 3. Perform ! varEnv.InitializeBinding(vn, undefined).
             let index = self.insert_binding(binding);
-            let value = self.register_allocator.alloc();
-            self.bytecode.emit_push_undefined(value.variable());
-            self.emit_binding_access(BindingAccessOpcode::DefInitVar, &index, &value);
-            self.register_allocator.dealloc(value);
+            self.emit_binding_access(
+                BindingAccessOpcode::DefInitVar,
+                &index,
+                &CallFrame::undefined_register(),
+            );
         }
 
         // 19. Return unused.
@@ -1182,10 +1186,11 @@ impl ByteCompiler<'_> {
                         // 3. Perform ! env.InitializeBinding(n, undefined).
                         let binding = scope.get_binding_reference(&n).expect("binding must exist");
                         let index = self.insert_binding(binding);
-                        let value = self.register_allocator.alloc();
-                        self.bytecode.emit_push_undefined(value.variable());
-                        self.emit_binding_access(BindingAccessOpcode::DefInitVar, &index, &value);
-                        self.register_allocator.dealloc(value);
+                        self.emit_binding_access(
+                            BindingAccessOpcode::DefInitVar,
+                            &index,
+                            &CallFrame::undefined_register(),
+                        );
                     }
                 }
 
@@ -1218,10 +1223,11 @@ impl ByteCompiler<'_> {
                             .get_binding_reference(&f_string)
                             .expect("binding must exist");
                         let index = self.insert_binding(binding);
-                        let value = self.register_allocator.alloc();
-                        self.bytecode.emit_push_undefined(value.variable());
-                        self.emit_binding_access(BindingAccessOpcode::DefInitVar, &index, &value);
-                        self.register_allocator.dealloc(value);
+                        self.emit_binding_access(
+                            BindingAccessOpcode::DefInitVar,
+                            &index,
+                            &CallFrame::undefined_register(),
+                        );
 
                         // c. Append F to instantiatedVarNames.
                         instantiated_var_names.push(f);

--- a/core/engine/src/bytecompiler/jump_control.rs
+++ b/core/engine/src/bytecompiler/jump_control.rs
@@ -159,12 +159,7 @@ impl JumpRecord {
 
                         // Pushes `undefined` to the stack, which acts as the
                         // `this` value of the call.
-                        {
-                            let value = compiler.register_allocator.alloc();
-                            compiler.bytecode.emit_push_undefined(value.variable());
-                            compiler.push_from_register(&value);
-                            compiler.register_allocator.dealloc(value);
-                        }
+                        compiler.push_from_register(&CallFrame::undefined_register());
 
                         compiler.if_else_with_dealloc(
                             has_exception,
@@ -172,9 +167,8 @@ impl JumpRecord {
                                 // has_exception == true, so we need to call `reject`
                                 // with the current exception.
 
-                                compiler.bytecode.emit_push_from_register(
-                                    (CallFrame::PROMISE_CAPABILITY_REJECT_REGISTER_INDEX as u32)
-                                        .into(),
+                                compiler.push_from_register(
+                                    &CallFrame::promise_capability_reject_register(),
                                 );
                                 compiler.push_from_register(&exception);
                                 compiler.register_allocator.dealloc(exception);
@@ -183,9 +177,8 @@ impl JumpRecord {
                             |compiler| {
                                 // has_exception == false, call `resolve` normally.
 
-                                compiler.bytecode.emit_push_from_register(
-                                    (CallFrame::PROMISE_CAPABILITY_RESOLVE_REGISTER_INDEX as u32)
-                                        .into(),
+                                compiler.push_from_register(
+                                    &CallFrame::promise_capability_resolve_register(),
                                 );
 
                                 {

--- a/core/engine/src/bytecompiler/mod.rs
+++ b/core/engine/src/bytecompiler/mod.rs
@@ -553,6 +553,11 @@ impl<'ctx> ByteCompiler<'ctx> {
         code_block_flags |= CodeBlockFlags::HAS_PROTOTYPE_PROPERTY;
 
         let mut register_allocator = RegisterAllocator::default();
+        let undefined_register = register_allocator.alloc_persistent();
+        debug_assert_eq!(
+            undefined_register.index(),
+            CallFrame::undefined_register().index()
+        );
         if is_async {
             let promise_register = register_allocator.alloc_persistent();
             let resolve_register = register_allocator.alloc_persistent();
@@ -560,22 +565,22 @@ impl<'ctx> ByteCompiler<'ctx> {
 
             debug_assert_eq!(
                 promise_register.index(),
-                CallFrame::PROMISE_CAPABILITY_PROMISE_REGISTER_INDEX as u32
+                CallFrame::promise_capability_promise_register().index()
             );
             debug_assert_eq!(
                 resolve_register.index(),
-                CallFrame::PROMISE_CAPABILITY_RESOLVE_REGISTER_INDEX as u32
+                CallFrame::promise_capability_resolve_register().index()
             );
             debug_assert_eq!(
                 reject_register.index(),
-                CallFrame::PROMISE_CAPABILITY_REJECT_REGISTER_INDEX as u32
+                CallFrame::promise_capability_reject_register().index()
             );
 
             if is_generator {
                 let async_function_object_register = register_allocator.alloc_persistent();
                 debug_assert_eq!(
                     async_function_object_register.index(),
-                    CallFrame::ASYNC_GENERATOR_OBJECT_REGISTER_INDEX as u32
+                    CallFrame::async_generator_object_register().index()
                 );
             }
         }
@@ -2157,16 +2162,10 @@ impl<'ctx> ByteCompiler<'ctx> {
                         self.push_from_register(&value);
                         self.register_allocator.dealloc(value);
                     } else {
-                        let value = self.register_allocator.alloc();
-                        self.bytecode.emit_push_undefined(value.variable());
-                        self.push_from_register(&value);
-                        self.register_allocator.dealloc(value);
+                        self.push_from_register(&CallFrame::undefined_register());
                     }
                 } else {
-                    let value = self.register_allocator.alloc();
-                    self.bytecode.emit_push_undefined(value.variable());
-                    self.push_from_register(&value);
-                    self.register_allocator.dealloc(value);
+                    self.push_from_register(&CallFrame::undefined_register());
                 }
 
                 let value = self.register_allocator.alloc();
@@ -2175,13 +2174,10 @@ impl<'ctx> ByteCompiler<'ctx> {
                 self.register_allocator.dealloc(value);
             }
             expr => {
-                let this = self.register_allocator.alloc();
                 let value = self.register_allocator.alloc();
                 self.compile_expr(expr, &value);
-                self.bytecode.emit_push_undefined(this.variable());
-                self.push_from_register(&this);
+                self.push_from_register(&CallFrame::undefined_register());
                 self.push_from_register(&value);
-                self.register_allocator.dealloc(this);
                 self.register_allocator.dealloc(value);
             }
         }

--- a/core/engine/src/bytecompiler/register.rs
+++ b/core/engine/src/bytecompiler/register.rs
@@ -50,6 +50,13 @@ impl Register {
     pub(crate) fn variable(&self) -> VaryingOperand {
         self.index.into()
     }
+
+    pub(crate) fn persistent(index: u32) -> Self {
+        Self {
+            index,
+            flags: RegisterFlags::PERSISTENT,
+        }
+    }
 }
 
 impl Drop for Register {

--- a/core/engine/src/bytecompiler/statement/loop.rs
+++ b/core/engine/src/bytecompiler/statement/loop.rs
@@ -233,13 +233,7 @@ impl ByteCompiler<'_> {
         self.pop_loop_control_info();
 
         self.iterator_close(false);
-
-        let skip_early_exit = self.jump();
         self.patch_jump(early_exit);
-        let value = self.register_allocator.alloc();
-        self.bytecode.emit_push_undefined(value.variable());
-        self.register_allocator.dealloc(value);
-        self.patch_jump(skip_early_exit);
     }
 
     pub(crate) fn compile_for_of_loop(

--- a/core/engine/src/bytecompiler/statement/mod.rs
+++ b/core/engine/src/bytecompiler/statement/mod.rs
@@ -1,5 +1,5 @@
 use super::jump_control::{JumpRecord, JumpRecordAction, JumpRecordKind};
-use crate::bytecompiler::ByteCompiler;
+use crate::{bytecompiler::ByteCompiler, vm::CallFrame};
 use boa_ast::Statement;
 
 mod block;
@@ -41,19 +41,15 @@ impl ByteCompiler<'_> {
             }
             Statement::Continue(node) => {
                 if root_statement && (use_expr || self.jump_control_info_has_use_expr()) {
-                    let value = self.register_allocator.alloc();
-                    self.bytecode.emit_push_undefined(value.variable());
-                    self.bytecode.emit_set_accumulator(value.variable());
-                    self.register_allocator.dealloc(value);
+                    self.bytecode
+                        .emit_set_accumulator(CallFrame::undefined_register().variable());
                 }
                 self.compile_continue(*node, use_expr);
             }
             Statement::Break(node) => {
                 if root_statement && (use_expr || self.jump_control_info_has_use_expr()) {
-                    let value = self.register_allocator.alloc();
-                    self.bytecode.emit_push_undefined(value.variable());
-                    self.bytecode.emit_set_accumulator(value.variable());
-                    self.register_allocator.dealloc(value);
+                    self.bytecode
+                        .emit_set_accumulator(CallFrame::undefined_register().variable());
                 }
                 self.compile_break(*node, use_expr);
             }

--- a/core/engine/src/bytecompiler/statement/try.rs
+++ b/core/engine/src/bytecompiler/statement/try.rs
@@ -1,6 +1,6 @@
 use crate::{
     bytecompiler::{ByteCompiler, Register, ToJsString, jump_control::JumpControlInfoFlags},
-    vm::opcode::BindingOpcode,
+    vm::{CallFrame, opcode::BindingOpcode},
 };
 use boa_ast::{
     Statement, StatementListItem,
@@ -223,10 +223,8 @@ impl ByteCompiler<'_> {
             match statement {
                 StatementListItem::Statement(statement) => match statement.as_ref() {
                     Statement::Break(_) | Statement::Continue(_) => {
-                        let value = self.register_allocator.alloc();
-                        self.bytecode.emit_push_undefined(value.variable());
-                        self.bytecode.emit_set_accumulator(value.variable());
-                        self.register_allocator.dealloc(value);
+                        self.bytecode
+                            .emit_set_accumulator(CallFrame::undefined_register().variable());
                         break;
                     }
                     Statement::Block(block) => b = block,

--- a/core/engine/src/module/source.rs
+++ b/core/engine/src/module/source.rs
@@ -1671,14 +1671,11 @@ impl SourceTextModule {
                             .get_binding_reference(&name)
                             .expect("binding must exist");
                         let index = compiler.insert_binding(binding);
-                        let value = compiler.register_allocator.alloc();
-                        compiler.bytecode.emit_push_undefined(value.variable());
                         compiler.emit_binding_access(
                             BindingAccessOpcode::DefInitVar,
                             &index,
-                            &value,
+                            &CallFrame::undefined_register(),
                         );
-                        compiler.register_allocator.dealloc(value);
 
                         // 3. Append dn to declaredVarNames.
                         declared_var_names.push(name);

--- a/core/engine/src/vm/call_frame/mod.rs
+++ b/core/engine/src/vm/call_frame/mod.rs
@@ -4,8 +4,12 @@
 
 use super::ActiveRunnable;
 use crate::{
-    JsValue, builtins::iterable::IteratorRecord, environments::EnvironmentStack, realm::Realm,
-    vm::CodeBlock, vm::SourcePath,
+    JsValue,
+    builtins::iterable::IteratorRecord,
+    bytecompiler::Register,
+    environments::EnvironmentStack,
+    realm::Realm,
+    vm::{CodeBlock, SourcePath},
 };
 use boa_ast::Position;
 use boa_ast::scope::BindingLocator;
@@ -105,10 +109,31 @@ impl CallFrame {
     pub(crate) const FUNCTION_PROLOGUE: u32 = 2;
     const THIS_POSITION: usize = 2;
     const FUNCTION_POSITION: usize = 1;
-    pub(crate) const PROMISE_CAPABILITY_PROMISE_REGISTER_INDEX: usize = 0;
-    pub(crate) const PROMISE_CAPABILITY_RESOLVE_REGISTER_INDEX: usize = 1;
-    pub(crate) const PROMISE_CAPABILITY_REJECT_REGISTER_INDEX: usize = 2;
-    pub(crate) const ASYNC_GENERATOR_OBJECT_REGISTER_INDEX: usize = 3;
+    pub(crate) const UNDEFINED_REGISTER_INDEX: usize = 0;
+    pub(crate) const PROMISE_CAPABILITY_PROMISE_REGISTER_INDEX: usize = 1;
+    pub(crate) const PROMISE_CAPABILITY_RESOLVE_REGISTER_INDEX: usize = 2;
+    pub(crate) const PROMISE_CAPABILITY_REJECT_REGISTER_INDEX: usize = 3;
+    pub(crate) const ASYNC_GENERATOR_OBJECT_REGISTER_INDEX: usize = 4;
+
+    pub(crate) fn undefined_register() -> Register {
+        Register::persistent(Self::UNDEFINED_REGISTER_INDEX as u32)
+    }
+
+    pub(crate) fn promise_capability_promise_register() -> Register {
+        Register::persistent(Self::PROMISE_CAPABILITY_PROMISE_REGISTER_INDEX as u32)
+    }
+
+    pub(crate) fn promise_capability_resolve_register() -> Register {
+        Register::persistent(Self::PROMISE_CAPABILITY_RESOLVE_REGISTER_INDEX as u32)
+    }
+
+    pub(crate) fn promise_capability_reject_register() -> Register {
+        Register::persistent(Self::PROMISE_CAPABILITY_REJECT_REGISTER_INDEX as u32)
+    }
+
+    pub(crate) fn async_generator_object_register() -> Register {
+        Register::persistent(Self::ASYNC_GENERATOR_OBJECT_REGISTER_INDEX as u32)
+    }
 
     /// Creates a new `CallFrame` with the provided `CodeBlock`.
     pub(crate) fn new(


### PR DESCRIPTION
This adds a new register on the bytecompiler that only has the `undefined` value in it. This is really useful to skip allocating and deallocating registers on operations that only require a register with the `undefined` value available.