### PR TITLE
perf: Replace ThinVec with SmallVec for opcode variable arguments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -472,6 +472,7 @@ dependencies = [
  "serde",
  "serde_json",
  "small_btree",
+ "smallvec",
  "static_assertions",
  "sys-locale",
  "tag_ptr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,7 @@ reqwest = { version = "0.13.2" }
 rustc-hash = { version = "2.1.1", default-features = false }
 serde_json = "1.0.149"
 serde = "1.0.219"
+smallvec = "1.15.0"
 static_assertions = "1.1.0"
 textwrap = "0.16.2"
 thin-vec = "0.2.14"

--- a/core/engine/Cargo.toml
+++ b/core/engine/Cargo.toml
@@ -122,6 +122,7 @@ paste.workspace = true
 thiserror.workspace = true
 dashmap.workspace = true
 num_enum.workspace = true
+smallvec.workspace = true
 thin-vec.workspace = true
 itertools = { workspace = true, default-features = false }
 icu_normalizer = { workspace = true, features = [

--- a/core/engine/src/bytecompiler/class.rs
+++ b/core/engine/src/bytecompiler/class.rs
@@ -15,7 +15,7 @@ use boa_ast::{
 };
 use boa_gc::Gc;
 use boa_interner::Sym;
-use thin_vec::ThinVec;
+use crate::vm::opcode::OpVec;
 
 // Static class elements that are initialized at a later time in the class creation.
 enum StaticElement {
@@ -185,7 +185,7 @@ impl ByteCompiler<'_> {
         );
         self.register_allocator.dealloc(prototype_register);
 
-        let mut name_indices = ThinVec::new();
+        let mut name_indices = OpVec::new();
         for element in class.elements {
             match element {
                 ClassElement::MethodDefinition(m) => {

--- a/core/engine/src/bytecompiler/declaration/declaration_pattern.rs
+++ b/core/engine/src/bytecompiler/declaration/declaration_pattern.rs
@@ -6,7 +6,7 @@ use boa_ast::{
     pattern::{ArrayPatternElement, ObjectPatternElement, Pattern},
     property::PropertyName,
 };
-use thin_vec::ThinVec;
+use crate::vm::opcode::OpVec;
 
 impl ByteCompiler<'_> {
     pub(crate) fn compile_declaration_pattern_impl(
@@ -89,7 +89,7 @@ impl ByteCompiler<'_> {
                             let value = self.register_allocator.alloc();
                             self.bytecode.emit_push_empty_object(value.variable());
                             let mut excluded_keys =
-                                ThinVec::with_capacity(excluded_keys_registers.len());
+                                OpVec::with_capacity(excluded_keys_registers.len());
                             for r in &excluded_keys_registers {
                                 excluded_keys.push(r.variable());
                             }
@@ -108,7 +108,7 @@ impl ByteCompiler<'_> {
                             let value = self.register_allocator.alloc();
                             self.bytecode.emit_push_empty_object(value.variable());
                             let mut excluded_keys =
-                                ThinVec::with_capacity(excluded_keys_registers.len());
+                                OpVec::with_capacity(excluded_keys_registers.len());
                             for r in &excluded_keys_registers {
                                 excluded_keys.push(r.variable());
                             }

--- a/core/engine/src/bytecompiler/expression/mod.rs
+++ b/core/engine/src/bytecompiler/expression/mod.rs
@@ -21,7 +21,7 @@ use boa_ast::{
         operator::Conditional,
     },
 };
-use thin_vec::ThinVec;
+use crate::vm::opcode::OpVec;
 
 impl ByteCompiler<'_> {
     fn compile_literal(&mut self, lit: &AstLiteral, dst: &Register) {
@@ -68,7 +68,7 @@ impl ByteCompiler<'_> {
             registers.push(value);
         }
 
-        let mut values = ThinVec::with_capacity(registers.len());
+        let mut values = OpVec::with_capacity(registers.len());
         for reg in &registers {
             values.push(reg.variable());
         }
@@ -323,7 +323,7 @@ impl ByteCompiler<'_> {
                     part_registers.push(value);
                 }
 
-                let mut values = ThinVec::with_capacity(count as usize * 2);
+                let mut values = OpVec::with_capacity(count as usize * 2);
                 for r in &part_registers {
                     values.push(r.index());
                 }

--- a/core/engine/src/bytecompiler/expression/object_literal.rs
+++ b/core/engine/src/bytecompiler/expression/object_literal.rs
@@ -5,7 +5,7 @@ use boa_ast::{
     property::{MethodDefinitionKind, PropertyName},
 };
 use boa_interner::Sym;
-use thin_vec::ThinVec;
+use crate::vm::opcode::OpVec;
 
 impl ByteCompiler<'_> {
     pub(crate) fn compile_object_literal(&mut self, literal: &ObjectLiteral, dst: &Register) {
@@ -113,7 +113,7 @@ impl ByteCompiler<'_> {
                     self.bytecode.emit_copy_data_properties(
                         dst.variable(),
                         source.variable(),
-                        ThinVec::new(),
+                        OpVec::new(),
                     );
                     self.register_allocator.dealloc(source);
                 }

--- a/core/engine/src/bytecompiler/jump_control.rs
+++ b/core/engine/src/bytecompiler/jump_control.rs
@@ -16,7 +16,7 @@ use crate::{
 };
 use bitflags::bitflags;
 use boa_interner::Sym;
-use thin_vec::thin_vec;
+use smallvec::smallvec;
 
 /// An actions to be performed for the local control flow.
 #[derive(Debug, Clone, Copy)]
@@ -608,7 +608,7 @@ impl ByteCompiler<'_> {
         self.bytecode.emit_jump_table(
             finally_throw_index,
             Self::DUMMY_ADDRESS,
-            thin_vec![Self::DUMMY_ADDRESS; info.jumps.len()],
+            smallvec![Self::DUMMY_ADDRESS; info.jumps.len()],
         );
 
         let mut patch_jumps = Vec::with_capacity(info.jumps.len());

--- a/core/engine/src/vm/opcode/args.rs
+++ b/core/engine/src/vm/opcode/args.rs
@@ -1,6 +1,10 @@
-use thin_vec::ThinVec;
+use smallvec::SmallVec;
 
 use super::VaryingOperand;
+
+/// A small-vector type for opcode variable arguments.
+/// Inline capacity of 8 avoids heap allocation for typical operand counts.
+pub(crate) type OpVec<T> = SmallVec<[T; 8]>;
 
 /// A trait for types that can be read from a byte slice.
 ///
@@ -279,7 +283,7 @@ impl Argument for (u32, VaryingOperand, VaryingOperand) {
     }
 }
 
-impl Argument for (VaryingOperand, ThinVec<VaryingOperand>) {
+impl Argument for (VaryingOperand, OpVec<VaryingOperand>) {
     fn encode(self, bytes: &mut Vec<u8>) {
         // Write length of all arguments
         let total_len = self.1.len();
@@ -308,7 +312,7 @@ impl Argument for (VaryingOperand, ThinVec<VaryingOperand>) {
         let first = unsafe { read_unchecked::<u32>(bytes, pos + 2) };
 
         // Read remaining arguments
-        let mut rest = ThinVec::with_capacity(total_len);
+        let mut rest = OpVec::with_capacity(total_len);
         for i in 0..total_len {
             let value = unsafe { read_unchecked::<u32>(bytes, pos + 6 + i * 4) };
             rest.push(value.into());
@@ -318,7 +322,7 @@ impl Argument for (VaryingOperand, ThinVec<VaryingOperand>) {
     }
 }
 
-impl Argument for (VaryingOperand, VaryingOperand, ThinVec<VaryingOperand>) {
+impl Argument for (VaryingOperand, VaryingOperand, OpVec<VaryingOperand>) {
     fn encode(self, bytes: &mut Vec<u8>) {
         // Write length of all arguments
         let total_len = self.2.len();
@@ -348,7 +352,7 @@ impl Argument for (VaryingOperand, VaryingOperand, ThinVec<VaryingOperand>) {
         let (first, second) = unsafe { read_unchecked::<(u32, u32)>(bytes, pos + 2) };
 
         // Read remaining arguments
-        let mut rest = ThinVec::with_capacity(total_len);
+        let mut rest = OpVec::with_capacity(total_len);
         for i in 0..total_len {
             let value = unsafe { read_unchecked::<u32>(bytes, pos + 10 + i * 4) };
             rest.push(value.into());
@@ -395,7 +399,7 @@ impl Argument for (u32, u32, VaryingOperand, VaryingOperand, VaryingOperand) {
     }
 }
 
-impl Argument for (u32, ThinVec<u32>) {
+impl Argument for (u32, OpVec<u32>) {
     fn encode(self, bytes: &mut Vec<u8>) {
         // Write length
         let total_len = self.1.len();
@@ -424,7 +428,7 @@ impl Argument for (u32, ThinVec<u32>) {
         let first = unsafe { read_unchecked::<u32>(bytes, pos + 2) };
 
         // Read remaining arguments
-        let mut rest = ThinVec::with_capacity(total_len);
+        let mut rest = OpVec::with_capacity(total_len);
         for i in 0..total_len {
             let value = unsafe { read_unchecked::<u32>(bytes, pos + 6 + i * 4) };
             rest.push(value);
@@ -434,7 +438,7 @@ impl Argument for (u32, ThinVec<u32>) {
     }
 }
 
-impl Argument for (u64, VaryingOperand, ThinVec<u32>) {
+impl Argument for (u64, VaryingOperand, OpVec<u32>) {
     fn encode(self, bytes: &mut Vec<u8>) {
         // Write length
         let total_len = self.2.len();
@@ -465,7 +469,7 @@ impl Argument for (u64, VaryingOperand, ThinVec<u32>) {
         let second = unsafe { read_unchecked::<u32>(bytes, pos + 10) };
 
         // Read remaining arguments
-        let mut rest = ThinVec::with_capacity(total_len);
+        let mut rest = OpVec::with_capacity(total_len);
         for i in 0..total_len {
             let value = unsafe { read_unchecked::<u32>(bytes, pos + 14 + i * 4) };
             rest.push(value);
@@ -475,7 +479,7 @@ impl Argument for (u64, VaryingOperand, ThinVec<u32>) {
     }
 }
 
-impl Argument for (VaryingOperand, ThinVec<u32>) {
+impl Argument for (VaryingOperand, OpVec<u32>) {
     fn encode(self, bytes: &mut Vec<u8>) {
         // Write length
         let total_len = self.1.len();
@@ -504,7 +508,7 @@ impl Argument for (VaryingOperand, ThinVec<u32>) {
         let first = unsafe { read_unchecked::<u32>(bytes, pos + 2) };
 
         // Read remaining arguments
-        let mut rest = ThinVec::with_capacity(total_len);
+        let mut rest = OpVec::with_capacity(total_len);
         for i in 0..total_len {
             let value = unsafe { read_unchecked::<u32>(bytes, pos + 6 + i * 4) };
             rest.push(value);
@@ -514,7 +518,7 @@ impl Argument for (VaryingOperand, ThinVec<u32>) {
     }
 }
 
-impl Argument for (u32, u32, ThinVec<u32>) {
+impl Argument for (u32, u32, OpVec<u32>) {
     fn encode(self, bytes: &mut Vec<u8>) {
         // Write first argument
         write_u32(bytes, self.0);
@@ -549,7 +553,7 @@ impl Argument for (u32, u32, ThinVec<u32>) {
         let second = unsafe { read_unchecked::<u32>(bytes, pos + 6) };
 
         // Read remaining arguments
-        let mut rest = ThinVec::with_capacity(total_len);
+        let mut rest = OpVec::with_capacity(total_len);
         for i in 0..total_len {
             let value = unsafe { read_unchecked::<u32>(bytes, pos + 10 + i * 4) };
             rest.push(value);

--- a/core/engine/src/vm/opcode/concat/mod.rs
+++ b/core/engine/src/vm/opcode/concat/mod.rs
@@ -1,6 +1,6 @@
 use super::VaryingOperand;
 use crate::{Context, JsResult, JsString, vm::opcode::Operation};
-use thin_vec::ThinVec;
+use super::OpVec;
 
 /// `ConcatToString` implements the Opcode Operation for `Opcode::ConcatToString`
 ///
@@ -12,7 +12,7 @@ pub(crate) struct ConcatToString;
 impl ConcatToString {
     #[inline(always)]
     pub(super) fn operation(
-        (string, values): (VaryingOperand, ThinVec<VaryingOperand>),
+        (string, values): (VaryingOperand, OpVec<VaryingOperand>),
 
         context: &mut Context,
     ) -> JsResult<()> {

--- a/core/engine/src/vm/opcode/control_flow/jump.rs
+++ b/core/engine/src/vm/opcode/control_flow/jump.rs
@@ -2,7 +2,7 @@ use crate::{
     Context,
     vm::opcode::{Operation, VaryingOperand},
 };
-use thin_vec::ThinVec;
+use crate::vm::opcode::OpVec;
 
 /// `Jump` implements the Opcode Operation for `Opcode::Jump`
 ///
@@ -126,7 +126,7 @@ pub(crate) struct JumpTable;
 impl JumpTable {
     #[inline(always)]
     pub(crate) fn operation(
-        (index, default, addresses): (u32, u32, ThinVec<u32>),
+        (index, default, addresses): (u32, u32, OpVec<u32>),
         context: &mut Context,
     ) {
         let value = context.vm.get_register(index as usize);

--- a/core/engine/src/vm/opcode/copy/mod.rs
+++ b/core/engine/src/vm/opcode/copy/mod.rs
@@ -1,6 +1,6 @@
 use super::VaryingOperand;
 use crate::{Context, JsResult, vm::opcode::Operation};
-use thin_vec::ThinVec;
+use super::OpVec;
 
 /// `CopyDataProperties` implements the Opcode Operation for `Opcode::CopyDataProperties`
 ///
@@ -12,7 +12,7 @@ pub(crate) struct CopyDataProperties;
 impl CopyDataProperties {
     #[inline(always)]
     pub(super) fn operation(
-        (object, source, keys): (VaryingOperand, VaryingOperand, ThinVec<VaryingOperand>),
+        (object, source, keys): (VaryingOperand, VaryingOperand, OpVec<VaryingOperand>),
         context: &mut Context,
     ) -> JsResult<()> {
         let object = context.vm.get_register(object.into()).clone();

--- a/core/engine/src/vm/opcode/mod.rs
+++ b/core/engine/src/vm/opcode/mod.rs
@@ -5,8 +5,8 @@ use crate::{
     vm::{completion_record::CompletionRecord, completion_record::IntoCompletionRecord},
 };
 use args::{Argument, read};
+pub(crate) use args::OpVec;
 use std::ops::ControlFlow;
-use thin_vec::ThinVec;
 
 mod args;
 
@@ -1507,7 +1507,7 @@ generate_opcodes! {
     ///
     /// - Registers:
     ///   - Input: object, source, excluded_keys
-    CopyDataProperties { object: VaryingOperand, source: VaryingOperand, excluded_keys: ThinVec<VaryingOperand> },
+    CopyDataProperties { object: VaryingOperand, source: VaryingOperand, excluded_keys: OpVec<VaryingOperand> },
 
     /// Call ToPropertyKey on the value on the stack.
     ///
@@ -1572,7 +1572,7 @@ generate_opcodes! {
     /// that has finally block.
     ///
     /// Operands: index: Register, default: `u32`, count: `u32`, address: `u32` * count
-    JumpTable { index: u32, default: u32, addresses: ThinVec<u32> },
+    JumpTable { index: u32, default: u32, addresses: OpVec<u32> },
 
     /// Throw exception.
     ///
@@ -1906,7 +1906,7 @@ generate_opcodes! {
     /// - Registers:
     ///   - Input: values
     ///   - Output: dst
-    ConcatToString { dst: VaryingOperand, values: ThinVec<VaryingOperand> },
+    ConcatToString { dst: VaryingOperand, values: OpVec<VaryingOperand> },
 
     /// Require the stack value to be neither null nor undefined.
     ///
@@ -2030,7 +2030,7 @@ generate_opcodes! {
     /// - Registers:
     ///   - Inputs: values
     ///   - Output: dst
-    TemplateCreate { site: u64, dst: VaryingOperand, values: ThinVec<u32> },
+    TemplateCreate { site: u64, dst: VaryingOperand, values: OpVec<u32> },
 
     /// Push a private environment.
     ///
@@ -2038,7 +2038,7 @@ generate_opcodes! {
     ///
     /// - Registers:
     ///   - Input: class, name_indices
-    PushPrivateEnvironment { class: VaryingOperand, name_indices: ThinVec<u32> },
+    PushPrivateEnvironment { class: VaryingOperand, name_indices: OpVec<u32> },
 
     /// Pop a private environment.
     PopPrivateEnvironment,

--- a/core/engine/src/vm/opcode/push/environment.rs
+++ b/core/engine/src/vm/opcode/push/environment.rs
@@ -5,7 +5,7 @@ use crate::{
     vm::opcode::{Operation, VaryingOperand},
 };
 use boa_gc::Gc;
-use thin_vec::ThinVec;
+use crate::vm::opcode::OpVec;
 
 /// `PushScope` implements the Opcode Operation for `Opcode::PushScope`
 ///
@@ -65,7 +65,7 @@ pub(crate) struct PushPrivateEnvironment;
 impl PushPrivateEnvironment {
     #[inline(always)]
     pub(crate) fn operation(
-        (class, name_indices): (VaryingOperand, ThinVec<u32>),
+        (class, name_indices): (VaryingOperand, OpVec<u32>),
         context: &mut Context,
     ) {
         let class = context.vm.get_register(class.into());

--- a/core/engine/src/vm/opcode/templates/mod.rs
+++ b/core/engine/src/vm/opcode/templates/mod.rs
@@ -3,7 +3,7 @@ use crate::{
     Context, builtins::array::Array, js_string, object::IntegrityLevel,
     property::PropertyDescriptor, vm::opcode::Operation,
 };
-use thin_vec::ThinVec;
+use super::OpVec;
 
 /// `TemplateLookup` implements the Opcode Operation for `Opcode::TemplateLookup`
 ///
@@ -38,7 +38,7 @@ pub(crate) struct TemplateCreate;
 impl TemplateCreate {
     #[inline(always)]
     pub(super) fn operation(
-        (site, dst, values): (u64, VaryingOperand, ThinVec<u32>),
+        (site, dst, values): (u64, VaryingOperand, OpVec<u32>),
         context: &mut Context,
     ) {
         let count = values.len() / 2;


### PR DESCRIPTION
Opcode variable arguments are short-lived vectors decoded from bytecode and immediately consumed by opcode handlers. Using SmallVec with an inline capacity of 8 avoids heap allocation for typical operand counts, reducing allocator pressure on the instruction dispatch hot path.
