### PR TITLE
Remove "count" and use hexa and better alignment in trace

### DIFF
--- a/core/engine/src/vm/code_block.rs
+++ b/core/engine/src/vm/code_block.rs
@@ -948,7 +948,7 @@ impl Display for CodeBlock {
                 } else {
                     ' '
                 };
-                format!("{border_char}{i:2}: {:06}", handler.handler())
+                format!("{border_char}{i:2}: {:06x}", handler.handler())
             } else {
                 "           ".to_string()
             };


### PR DESCRIPTION
When writing the bytecode in a codeblock, remove confusing count and use hexadecimal for locations. Also fixes an issue with vertical alignment of the handler column. This makes for a simpler and easier to follow trace.
