### PR TITLE
Switch to zerocopy tzdb provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2601,12 +2601,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jiff-tzdb"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68971ebff725b9e2ca27a601c5eb38a4c5d64422c4cbab0c535f248087eda5c2"
-
-[[package]]
 name = "jni"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4443,10 +4437,8 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "838a6ce9f08d07a637682a7dda441b97dc34e4aaf0dbfd9ca3d7eaf6fe1e8495"
 dependencies = [
- "combine",
- "jiff-tzdb",
  "tinystr",
- "tzif",
+ "zerofrom",
  "zerotrie",
  "zerovec",
 ]
@@ -4772,15 +4764,6 @@ name = "typeid"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
-
-[[package]]
-name = "tzif"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0376dfa52cce372f3b095010fd064fb850a5d8fbfd5be8b0ffa3d64eeab5a5d"
-dependencies = [
- "combine",
-]
 
 [[package]]
 name = "unicode-ident"

--- a/core/engine/Cargo.toml
+++ b/core/engine/Cargo.toml
@@ -56,7 +56,7 @@ intl = [
     "dep:fixed_decimal",
     "dep:tinystr",
     "dep:timezone_provider",
-    "timezone_provider/tzif",
+    "timezone_provider/experimental_tzif",
 ]
 
 fuzz = ["boa_ast/arbitrary", "boa_interner/arbitrary"]
@@ -71,7 +71,7 @@ trace = ["js"]
 annex-b = ["boa_ast/annex-b", "boa_parser/annex-b"]
 
 # Enable Boa's Temporal proposal implementation
-temporal = ["dep:icu_calendar", "dep:temporal_rs", "dep:timezone_provider", "timezone_provider/tzif"]
+temporal = ["dep:icu_calendar", "dep:temporal_rs", "dep:timezone_provider", "timezone_provider/experimental_tzif"]
 
 #Enable access to host system timezone
 system-time-zone = ["dep:iana-time-zone"]

--- a/core/engine/src/context/mod.rs
+++ b/core/engine/src/context/mod.rs
@@ -12,7 +12,7 @@ use intrinsics::Intrinsics;
 #[cfg(any(feature = "temporal", feature = "intl"))]
 use temporal_rs::provider::TimeZoneProvider;
 #[cfg(any(feature = "temporal", feature = "intl"))]
-use timezone_provider::tzif::CompiledTzdbProvider;
+use timezone_provider::experimental_tzif::ZeroCompiledTzdbProvider;
 
 use crate::job::Job;
 use crate::module::DynModuleLoader;
@@ -1142,7 +1142,7 @@ impl ContextBuilder {
             timezone_provider: if let Some(provider) = self.timezone_provider {
                 provider
             } else {
-                Box::new(CompiledTzdbProvider::default())
+                Box::new(ZeroCompiledTzdbProvider::default())
             },
             #[cfg(feature = "intl")]
             intl_provider: if let Some(icu) = self.icu {


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This switches us off the compiled tzdb provider that parses data at runtime to the zerocopy compiled tzdb provider.

Also, it lowers our dependencies, so that's nice.
