### PR TITLE
fix(jspromise): convert panics to EngineError::Panic using js_expect

### DIFF
--- a/core/engine/src/builtins/array/from_async.rs
+++ b/core/engine/src/builtins/array/from_async.rs
@@ -116,7 +116,7 @@ impl Array {
                     from_array_like(Ok(JsValue::undefined()), &coroutine_state, context)?
                 {
                     // Coroutine yielded. We need to allocate it for a future execution.
-                    JsPromise::resolve(value, context).await_native(
+                    JsPromise::resolve(value, context)?.await_native(
                         NativeCoroutine::from_copy_closure_with_captures(
                             from_array_like,
                             coroutine_state,
@@ -161,7 +161,7 @@ impl Array {
             if let CoroutineState::Yielded(value) =
                 from_async_iterator(Ok(JsValue::undefined()), &coroutine_state, context)?
             {
-                JsPromise::resolve(value, context).await_native(
+                JsPromise::resolve(value, context)?.await_native(
                     NativeCoroutine::from_copy_closure_with_captures(
                         from_async_iterator,
                         coroutine_state,
@@ -449,7 +449,7 @@ fn from_async_iterator(
 
         // i. Assert: result is a throw completion.
         Err(err) => {
-            // ii. Perform ! Call(promiseCapability.[[Reject]], undefined, « result.[[Value]] »).
+            // ii. Perform ! Call(promiseCapability.[[Reject]], undefined, « result.[[Value]] »).
             global_state
                 .resolvers
                 .reject
@@ -610,7 +610,7 @@ fn from_array_like(
         Ok(cont) => Ok(cont),
         // i. Assert: result is a throw completion.
         Err(err) => {
-            // ii. Perform ! Call(promiseCapability.[[Reject]], undefined, « result.[[Value]] »).
+            // ii. Perform ! Call(promiseCapability.[[Reject]], undefined, « result.[[Value]] »).
             global_state
                 .resolvers
                 .reject

--- a/core/engine/src/module/mod.rs
+++ b/core/engine/src/module/mod.rs
@@ -658,6 +658,7 @@ impl Module {
                 None,
                 context,
             )
+            .expect("`then` cannot fail for a native `JsPromise`")
             .then(
                 Some(
                     NativeFunction::from_copy_closure_with_captures(
@@ -669,6 +670,7 @@ impl Module {
                 None,
                 context,
             )
+            .expect("`then` cannot fail for a native `JsPromise`")
     }
 
     /// Abstract operation [`GetModuleNamespace ( module )`][spec].

--- a/core/engine/src/module/synthetic.rs
+++ b/core/engine/src/module/synthetic.rs
@@ -257,8 +257,8 @@ impl SyntheticModule {
     ///
     /// [spec]: https://tc39.es/proposal-json-modules/#sec-smr-LoadRequestedModules
     pub(super) fn load(context: &mut Context) -> JsPromise {
-        // 1. Return ! PromiseResolve(%Promise%, undefined).
         JsPromise::resolve(JsValue::undefined(), context)
+            .expect("default resolve functions cannot throw and must return a promise")
     }
 
     /// Concrete method [`GetExportedNames ( [ exportStarSet ] )`][spec].

--- a/core/engine/src/object/builtins/jspromise.rs
+++ b/core/engine/src/object/builtins/jspromise.rs
@@ -3,7 +3,7 @@
 use super::{JsArray, JsFunction};
 use crate::value::TryIntoJs;
 use crate::{
-    Context, JsArgs, JsError, JsNativeError, JsResult, JsValue, NativeFunction,
+    Context, JsArgs, JsError, JsExpect, JsNativeError, JsResult, JsValue, NativeFunction,
     builtins::{
         Promise,
         promise::{PromiseState, ResolvingFunctions},
@@ -65,14 +65,14 @@ use std::{future::Future, pin::Pin, task};
 ///         ),
 ///         None,
 ///         context,
-///     )
+///     )?
 ///     .catch(
 ///         NativeFunction::from_fn_ptr(|_, args, _| {
 ///             Ok(args.get_or_undefined(0).clone())
 ///         })
 ///         .to_js_function(context.realm()),
 ///         context,
-///     )
+///     )?
 ///     .finally(
 ///         NativeFunction::from_fn_ptr(|_, _, context| {
 ///             context.global_object().clone().set(
@@ -85,7 +85,7 @@ use std::{future::Future, pin::Pin, task};
 ///         })
 ///         .to_js_function(context.realm()),
 ///         context,
-///     );
+///     )?;
 ///
 /// context.run_jobs();
 ///
@@ -178,7 +178,7 @@ impl JsPromise {
             resolvers
                 .reject
                 .call(&JsValue::undefined(), &[e], context)
-                .expect("default `reject` function cannot throw");
+                .js_expect("default `reject` function cannot throw")?;
         }
 
         Ok(Self { inner: promise })
@@ -335,6 +335,7 @@ impl JsPromise {
     /// #    builtins::promise::PromiseState,
     /// #    Context, JsResult, JsString, js_string, js_error
     /// # };
+    /// # fn main() -> Result<(), Box<dyn Error>> {
     /// let context = &mut Context::default();
     ///
     /// fn do_thing(success: bool) -> JsResult<JsString> {
@@ -343,22 +344,24 @@ impl JsPromise {
     ///         .ok_or(js_error!("rejected!"))
     /// }
     ///
-    /// let promise = JsPromise::from_result(do_thing(true), context);
+    /// let promise = JsPromise::from_result(do_thing(true), context)?;
     /// assert_eq!(
     ///     promise.state(),
     ///     PromiseState::Fulfilled(js_string!("resolved!").into())
     /// );
     ///
-    /// let promise = JsPromise::from_result(do_thing(false), context);
+    /// let promise = JsPromise::from_result(do_thing(false), context)?;
     /// assert_eq!(
     ///     promise.state(),
     ///     PromiseState::Rejected(js_string!("rejected!").into())
     /// );
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn from_result<V: Into<JsValue>, E: Into<JsError>>(
         value: Result<V, E>,
         context: &mut Context,
-    ) -> Self {
+    ) -> JsResult<Self> {
         match value {
             Ok(v) => Self::resolve(v, context),
             Err(e) => Self::reject(e, context),
@@ -382,26 +385,30 @@ impl JsPromise {
     /// #    builtins::promise::PromiseState,
     /// #    Context, js_string
     /// # };
+    /// # fn main() -> Result<(), Box<dyn Error>> {
     /// let context = &mut Context::default();
     ///
-    /// let promise = JsPromise::resolve(js_string!("resolved!"), context);
+    /// let promise = JsPromise::resolve(js_string!("resolved!"), context)?;
     ///
     /// assert_eq!(
     ///     promise.state(),
     ///     PromiseState::Fulfilled(js_string!("resolved!").into())
     /// );
+    /// # Ok(())
+    /// # }
     /// ```
     ///
     /// [`Promise.resolve()`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/resolve
     /// [thenables]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise#thenables
-    pub fn resolve<V: Into<JsValue>>(value: V, context: &mut Context) -> Self {
+    pub fn resolve<V: Into<JsValue>>(value: V, context: &mut Context) -> JsResult<Self> {
         Promise::promise_resolve(
             &context.intrinsics().constructors().promise().constructor(),
             value.into(),
             context,
         )
         .and_then(Self::from_object)
-        .expect("default resolve functions cannot throw and must return a promise")
+        .js_expect("default resolve functions cannot throw and must return a promise")
+        .map_err(Into::into)
     }
 
     /// Creates a `JsPromise` that is rejected with the reason `error`.
@@ -420,22 +427,25 @@ impl JsPromise {
     /// #    builtins::promise::PromiseState,
     /// #    Context, js_string, JsError
     /// # };
+    /// # fn main() -> Result<(), Box<dyn Error>> {
     /// let context = &mut Context::default();
     ///
     /// let promise = JsPromise::reject(
     ///     JsError::from_opaque(js_string!("oops!").into()),
     ///     context,
-    /// );
+    /// )?;
     ///
     /// assert_eq!(
     ///     promise.state(),
     ///     PromiseState::Rejected(js_string!("oops!").into())
     /// );
+    /// # Ok(())
+    /// # }
     /// ```
     ///
     /// [`Promise.reject`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/reject
     /// [thenable]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise#thenables
-    pub fn reject<E: Into<JsError>>(error: E, context: &mut Context) -> Self {
+    pub fn reject<E: Into<JsError>>(error: E, context: &mut Context) -> JsResult<Self> {
         let error = error.into();
         assert!(
             error.is_catchable(),
@@ -448,7 +458,8 @@ impl JsPromise {
             context,
         )
         .and_then(Self::from_object)
-        .expect("default resolve functions cannot throw and must return a promise")
+        .js_expect("default resolve functions cannot throw and must return a promise")
+        .map_err(Into::into)
     }
 
     /// Gets the current state of the promise.
@@ -508,6 +519,7 @@ impl JsPromise {
     /// #     object::{builtins::JsPromise, FunctionObjectBuilder},
     /// #     Context, JsArgs, JsError, JsValue, NativeFunction,
     /// # };
+    /// # fn main() -> Result<(), Box<dyn Error>> {
     /// let context = &mut Context::default();
     ///
     /// let promise = JsPromise::new(
@@ -520,8 +532,7 @@ impl JsPromise {
     ///         Ok(JsValue::undefined())
     ///     },
     ///     context,
-    /// )
-    /// .unwrap()
+    /// )?
     /// .then(
     ///     Some(
     ///         NativeFunction::from_fn_ptr(|_, args, context| {
@@ -533,7 +544,7 @@ impl JsPromise {
     ///     ),
     ///     None,
     ///     context,
-    /// );
+    /// )?;
     ///
     /// context.run_jobs();
     ///
@@ -541,6 +552,8 @@ impl JsPromise {
     ///     promise.state(),
     ///     PromiseState::Fulfilled(js_string!("255.255").into())
     /// );
+    /// # Ok(())
+    /// # }
     /// ```
     ///
     /// [`Promise.prototype.then`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/then
@@ -551,10 +564,11 @@ impl JsPromise {
         on_fulfilled: Option<JsFunction>,
         on_rejected: Option<JsFunction>,
         context: &mut Context,
-    ) -> Self {
+    ) -> JsResult<Self> {
         Promise::inner_then(self, on_fulfilled, on_rejected, context)
             .and_then(Self::from_object)
-            .expect("`inner_then` cannot fail for native `JsPromise`")
+            .js_expect("`inner_then` cannot fail for native `JsPromise`")
+            .map_err(Into::into)
     }
 
     /// Schedules a callback to run when the promise is rejected.
@@ -574,6 +588,7 @@ impl JsPromise {
     /// #     object::{builtins::JsPromise, FunctionObjectBuilder},
     /// #     Context, JsArgs, JsNativeError, JsValue, NativeFunction,
     /// # };
+    /// # fn main() -> Result<(), Box<dyn Error>> {
     /// let context = &mut Context::default();
     ///
     /// let promise = JsPromise::new(
@@ -588,8 +603,7 @@ impl JsPromise {
     ///         Ok(JsValue::undefined())
     ///     },
     ///     context,
-    /// )
-    /// .unwrap()
+    /// )?
     /// .catch(
     ///     NativeFunction::from_fn_ptr(|_, args, context| {
     ///         args.get_or_undefined(0)
@@ -598,7 +612,7 @@ impl JsPromise {
     ///     })
     ///     .to_js_function(context.realm()),
     ///     context,
-    /// );
+    /// )?;
     ///
     /// context.run_jobs();
     ///
@@ -606,13 +620,15 @@ impl JsPromise {
     ///     promise.state(),
     ///     PromiseState::Fulfilled(js_string!("TypeError: thrown").into())
     /// );
+    /// # Ok(())
+    /// # }
     /// ```
     ///
     /// [`Promise.prototype.catch`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/catch
     /// [then]: JsPromise::then
     #[inline]
     #[allow(clippy::return_self_not_must_use)] // Could just be used to add a handler on an existing promise
-    pub fn catch(&self, on_rejected: JsFunction, context: &mut Context) -> Self {
+    pub fn catch(&self, on_rejected: JsFunction, context: &mut Context) -> JsResult<Self> {
         self.then(None, Some(on_rejected), context)
     }
 
@@ -670,7 +686,7 @@ impl JsPromise {
     ///     })
     ///     .to_js_function(context.realm()),
     ///     context,
-    /// );
+    /// )?;
     ///
     /// context.run_jobs();
     ///
@@ -690,7 +706,7 @@ impl JsPromise {
     /// [then]: JsPromise::then
     #[inline]
     #[allow(clippy::return_self_not_must_use)] // Could just be used to add a handler on an existing promise
-    pub fn finally(&self, on_finally: JsFunction, context: &mut Context) -> Self {
+    pub fn finally(&self, on_finally: JsFunction, context: &mut Context) -> JsResult<Self> {
         let (then, catch) = Promise::then_catch_finally_closures(
             context.intrinsics().constructors().promise().constructor(),
             on_finally,
@@ -698,7 +714,8 @@ impl JsPromise {
         );
         Promise::inner_then(self, Some(then), Some(catch), context)
             .and_then(Self::from_object)
-            .expect("`inner_then` cannot fail for native `JsPromise`")
+            .js_expect("`inner_then` cannot fail for native `JsPromise`")
+            .map_err(Into::into)
     }
 
     /// Waits for a list of promises to settle with fulfilled values, rejecting the aggregate promise
@@ -720,21 +737,21 @@ impl JsPromise {
     ///
     /// let promise1 = JsPromise::all(
     ///     [
-    ///         JsPromise::resolve(0, context),
-    ///         JsPromise::resolve(2, context),
-    ///         JsPromise::resolve(4, context),
+    ///         JsPromise::resolve(0, context)?,
+    ///         JsPromise::resolve(2, context)?,
+    ///         JsPromise::resolve(4, context)?,
     ///     ],
     ///     context,
-    /// );
+    /// )?;
     ///
     /// let promise2 = JsPromise::all(
     ///     [
-    ///         JsPromise::resolve(1, context),
-    ///         JsPromise::reject(JsNativeError::typ(), context),
-    ///         JsPromise::resolve(3, context),
+    ///         JsPromise::resolve(1, context)?,
+    ///         JsPromise::reject(JsNativeError::typ(), context)?,
+    ///         JsPromise::resolve(3, context)?,
     ///     ],
     ///     context,
-    /// );
+    /// )?;
     ///
     /// context.run_jobs();
     ///
@@ -757,7 +774,7 @@ impl JsPromise {
     /// ```
     ///
     /// [`Promise.all`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/all
-    pub fn all<I>(promises: I, context: &mut Context) -> Self
+    pub fn all<I>(promises: I, context: &mut Context) -> JsResult<Self>
     where
         I: IntoIterator<Item = Self>,
     {
@@ -771,14 +788,14 @@ impl JsPromise {
             .into();
 
         let value = Promise::all(c, &[promises.into()], context)
-            .expect("Promise.all cannot fail with the default `%Promise%` constructor");
+            .js_expect("Promise.all cannot fail with the default `%Promise%` constructor")?;
 
         let object = value
             .as_object()
-            .expect("`Promise.all` always returns an object on success");
+            .js_expect("`Promise.all` always returns an object on success")?;
 
         Self::from_object(object.clone())
-        .expect("`Promise::all` with the  default `%Promise%` constructor always returns a native `JsPromise`")
+            .js_expect("`Promise::all` with the default `%Promise%` constructor always returns a native `JsPromise`").map_err(Into::into)
     }
 
     /// Waits for a list of promises to settle, fulfilling with an array of the outcomes of every
@@ -800,12 +817,12 @@ impl JsPromise {
     ///
     /// let promise = JsPromise::all_settled(
     ///     [
-    ///         JsPromise::resolve(1, context),
-    ///         JsPromise::reject(JsNativeError::typ(), context),
-    ///         JsPromise::resolve(3, context),
+    ///         JsPromise::resolve(1, context)?,
+    ///         JsPromise::reject(JsNativeError::typ(), context)?,
+    ///         JsPromise::resolve(3, context)?,
     ///     ],
     ///     context,
-    /// );
+    /// )?;
     ///
     /// context.run_jobs();
     ///
@@ -846,7 +863,7 @@ impl JsPromise {
     /// ```
     ///
     /// [`Promise.allSettled`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/allSettled
-    pub fn all_settled<I>(promises: I, context: &mut Context) -> Self
+    pub fn all_settled<I>(promises: I, context: &mut Context) -> JsResult<Self>
     where
         I: IntoIterator<Item = Self>,
     {
@@ -859,15 +876,16 @@ impl JsPromise {
             .constructor()
             .into();
 
-        let value = Promise::all_settled(c, &[promises.into()], context)
-            .expect("`Promise.all_settled` cannot fail with the default `%Promise%` constructor");
+        let value = Promise::all_settled(c, &[promises.into()], context).js_expect(
+            "`Promise.all_settled` cannot fail with the default `%Promise%` constructor",
+        )?;
 
         let object = value
             .as_object()
-            .expect("`Promise.all_settled` always returns an object on success");
+            .js_expect("`Promise.all_settled` always returns an object on success")?;
 
         Self::from_object(object.clone())
-        .expect("`Promise::all_settled` with the  default `%Promise%` constructor always returns a native `JsPromise`")
+            .js_expect("`Promise::all_settled` with the default `%Promise%` constructor always returns a native `JsPromise`").map_err(Into::into)
     }
 
     /// Returns the first promise that fulfills from a list of promises.
@@ -888,17 +906,18 @@ impl JsPromise {
     /// #     object::builtins::JsPromise,
     /// #     Context, JsNativeError,
     /// # };
+    /// # fn main() -> Result<(), Box<dyn Error>> {
     /// let context = &mut Context::default();
     ///
     /// let promise = JsPromise::any(
     ///     [
-    ///         JsPromise::reject(JsNativeError::syntax(), context),
-    ///         JsPromise::reject(JsNativeError::typ(), context),
-    ///         JsPromise::resolve(js_string!("fulfilled"), context),
-    ///         JsPromise::reject(JsNativeError::range(), context),
+    ///         JsPromise::reject(JsNativeError::syntax(), context)?,
+    ///         JsPromise::reject(JsNativeError::typ(), context)?,
+    ///         JsPromise::resolve(js_string!("fulfilled"), context)?,
+    ///         JsPromise::reject(JsNativeError::range(), context)?,
     ///     ],
     ///     context,
-    /// );
+    /// )?;
     ///
     /// context.run_jobs();
     ///
@@ -906,10 +925,12 @@ impl JsPromise {
     ///     promise.state(),
     ///     PromiseState::Fulfilled(js_string!("fulfilled").into())
     /// );
+    /// # Ok(())
+    /// # }
     /// ```
     ///
     /// [`Promise.any`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/any
-    pub fn any<I>(promises: I, context: &mut Context) -> Self
+    pub fn any<I>(promises: I, context: &mut Context) -> JsResult<Self>
     where
         I: IntoIterator<Item = Self>,
     {
@@ -923,14 +944,14 @@ impl JsPromise {
             .into();
 
         let value = Promise::any(c, &[promises.into()], context)
-            .expect("`Promise.any` cannot fail with the default `%Promise%` constructor");
+            .js_expect("`Promise.any` cannot fail with the default `%Promise%` constructor")?;
 
         let object = value
             .as_object()
-            .expect("`Promise.any` always returns an object on success");
+            .js_expect("`Promise.any` always returns an object on success")?;
 
         Self::from_object(object.clone())
-        .expect("`Promise::any` with the  default `%Promise%` constructor always returns a native `JsPromise`")
+            .js_expect("`Promise::any` with the default `%Promise%` constructor always returns a native `JsPromise`").map_err(Into::into)
     }
 
     /// Returns the first promise that settles from a list of promises.
@@ -957,7 +978,7 @@ impl JsPromise {
     /// let (b, resolvers_b) = JsPromise::new_pending(context);
     /// let (c, resolvers_c) = JsPromise::new_pending(context);
     ///
-    /// let promise = JsPromise::race([a, b, c], context);
+    /// let promise = JsPromise::race([a, b, c], context)?;
     ///
     /// resolvers_b
     ///     .reject
@@ -983,7 +1004,7 @@ impl JsPromise {
     /// ```
     ///
     /// [`Promise.race`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/race
-    pub fn race<I>(promises: I, context: &mut Context) -> Self
+    pub fn race<I>(promises: I, context: &mut Context) -> JsResult<Self>
     where
         I: IntoIterator<Item = Self>,
     {
@@ -997,14 +1018,14 @@ impl JsPromise {
             .into();
 
         let value = Promise::race(c, &[promises.into()], context)
-            .expect("`Promise.race` cannot fail with the default `%Promise%` constructor");
+            .js_expect("`Promise.race` cannot fail with the default `%Promise%` constructor")?;
 
         let object = value
             .as_object()
-            .expect("`Promise.race` always returns an object on success");
+            .js_expect("`Promise.race` always returns an object on success")?;
 
         Self::from_object(object.clone())
-        .expect("`Promise::race` with the  default `%Promise%` constructor always returns a native `JsPromise`")
+            .js_expect("`Promise::race` with the default `%Promise%` constructor always returns a native `JsPromise`").map_err(Into::into)
     }
 
     /// Creates a `JsFuture` from this `JsPromise`.
@@ -1026,7 +1047,7 @@ impl JsPromise {
     /// let context = &mut Context::default();
     ///
     /// let (promise, resolvers) = JsPromise::new_pending(context);
-    /// let promise_future = promise.into_js_future(context);
+    /// let promise_future = promise.into_js_future(context)?;
     ///
     /// let future1 = async move { promise_future.await };
     ///
@@ -1046,7 +1067,7 @@ impl JsPromise {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn into_js_future(self, context: &mut Context) -> JsFuture {
+    pub fn into_js_future(self, context: &mut Context) -> JsResult<JsFuture> {
         // Mostly based from:
         // https://docs.rs/wasm-bindgen-futures/0.4.37/src/wasm_bindgen_futures/lib.rs.html#109-168
 
@@ -1106,9 +1127,9 @@ impl JsPromise {
             Some(resolve.to_js_function(context.realm())),
             Some(reject.to_js_function(context.realm())),
             context,
-        ));
+        )?);
 
-        JsFuture { inner: state }
+        Ok(JsFuture { inner: state })
     }
 
     /// Run jobs until this promise is resolved or rejected. This could
@@ -1127,6 +1148,7 @@ impl JsPromise {
     /// ```
     /// # use boa_engine::{Context, JsArgs, JsValue, NativeFunction};
     /// # use boa_engine::object::builtins::{JsFunction, JsPromise};
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let context = &mut Context::default();
     ///
     /// let p1 = JsPromise::new(
@@ -1135,8 +1157,7 @@ impl JsPromise {
     ///             .call(&JsValue::undefined(), &[JsValue::new(1)], context)
     ///     },
     ///     context,
-    /// )
-    /// .unwrap();
+    /// )?;
     /// let p2 = p1.then(
     ///     Some(
     ///         NativeFunction::from_fn_ptr(|_, args, context| {
@@ -1147,9 +1168,11 @@ impl JsPromise {
     ///     ),
     ///     None,
     ///     context,
-    /// );
+    /// )?;
     ///
     /// assert_eq!(p2.await_blocking(context), Ok(JsValue::new(2)));
+    /// # Ok(())
+    /// # }
     /// ```
     ///
     /// This will not panic as `run_jobs()` is not executed.
@@ -1157,12 +1180,12 @@ impl JsPromise {
     /// # use boa_engine::{Context, JsValue, NativeFunction};
     /// # use boa_engine::object::builtins::JsPromise;
     ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let context = &mut Context::default();
     /// let p1 = JsPromise::new(
     ///     |fns, context| fns.resolve.call(&JsValue::undefined(), &[], context),
     ///     context,
-    /// )
-    /// .unwrap()
+    /// )?
     /// .then(
     ///     Some(
     ///         NativeFunction::from_fn_ptr(|_, _, _| {
@@ -1172,12 +1195,14 @@ impl JsPromise {
     ///     ),
     ///     None,
     ///     context,
-    /// );
-    /// let p2 = JsPromise::resolve(1, context);
+    /// )?;
+    /// let p2 = JsPromise::resolve(1, context)?;
     ///
     /// assert_eq!(p2.await_blocking(context), Ok(JsValue::new(1)));
     /// // Uncommenting the following line would panic.
     /// // context.run_jobs();
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn await_blocking(&self, context: &mut Context) -> Result<JsValue, JsError> {
         loop {
@@ -1222,14 +1247,17 @@ impl JsPromise {
                     // c. Push asyncContext onto the execution context stack; asyncContext is now the running execution context.
                     // d. Resume the suspended evaluation of asyncContext using NormalCompletion(value) as the result of the operation that suspended it.
                     let continuation = &captures.0;
-                    let mut r#gen = captures.1.take().expect("should only run once");
+                    let mut r#gen = captures.1.take().js_expect("should only run once")?;
 
                     // NOTE: We need to get the object before resuming, since it could clear the stack.
                     let async_generator = r#gen.async_generator_object();
 
                     std::mem::swap(&mut context.vm.stack, &mut r#gen.stack);
                     std::mem::swap(&mut context.vm.registers, &mut r#gen.registers);
-                    let frame = r#gen.call_frame.take().expect("should have a call frame");
+                    let frame = r#gen
+                        .call_frame
+                        .take()
+                        .js_expect("should have a call frame")?;
                     let rp = frame.rp;
                     let fp = frame.fp;
                     context.vm.push_frame(frame);
@@ -1239,7 +1267,7 @@ impl JsPromise {
                     if let crate::native_function::CoroutineState::Yielded(value) =
                         continuation.call(Ok(args.get_or_undefined(0).clone()), context)?
                     {
-                        JsPromise::resolve(value, context)
+                        JsPromise::resolve(value, context)?
                             .await_native(continuation.clone(), context);
                     }
 
@@ -1251,7 +1279,7 @@ impl JsPromise {
                     if let Some(async_generator) = async_generator {
                         async_generator
                             .downcast_mut::<AsyncGenerator>()
-                            .expect("must be async generator")
+                            .js_expect("must be async generator")?
                             .context = Some(r#gen);
                     }
 
@@ -1285,14 +1313,17 @@ impl JsPromise {
                     // e. Assert: When we reach this step, asyncContext has already been removed from the execution context stack and prevContext is the currently running execution context.
                     // f. Return undefined.
                     let continuation = &captures.0;
-                    let mut r#gen = captures.1.take().expect("should only run once");
+                    let mut r#gen = captures.1.take().js_expect("should only run once")?;
 
                     // NOTE: We need to get the object before resuming, since it could clear the stack.
                     let async_generator = r#gen.async_generator_object();
 
                     std::mem::swap(&mut context.vm.stack, &mut r#gen.stack);
                     std::mem::swap(&mut context.vm.registers, &mut r#gen.registers);
-                    let frame = r#gen.call_frame.take().expect("should have a call frame");
+                    let frame = r#gen
+                        .call_frame
+                        .take()
+                        .js_expect("should have a call frame")?;
                     let rp = frame.rp;
                     let fp = frame.fp;
                     context.vm.push_frame(frame);
@@ -1305,7 +1336,7 @@ impl JsPromise {
                             context,
                         )?
                     {
-                        JsPromise::resolve(value, context)
+                        JsPromise::resolve(value, context)?
                             .await_native(continuation.clone(), context);
                     }
 
@@ -1317,7 +1348,7 @@ impl JsPromise {
                     if let Some(async_generator) = async_generator {
                         async_generator
                             .downcast_mut::<AsyncGenerator>()
-                            .expect("must be async generator")
+                            .js_expect("must be async generator")?
                             .context = Some(r#gen);
                     }
 

--- a/examples/src/bin/jspromise.rs
+++ b/examples/src/bin/jspromise.rs
@@ -54,7 +54,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .to_js_function(context.realm()),
             ),
             context,
-        )
+        )?
         .finally(
             NativeFunction::from_fn_ptr(|_, _, _| {
                 println!("Promise settled!");
@@ -62,7 +62,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             })
             .to_js_function(context.realm()),
             context,
-        );
+        )?;
 
     // Run the event loop to process promises
     drop(context.run_jobs());
@@ -70,12 +70,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("\n2. Promise.all Example");
     // Create multiple promises
     let promises = vec![
-        JsPromise::resolve(1, context),
-        JsPromise::resolve(2, context),
-        JsPromise::resolve(3, context),
+        JsPromise::resolve(1, context)?,
+        JsPromise::resolve(2, context)?,
+        JsPromise::resolve(3, context)?,
     ];
 
-    let all_promise = JsPromise::all(promises, context);
+    let all_promise = JsPromise::all(promises, context)?;
     drop(context.run_jobs());
 
     match all_promise.state() {
@@ -95,7 +95,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (fast_promise, fast_resolvers) = JsPromise::new_pending(context);
     let (slow_promise, slow_resolvers) = JsPromise::new_pending(context);
 
-    let race_promise = JsPromise::race([fast_promise, slow_promise], context);
+    let race_promise = JsPromise::race([fast_promise, slow_promise], context)?;
 
     // Resolve promises in different order
     slow_resolvers
@@ -131,12 +131,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     println!("\n5. Promise.any Example");
     let promises = vec![
-        JsPromise::reject(JsNativeError::error().with_message("Error 1"), context),
-        JsPromise::resolve(js_string!("Success!"), context),
-        JsPromise::reject(JsNativeError::error().with_message("Error 2"), context),
+        JsPromise::reject(JsNativeError::error().with_message("Error 1"), context)?,
+        JsPromise::resolve(js_string!("Success!"), context)?,
+        JsPromise::reject(JsNativeError::error().with_message("Error 2"), context)?,
     ];
 
-    let any_promise = JsPromise::any(promises, context);
+    let any_promise = JsPromise::any(promises, context)?;
     drop(context.run_jobs());
 
     match any_promise.state() {

--- a/examples/src/bin/modules.rs
+++ b/examples/src/bin/modules.rs
@@ -70,6 +70,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             None,
             context,
         )
+        .expect("`then` cannot fail for a native `JsPromise`")
         .then(
             Some(
                 NativeFunction::from_copy_closure_with_captures(
@@ -84,7 +85,8 @@ fn main() -> Result<(), Box<dyn Error>> {
             ),
             None,
             context,
-        );
+        )
+        .expect("`then` cannot fail for a native `JsPromise`");
 
     // Very important to push forward the job queue after queueing promises.
     context.run_jobs()?;


### PR DESCRIPTION
Part of #3241

Converts all 23 panics in jspromise.rs to EngineError::Panic using
js_expect introduced in #4828.

Patterns converted:
- `.js_expect()` on internal promise operations that cannot fail
- `.js_expect().map_err(Into::into)` for methods returning `JsResult<JsPromise>`

Signature changes:
- `resolve()`, `reject()`, `from_result()` → `JsResult<Self>`
- `then()`, `catch()`, `finally()` → `JsResult<JsPromise>`
- `all()`, `all_settled()`, `any()`, `race()` → `JsResult<JsPromise>`
- `into_js_future()` → `JsResult<JsFuture>`

Files modified: 6