### PR TITLE
perf: optimize loop update expressions and comparison fast paths

### DIFF
--- a/core/engine/src/bytecompiler/expression/mod.rs
+++ b/core/engine/src/bytecompiler/expression/mod.rs
@@ -91,7 +91,7 @@ impl ByteCompiler<'_> {
                 );
             }
             Expression::Unary(unary) => self.compile_unary(unary, dst),
-            Expression::Update(update) => self.compile_update(update, dst),
+            Expression::Update(update) => self.compile_update(update, dst, false),
             Expression::Binary(binary) => self.compile_binary(binary, dst),
             Expression::BinaryInPrivate(binary) => self.compile_binary_in_private(binary, dst),
             Expression::Assign(assign) => self.compile_assign(assign, dst),

--- a/core/engine/src/bytecompiler/expression/update.rs
+++ b/core/engine/src/bytecompiler/expression/update.rs
@@ -10,7 +10,7 @@ use boa_ast::{
 };
 
 impl ByteCompiler<'_> {
-    pub(crate) fn compile_update(&mut self, update: &Update, dst: &Register) {
+    pub(crate) fn compile_update(&mut self, update: &Update, dst: &Register, discard: bool) {
         let mut compiler = self.position_guard(update);
         let increment = matches!(
             update.op(),
@@ -51,6 +51,17 @@ impl ByteCompiler<'_> {
                     && let BindingKind::Local(Some(local_reg)) = &index
                 {
                     let local_op = (*local_reg).into();
+
+                    if discard {
+                        // Result unused — just increment in-place.
+                        if increment {
+                            compiler.bytecode.emit_inc(local_op, local_op);
+                        } else {
+                            compiler.bytecode.emit_dec(local_op, local_op);
+                        }
+                        return;
+                    }
+
                     if post {
                         // Save old value to dst (post-increment returns old value).
                         compiler.bytecode.emit_move(dst.variable(), local_op);
@@ -112,7 +123,7 @@ impl ByteCompiler<'_> {
                         &value,
                     );
                 }
-                if !post {
+                if !post && !discard {
                     compiler
                         .bytecode
                         .emit_move(dst.variable(), value.variable());

--- a/core/engine/src/bytecompiler/statement/loop.rs
+++ b/core/engine/src/bytecompiler/statement/loop.rs
@@ -1,4 +1,5 @@
 use boa_ast::{
+    Expression,
     declaration::Binding,
     operations::bound_names,
     scope::BindingLocatorError,
@@ -122,7 +123,11 @@ impl ByteCompiler<'_> {
 
         if let Some(final_expr) = for_loop.final_expr() {
             let value = self.register_allocator.alloc();
-            self.compile_expr(final_expr, &value);
+            if let Expression::Update(update) = final_expr {
+                self.compile_update(update, &value, true);
+            } else {
+                self.compile_expr(final_expr, &value);
+            }
             self.register_allocator.dealloc(value);
         }
 

--- a/core/engine/src/value/operations.rs
+++ b/core/engine/src/value/operations.rs
@@ -835,46 +835,46 @@ impl JsValue {
 
     /// Fast path for the `<` operator.
     #[inline]
-    pub(crate) fn lt_fast(&self, other: &Self) -> Option<Self> {
+    pub(crate) fn lt_fast(&self, other: &Self) -> Option<bool> {
         if let (Some(x), Some(y)) = (self.0.as_integer32(), other.0.as_integer32()) {
-            return Some(Self::new(x < y));
+            return Some(x < y);
         }
         let x = self.as_number_cheap()?;
         let y = other.as_number_cheap()?;
-        Some(Self::new(x < y))
+        Some(x < y)
     }
 
     /// Fast path for the `<=` operator.
     #[inline]
-    pub(crate) fn le_fast(&self, other: &Self) -> Option<Self> {
+    pub(crate) fn le_fast(&self, other: &Self) -> Option<bool> {
         if let (Some(x), Some(y)) = (self.0.as_integer32(), other.0.as_integer32()) {
-            return Some(Self::new(x <= y));
+            return Some(x <= y);
         }
         let x = self.as_number_cheap()?;
         let y = other.as_number_cheap()?;
-        Some(Self::new(x <= y))
+        Some(x <= y)
     }
 
     /// Fast path for the `>` operator.
     #[inline]
-    pub(crate) fn gt_fast(&self, other: &Self) -> Option<Self> {
+    pub(crate) fn gt_fast(&self, other: &Self) -> Option<bool> {
         if let (Some(x), Some(y)) = (self.0.as_integer32(), other.0.as_integer32()) {
-            return Some(Self::new(x > y));
+            return Some(x > y);
         }
         let x = self.as_number_cheap()?;
         let y = other.as_number_cheap()?;
-        Some(Self::new(x > y))
+        Some(x > y)
     }
 
     /// Fast path for the `>=` operator.
     #[inline]
-    pub(crate) fn ge_fast(&self, other: &Self) -> Option<Self> {
+    pub(crate) fn ge_fast(&self, other: &Self) -> Option<bool> {
         if let (Some(x), Some(y)) = (self.0.as_integer32(), other.0.as_integer32()) {
-            return Some(Self::new(x >= y));
+            return Some(x >= y);
         }
         let x = self.as_number_cheap()?;
         let y = other.as_number_cheap()?;
-        Some(Self::new(x >= y))
+        Some(x >= y)
     }
 
     /// Fast path for the `==` operator (numeric only).

--- a/core/engine/src/vm/opcode/control_flow/jump.rs
+++ b/core/engine/src/vm/opcode/control_flow/jump.rs
@@ -132,7 +132,7 @@ impl JumpIfNotLessThan {
         let lhs = context.vm.get_register(lhs.into());
         let rhs = context.vm.get_register(rhs.into());
         if let Some(result) = lhs.lt_fast(rhs) {
-            if !result.to_boolean() {
+            if !result {
                 context.vm.frame_mut().pc = u32::from(address);
             }
             return Ok(());
@@ -168,7 +168,7 @@ impl JumpIfNotLessThanOrEqual {
         let lhs = context.vm.get_register(lhs.into());
         let rhs = context.vm.get_register(rhs.into());
         if let Some(result) = lhs.le_fast(rhs) {
-            if !result.to_boolean() {
+            if !result {
                 context.vm.frame_mut().pc = u32::from(address);
             }
             return Ok(());
@@ -204,7 +204,7 @@ impl JumpIfNotGreaterThan {
         let lhs = context.vm.get_register(lhs.into());
         let rhs = context.vm.get_register(rhs.into());
         if let Some(result) = lhs.gt_fast(rhs) {
-            if !result.to_boolean() {
+            if !result {
                 context.vm.frame_mut().pc = u32::from(address);
             }
             return Ok(());
@@ -240,7 +240,7 @@ impl JumpIfNotGreaterThanOrEqual {
         let lhs = context.vm.get_register(lhs.into());
         let rhs = context.vm.get_register(rhs.into());
         if let Some(result) = lhs.ge_fast(rhs) {
-            if !result.to_boolean() {
+            if !result {
                 context.vm.frame_mut().pc = u32::from(address);
             }
             return Ok(());


### PR DESCRIPTION
- Add `discard` parameter to `compile_update` to skip dead Move opcodes when the result of an update expression is unused (e.g., `i++` in `for` loop final expressions)
- Return `bool` directly from comparison fast paths (`lt_fast`, `le_fast`, `gt_fast`, `ge_fast`) instead of wrapping in `JsValue`, avoiding unnecessary `.to_boolean()` calls in fused comparison-branch opcodes
