### PR TITLE
refactor: remove `PoisonableEnvironment` layer

### DIFF
--- a/core/engine/src/environments/runtime/declarative/function.rs
+++ b/core/engine/src/environments/runtime/declarative/function.rs
@@ -3,11 +3,9 @@ use boa_gc::{Finalize, GcRefCell, Trace, custom_trace};
 
 use crate::{JsNativeError, JsObject, JsResult, JsValue, builtins::function::OrdinaryFunction};
 
-use super::PoisonableEnvironment;
-
 #[derive(Debug, Trace, Finalize)]
 pub(crate) struct FunctionEnvironment {
-    inner: PoisonableEnvironment,
+    bindings: GcRefCell<Vec<Option<JsValue>>>,
     slots: Box<FunctionSlots>,
 
     // Safety: Nothing in `Scope` needs tracing.
@@ -17,15 +15,9 @@ pub(crate) struct FunctionEnvironment {
 
 impl FunctionEnvironment {
     /// Creates a new `FunctionEnvironment`.
-    pub(crate) fn new(
-        bindings: u32,
-        poisoned: bool,
-        with: bool,
-        slots: FunctionSlots,
-        scope: Scope,
-    ) -> Self {
+    pub(crate) fn new(bindings_count: u32, slots: FunctionSlots, scope: Scope) -> Self {
         Self {
-            inner: PoisonableEnvironment::new(bindings, poisoned, with),
+            bindings: GcRefCell::new(vec![None; bindings_count as usize]),
             slots: Box::new(slots),
             scope,
         }
@@ -41,11 +33,6 @@ impl FunctionEnvironment {
         &self.scope
     }
 
-    /// Gets the `poisonable_environment` of this function environment.
-    pub(crate) const fn poisonable_environment(&self) -> &PoisonableEnvironment {
-        &self.inner
-    }
-
     /// Gets the binding value from the environment by it's index.
     ///
     /// # Panics
@@ -53,7 +40,7 @@ impl FunctionEnvironment {
     /// Panics if the binding value is out of range or not initialized.
     #[track_caller]
     pub(crate) fn get(&self, index: u32) -> Option<JsValue> {
-        self.inner.get(index)
+        self.bindings.borrow()[index as usize].clone()
     }
 
     /// Sets the binding value from the environment by index.
@@ -63,7 +50,12 @@ impl FunctionEnvironment {
     /// Panics if the binding value is out of range.
     #[track_caller]
     pub(crate) fn set(&self, index: u32, value: JsValue) {
-        self.inner.set(index, value);
+        self.bindings.borrow_mut()[index as usize] = Some(value);
+    }
+
+    /// Gets the bindings of this poisonable environment.
+    pub(crate) const fn bindings(&self) -> &GcRefCell<Vec<Option<JsValue>>> {
+        &self.bindings
     }
 
     /// `BindThisValue`

--- a/core/engine/src/environments/runtime/declarative/global.rs
+++ b/core/engine/src/environments/runtime/declarative/global.rs
@@ -1,23 +1,17 @@
-use super::PoisonableEnvironment;
 use crate::JsValue;
-use boa_gc::{Finalize, Trace};
+use boa_gc::{Finalize, GcRefCell, Trace};
 
 #[derive(Debug, Trace, Finalize)]
 pub(crate) struct GlobalEnvironment {
-    inner: PoisonableEnvironment,
+    bindings: GcRefCell<Vec<Option<JsValue>>>,
 }
 
 impl GlobalEnvironment {
     /// Creates a new `GlobalEnvironment`.
     pub(crate) fn new() -> Self {
         Self {
-            inner: PoisonableEnvironment::new(0, false, false),
+            bindings: GcRefCell::new(Vec::new()),
         }
-    }
-
-    /// Gets the `poisonable_environment` of this global environment.
-    pub(crate) const fn poisonable_environment(&self) -> &PoisonableEnvironment {
-        &self.inner
     }
 
     /// Gets the binding value from the environment by it's index.
@@ -27,7 +21,7 @@ impl GlobalEnvironment {
     /// Panics if the binding value is out of range or not initialized.
     #[track_caller]
     pub(crate) fn get(&self, index: u32) -> Option<JsValue> {
-        self.inner.get(index)
+        self.bindings.borrow()[index as usize].clone()
     }
 
     /// Sets the binding value from the environment by index.
@@ -37,6 +31,11 @@ impl GlobalEnvironment {
     /// Panics if the binding value is out of range.
     #[track_caller]
     pub(crate) fn set(&self, index: u32, value: JsValue) {
-        self.inner.set(index, value);
+        self.bindings.borrow_mut()[index as usize] = Some(value);
+    }
+
+    /// Gets the bindings of this poisonable environment.
+    pub(crate) const fn bindings(&self) -> &GcRefCell<Vec<Option<JsValue>>> {
+        &self.bindings
     }
 }

--- a/core/engine/src/environments/runtime/declarative/lexical.rs
+++ b/core/engine/src/environments/runtime/declarative/lexical.rs
@@ -1,25 +1,18 @@
-use boa_gc::{Finalize, Trace};
+use boa_gc::{Finalize, GcRefCell, Trace};
 
 use crate::JsValue;
 
-use super::PoisonableEnvironment;
-
 #[derive(Debug, Trace, Finalize)]
 pub(crate) struct LexicalEnvironment {
-    inner: PoisonableEnvironment,
+    bindings: GcRefCell<Vec<Option<JsValue>>>,
 }
 
 impl LexicalEnvironment {
     /// Creates a new `LexicalEnvironment`.
-    pub(crate) fn new(bindings: u32, poisoned: bool, with: bool) -> Self {
+    pub(crate) fn new(bindings: u32) -> Self {
         Self {
-            inner: PoisonableEnvironment::new(bindings, poisoned, with),
+            bindings: GcRefCell::new(vec![None; bindings as usize]),
         }
-    }
-
-    /// Gets the `poisonable_environment` of this lexical environment.
-    pub(crate) const fn poisonable_environment(&self) -> &PoisonableEnvironment {
-        &self.inner
     }
 
     /// Gets the binding value from the environment by it's index.
@@ -29,7 +22,7 @@ impl LexicalEnvironment {
     /// Panics if the binding value is out of range or not initialized.
     #[track_caller]
     pub(crate) fn get(&self, index: u32) -> Option<JsValue> {
-        self.inner.get(index)
+        self.bindings.borrow()[index as usize].clone()
     }
 
     /// Sets the binding value from the environment by index.
@@ -39,6 +32,12 @@ impl LexicalEnvironment {
     /// Panics if the binding value is out of range.
     #[track_caller]
     pub(crate) fn set(&self, index: u32, value: JsValue) {
-        self.inner.set(index, value);
+        self.bindings.borrow_mut()[index as usize] = Some(value);
+    }
+
+    /// Gets the bindings of this poisonable environment.
+    #[expect(dead_code)]
+    pub(crate) const fn bindings(&self) -> &GcRefCell<Vec<Option<JsValue>>> {
+        &self.bindings
     }
 }

--- a/core/engine/src/environments/runtime/declarative/mod.rs
+++ b/core/engine/src/environments/runtime/declarative/mod.rs
@@ -9,7 +9,7 @@ pub(crate) use lexical::LexicalEnvironment;
 pub(crate) use module::ModuleEnvironment;
 
 use crate::{JsResult, JsValue};
-use boa_gc::{Finalize, GcRefCell, Trace};
+use boa_gc::{Finalize, Trace};
 use std::cell::Cell;
 
 /// A declarative environment holds binding values at runtime.
@@ -32,9 +32,13 @@ use std::cell::Cell;
 /// If bindings where added at runtime, the current environment and all inner environments
 /// are marked as poisoned.
 /// All poisoned environments have to be checked for added bindings.
+/// Module Environments are never poisoned as they run in strict mode.
 #[derive(Debug, Trace, Finalize)]
 pub(crate) struct DeclarativeEnvironment {
     kind: DeclarativeEnvironmentKind,
+    #[unsafe_ignore_trace]
+    poisoned: Cell<bool>,
+    with: bool,
 }
 
 impl DeclarativeEnvironment {
@@ -42,12 +46,18 @@ impl DeclarativeEnvironment {
     pub(crate) fn global() -> Self {
         Self {
             kind: DeclarativeEnvironmentKind::Global(GlobalEnvironment::new()),
+            poisoned: Cell::new(false),
+            with: false,
         }
     }
 
     /// Creates a new `DeclarativeEnvironment` from its kind and compile environment.
-    pub(crate) fn new(kind: DeclarativeEnvironmentKind) -> Self {
-        Self { kind }
+    pub(crate) fn new(kind: DeclarativeEnvironmentKind, poisoned: bool, with: bool) -> Self {
+        Self {
+            kind,
+            poisoned: Cell::new(poisoned),
+            with,
+        }
     }
 
     /// Returns a reference to the kind of the environment.
@@ -106,24 +116,24 @@ impl DeclarativeEnvironment {
 
     /// Returns `true` if this environment is poisoned.
     pub(crate) fn poisoned(&self) -> bool {
-        self.kind.poisoned()
+        self.poisoned.get()
     }
 
     /// Returns `true` if this environment is inside a `with` environment.
     pub(crate) fn with(&self) -> bool {
-        self.kind.with()
+        self.with
     }
 
     /// Poisons this environment for future binding searches.
     pub(crate) fn poison(&self) {
-        self.kind.poison();
+        self.poisoned.set(true);
     }
 
     /// Extends the environment with the bindings from the compile time environment.
     pub(crate) fn extend_from_compile(&self) {
         if let Some(env) = self.kind().as_function() {
             let compile_bindings_number = env.compile().num_bindings() as usize;
-            let mut bindings = env.poisonable_environment().bindings().borrow_mut();
+            let mut bindings = env.bindings().borrow_mut();
             if compile_bindings_number > bindings.len() {
                 bindings.resize(compile_bindings_number, None);
             }
@@ -232,96 +242,5 @@ impl DeclarativeEnvironmentKind {
             Self::Function(f) => f.has_this_binding(),
             Self::Global(_) | Self::Module(_) => true,
         }
-    }
-
-    /// Returns `true` if this environment is poisoned.
-    pub(crate) fn poisoned(&self) -> bool {
-        match self {
-            Self::Lexical(lex) => lex.poisonable_environment().poisoned(),
-            Self::Global(g) => g.poisonable_environment().poisoned(),
-            Self::Function(f) => f.poisonable_environment().poisoned(),
-            Self::Module(_) => false,
-        }
-    }
-
-    /// Returns `true` if this environment is inside a `with` environment.
-    pub(crate) fn with(&self) -> bool {
-        match self {
-            Self::Lexical(lex) => lex.poisonable_environment().with(),
-            Self::Global(g) => g.poisonable_environment().with(),
-            Self::Function(f) => f.poisonable_environment().with(),
-            Self::Module(_) => false,
-        }
-    }
-
-    /// Poisons this environment for future binding searches.
-    pub(crate) fn poison(&self) {
-        match self {
-            Self::Lexical(lex) => lex.poisonable_environment().poison(),
-            Self::Global(g) => g.poisonable_environment().poison(),
-            Self::Function(f) => f.poisonable_environment().poison(),
-            Self::Module(_) => {
-                unreachable!("modules are always run in strict mode")
-            }
-        }
-    }
-}
-
-#[derive(Debug, Trace, Finalize)]
-pub(crate) struct PoisonableEnvironment {
-    bindings: GcRefCell<Vec<Option<JsValue>>>,
-    #[unsafe_ignore_trace]
-    poisoned: Cell<bool>,
-    with: bool,
-}
-
-impl PoisonableEnvironment {
-    /// Creates a new `PoisonableEnvironment`.
-    pub(crate) fn new(bindings_count: u32, poisoned: bool, with: bool) -> Self {
-        Self {
-            bindings: GcRefCell::new(vec![None; bindings_count as usize]),
-            poisoned: Cell::new(poisoned),
-            with,
-        }
-    }
-
-    /// Gets the bindings of this poisonable environment.
-    pub(crate) const fn bindings(&self) -> &GcRefCell<Vec<Option<JsValue>>> {
-        &self.bindings
-    }
-
-    /// Gets the binding value from the environment by it's index.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the binding value is out of range.
-    #[track_caller]
-    fn get(&self, index: u32) -> Option<JsValue> {
-        self.bindings.borrow()[index as usize].clone()
-    }
-
-    /// Sets the binding value from the environment by index.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the binding value is out of range.
-    #[track_caller]
-    pub(crate) fn set(&self, index: u32, value: JsValue) {
-        self.bindings.borrow_mut()[index as usize] = Some(value);
-    }
-
-    /// Returns `true` if this environment is poisoned.
-    fn poisoned(&self) -> bool {
-        self.poisoned.get()
-    }
-
-    /// Returns `true` if this environment is inside a `with` environment.
-    fn with(&self) -> bool {
-        self.with
-    }
-
-    /// Poisons this environment for future binding searches.
-    fn poison(&self) {
-        self.poisoned.set(true);
     }
 }

--- a/core/engine/src/environments/runtime/mod.rs
+++ b/core/engine/src/environments/runtime/mod.rs
@@ -176,9 +176,11 @@ impl EnvironmentStack {
         let index = self.stack.len() as u32;
 
         self.stack.push(Environment::Declarative(Gc::new(
-            DeclarativeEnvironment::new(DeclarativeEnvironmentKind::Lexical(
-                LexicalEnvironment::new(bindings_count, poisoned, with),
-            )),
+            DeclarativeEnvironment::new(
+                DeclarativeEnvironmentKind::Lexical(LexicalEnvironment::new(bindings_count)),
+                poisoned,
+                with,
+            ),
         )));
 
         index
@@ -206,9 +208,15 @@ impl EnvironmentStack {
         };
 
         self.stack.push(Environment::Declarative(Gc::new(
-            DeclarativeEnvironment::new(DeclarativeEnvironmentKind::Function(
-                FunctionEnvironment::new(num_bindings, poisoned, with, function_slots, scope),
-            )),
+            DeclarativeEnvironment::new(
+                DeclarativeEnvironmentKind::Function(FunctionEnvironment::new(
+                    num_bindings,
+                    function_slots,
+                    scope,
+                )),
+                poisoned,
+                with,
+            ),
         )));
     }
 
@@ -216,9 +224,11 @@ impl EnvironmentStack {
     pub(crate) fn push_module(&mut self, scope: Scope) {
         let num_bindings = scope.num_bindings_non_local();
         self.stack.push(Environment::Declarative(Gc::new(
-            DeclarativeEnvironment::new(DeclarativeEnvironmentKind::Module(
-                ModuleEnvironment::new(num_bindings, scope),
-            )),
+            DeclarativeEnvironment::new(
+                DeclarativeEnvironmentKind::Module(ModuleEnvironment::new(num_bindings, scope)),
+                false,
+                false,
+            ),
         )));
     }
 

--- a/core/engine/src/realm.rs
+++ b/core/engine/src/realm.rs
@@ -191,8 +191,7 @@ impl Realm {
             .environment()
             .kind()
             .as_global()
-            .expect("Realm should only store global environments")
-            .poisonable_environment();
+            .expect("Realm should only store global environments");
         let mut bindings = env.bindings().borrow_mut();
 
         if bindings.len() < binding_number as usize {


### PR DESCRIPTION
As seen in the lines of changes of this PR, `PoisonableEnvironment` does not reduce code complexity and it adds extra branching for the simple `with` and `poisoned` functions.
