### PR TITLE
Make jump tables fast

### DIFF
--- a/core/engine/Cargo.toml
+++ b/core/engine/Cargo.toml
@@ -123,7 +123,7 @@ thiserror.workspace = true
 dashmap.workspace = true
 num_enum.workspace = true
 thin-vec.workspace = true
-itertools = { workspace = true, default-features = false }
+itertools = { workspace = true, default-features = false, features = ["use_alloc"] }
 icu_normalizer = { workspace = true, features = [
     "compiled_data",
     "utf16_iter",

--- a/core/engine/src/bytecompiler/jump_control.rs
+++ b/core/engine/src/bytecompiler/jump_control.rs
@@ -113,8 +113,7 @@ impl JumpRecord {
                     finally_throw_flag,
                     finally_throw_index,
                 } => {
-                    // Note: +1 because 0 is reserved for default entry in jump table (for fallthrough).
-                    let index = value as i32 + 1;
+                    let index = value as i32;
                     compiler.bytecode.emit_push_false(finally_throw_flag.into());
                     compiler.emit_push_integer_with_index(index, finally_throw_index.into());
                 }
@@ -607,9 +606,13 @@ impl ByteCompiler<'_> {
         let jump_table_index = self.next_opcode_location() + size_of::<u32>() as u32;
         self.bytecode.emit_jump_table(
             finally_throw_index,
-            Self::DUMMY_ADDRESS,
             thin_vec![Self::DUMMY_ADDRESS; info.jumps.len()],
         );
+
+        // We are assuming any indices outside our jump table will fallback
+        // to executing the next available op. Since we kinda control the jump
+        // table index here, this doesn't matter too much, but we _could_ also
+        // throw a PanicError on the next instruction.
 
         let mut patch_jumps = Vec::with_capacity(info.jumps.len());
         // Handle breaks/continue/returns in a finally block
@@ -620,10 +623,8 @@ impl ByteCompiler<'_> {
             jump_record.perform_actions(Self::DUMMY_ADDRESS, self);
         }
 
-        let default = self.bytecode.next_opcode_location();
-
         self.bytecode
-            .patch_jump_table(jump_table_index, (default, &patch_jumps));
+            .patch_jump_table(jump_table_index, &patch_jumps);
     }
 
     pub(crate) fn jump_info_open_environment_count(&self, index: usize) -> u32 {

--- a/core/engine/src/vm/code_block.rs
+++ b/core/engine/src/vm/code_block.rs
@@ -13,6 +13,7 @@ use crate::{
 use bitflags::bitflags;
 use boa_ast::scope::{BindingLocator, Scope};
 use boa_gc::{Finalize, Gc, Trace, empty_trace};
+use itertools::Itertools;
 use std::{cell::Cell, fmt::Display, fmt::Write as _};
 use thin_vec::ThinVec;
 
@@ -817,17 +818,11 @@ impl CodeBlock {
             Instruction::TemplateLookup { address, site, dst } => {
                 format!("address:{address}, site:{site}, dst:{dst}")
             }
-            Instruction::JumpTable {
-                index,
-                default,
-                addresses,
-            } => {
-                let mut operands =
-                    format!("index:{index} #{}: Default: {default:4}", addresses.len());
-                for (i, address) in addresses.iter().enumerate() {
-                    let _ = write!(operands, ", {i}: {address}");
-                }
-                operands
+            Instruction::JumpTable { index, addresses } => {
+                format!(
+                    "index:{index}, jump_table:[{}]",
+                    addresses.iter().join(", ")
+                )
             }
             Instruction::ConcatToString { dst, values } => {
                 format!("dst:{dst}, values:{values:?}")

--- a/core/engine/src/vm/flowgraph/mod.rs
+++ b/core/engine/src/vm/flowgraph/mod.rs
@@ -346,14 +346,14 @@ impl CodeBlock {
                 }
                 Instruction::JumpTable {
                     index: _,
-                    default,
                     addresses,
                 } => {
                     graph.add_node(previous_pc, NodeShape::None, label.into(), Color::None);
+
                     graph.add_edge(
                         previous_pc,
-                        default as usize,
-                        Some("DEFAULT".into()),
+                        pc,
+                        Some("CONTINUE".into()),
                         Color::None,
                         EdgeStyle::Line,
                     );
@@ -362,7 +362,7 @@ impl CodeBlock {
                         graph.add_edge(
                             previous_pc,
                             *address as usize,
-                            Some(format!("Index: {i}").into()),
+                            Some(format!("[{i}]").into()),
                             Color::None,
                             EdgeStyle::Line,
                         );

--- a/core/engine/src/vm/opcode/control_flow/jump.rs
+++ b/core/engine/src/vm/opcode/control_flow/jump.rs
@@ -125,26 +125,17 @@ pub(crate) struct JumpTable;
 
 impl JumpTable {
     #[inline(always)]
-    pub(crate) fn operation(
-        (index, default, addresses): (u32, u32, ThinVec<u32>),
-        context: &mut Context,
-    ) {
+    pub(crate) fn operation((index, addresses): (u32, ThinVec<u32>), context: &mut Context) {
         let value = context.vm.get_register(index as usize);
-        if let Some(value) = value.as_i32() {
-            let value = value as usize;
-            let mut target = None;
-            for (i, address) in addresses.iter().enumerate() {
-                if i + 1 == value {
-                    target = Some(*address);
-                }
-            }
-
-            context.vm.frame_mut().pc = target.unwrap_or(default);
-
+        let Some(offset) = value.as_i32().map(|i| i as usize) else {
             return;
-        }
+        };
 
-        unreachable!("expected positive integer, got {value:?}")
+        let Some(pc) = addresses.get(offset).copied() else {
+            return;
+        };
+
+        context.vm.frame_mut().pc = pc;
     }
 }
 

--- a/core/engine/src/vm/opcode/mod.rs
+++ b/core/engine/src/vm/opcode/mod.rs
@@ -170,23 +170,15 @@ impl ByteCodeEmitter {
     }
 
     /// Patch the jump instruction at the given label with jump table addresses.
-    pub(crate) fn patch_jump_table(&mut self, label: u32, patch: (u32, &[u32])) {
-        // label = opcode_pos + sizeof(u32), skipping past the index operand.
-        // +1 to skip the opcode byte itself.
-        let default_pos = label as usize + 1;
+    pub(crate) fn patch_jump_table(&mut self, label: u32, patch: &[u32]) {
+        let length_offset = label as usize + 1;
 
-        // Skip past default (u32) to read the ThinVec length (u32).
-        let (_, len_pos) = read::<u32>(&self.bytecode, default_pos);
-        let (total_len, first_addr_pos) = read::<u32>(&self.bytecode, len_pos);
-        assert_eq!(total_len as usize, patch.1.len());
-
-        // Write patched default address.
-        self.bytecode[default_pos..default_pos + size_of::<u32>()]
-            .copy_from_slice(&patch.0.to_le_bytes());
+        let (length, first_offset) = read::<u32>(&self.bytecode, length_offset);
+        assert_eq!(length as usize, patch.len());
 
         // Write patched address values.
-        for (i, value) in patch.1.iter().enumerate() {
-            let offset = first_addr_pos + i * size_of::<u32>();
+        for (i, value) in patch.iter().enumerate() {
+            let offset = first_offset + i * size_of::<u32>();
             self.bytecode[offset..offset + size_of::<u32>()].copy_from_slice(&value.to_le_bytes());
         }
     }
@@ -1567,8 +1559,8 @@ generate_opcodes! {
     /// This is used to handle special cases when we call `continue`, `break` or `return` in a try block,
     /// that has finally block.
     ///
-    /// Operands: index: Register, default: `u32`, count: `u32`, address: `u32` * count
-    JumpTable { index: u32, default: u32, addresses: ThinVec<u32> },
+    /// Operands: index: Register, count: `u32`, address: `u32` * count
+    JumpTable { index: u32, addresses: ThinVec<u32> },
 
     /// Throw exception.
     ///


### PR DESCRIPTION
Our current code to execute jump tables is kind of wonky; it iteratively goes through all the entries of the jump table until it finds the desired index. The intended way of using a jump table is to just use the value as an index into the table, then jump to the returned pc value.

This PR also removes the `default` argument of jump tables. The fallback is usually to just not jump and keep executing the next instruction, we don't need to explicitly add a default path.
