### PR TITLE
ci: test262 actions bot comments main commit too

### DIFF
--- a/.github/workflows/test262_pr.yml
+++ b/.github/workflows/test262_pr.yml
@@ -63,10 +63,13 @@ jobs:
         run: |
           cd boa
           comment="$(./target/release/boa_tester compare ../data/test262/refs/heads/main/latest.json ../results/test262/refs/heads/main/latest.json -m)"
+          maincommit="$(jq -r '.c' ../results/test262/refs/heads/main/latest.json)"
           echo "comment<<EOF" >> $GITHUB_OUTPUT
           echo "$comment" >> $GITHUB_OUTPUT
           echo "" >> $GITHUB_OUTPUT
+          echo "Tested main commit: [\`${maincommit}\`](${{ github.event.pull_request.base.repo.html_url }}/commit/${maincommit})" >> $GITHUB_OUTPUT
           echo "Tested PR commit: [\`${{ github.event.pull_request.head.sha }}\`](${{ github.event.pull_request.head.repo.html_url }}/commit/${{ github.event.pull_request.head.sha }})" >> $GITHUB_OUTPUT
+          echo "Compare commits: ${{ github.event.pull_request.base.repo.html_url }}/compare/${maincommit}...${{ github.event.pull_request.head.sha }}" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Get the PR number


### PR DESCRIPTION
Yet another upgrade for the test 262 actions bot. Currently, only PR commit is shown.
It is possible that the base commit on main is not immediately clear without this PR (e.g. if main has a newer commit than the PR's latest one)


Demo at https://github.com/zhuzhu81998/boa/pull/3:
<img width="1617" height="1122" alt="image" src="https://github.com/user-attachments/assets/a4288212-3010-4907-8fa0-6fe32c1be3c5" />

Made possible by #4792 (so that the `latest.json` would contain the correct commit, which is read here via `jq` which is by default included in the runner environment).