### PR TITLE
fix(jsproxy): convert panics to EngineError::Panic using js_expect

### DIFF
--- a/core/engine/src/object/builtins/jsproxy.rs
+++ b/core/engine/src/object/builtins/jsproxy.rs
@@ -393,7 +393,7 @@ impl JsProxyBuilder {
     /// Equivalent to the `Proxy ( target, handler )` constructor, but returns a
     /// [`JsObject`] in case there's a need to manipulate the returned object
     /// inside Rust code.
-        pub fn build(self, context: &mut Context) -> JsResult<JsProxy> {
+    pub fn build(self, context: &mut Context) -> JsResult<JsProxy> {
         let handler = JsObject::with_object_proto(context.intrinsics());
 
         if let Some(apply) = self.apply {


### PR DESCRIPTION
Part of #3241

Converts all 13 panics in `jsproxy.rs` to `EngineError::Panic` using
`js_expect` introduced in #4828.

`build()` and `build_revocable()` return types changed from `JsProxy`/
`JsRevocableProxy` to `JsResult<JsProxy>`/`JsResult<JsRevocableProxy>`.
Checked for external callers —> only a type re-export in `mod.rs`, so
the cascade is limited to 1 file.

Note: The two `JsNativeError::typ()` usages in `from_object()` and
`TryFromJs` are intentionally left unchanged (becauze i think  these are correct
user-facing TypeErrors, not internal implementation failures.)