### PR TITLE
refactor(vm): remove `execute_bytecode_instruction` and `execute_bytecode_instruction_with_budget`

### DIFF
--- a/core/engine/src/vm/mod.rs
+++ b/core/engine/src/vm/mod.rs
@@ -12,6 +12,7 @@ use crate::{
     object::JsFunction,
     realm::Realm,
     script::Script,
+    vm::opcode::{OPCODE_HANDLERS, OPCODE_HANDLERS_BUDGET},
 };
 use boa_gc::{Finalize, Gc, Trace, custom_trace};
 use shadow_stack::ShadowStack;
@@ -839,7 +840,10 @@ impl Context {
 
             match self.execute_one(
                 |context, opcode| {
-                    context.execute_bytecode_instruction_with_budget(&mut runtime_budget, opcode)
+                    let frame = context.vm.frame();
+                    let pc = frame.pc as usize;
+
+                    OPCODE_HANDLERS_BUDGET[opcode as usize](context, pc, &mut runtime_budget)
                 },
                 opcode,
             ) {
@@ -872,7 +876,15 @@ impl Context {
         {
             let opcode = Opcode::decode(*byte);
 
-            match self.execute_one(Self::execute_bytecode_instruction, opcode) {
+            match self.execute_one(
+                |context, opcode| {
+                    let frame = context.vm.frame();
+                    let pc = frame.pc as usize;
+
+                    OPCODE_HANDLERS[opcode as usize](context, pc)
+                },
+                opcode,
+            ) {
                 ControlFlow::Continue(()) => {}
                 ControlFlow::Break(value) => return value,
             }

--- a/core/engine/src/vm/opcode/mod.rs
+++ b/core/engine/src/vm/opcode/mod.rs
@@ -407,7 +407,7 @@ macro_rules! generate_opcodes {
 
         type OpcodeHandler = fn(&mut Context, usize) -> ControlFlow<CompletionRecord>;
 
-        const OPCODE_HANDLERS: [OpcodeHandler; 256] = {
+        pub(crate) const OPCODE_HANDLERS: [OpcodeHandler; 256] = {
             [
                 $(
                     paste::paste! { [<handle_ $Variant:snake>] },
@@ -417,7 +417,7 @@ macro_rules! generate_opcodes {
 
         type OpcodeHandlerBudget = fn(&mut Context, usize, &mut u32) -> ControlFlow<CompletionRecord>;
 
-        const OPCODE_HANDLERS_BUDGET: [OpcodeHandlerBudget; 256] = {
+        pub(crate) const OPCODE_HANDLERS_BUDGET: [OpcodeHandlerBudget; 256] = {
             [
                 $(
                     paste::paste! { [<handle_ $Variant:snake _budget>] },
@@ -505,29 +505,6 @@ macro_rules! generate_opcodes {
                 }
             }
         }
-    }
-}
-
-impl Context {
-    pub(crate) fn execute_bytecode_instruction(
-        &mut self,
-        opcode: Opcode,
-    ) -> ControlFlow<CompletionRecord> {
-        let frame = self.vm.frame_mut();
-        let pc = frame.pc as usize;
-
-        OPCODE_HANDLERS[opcode as usize](self, pc)
-    }
-
-    pub(crate) fn execute_bytecode_instruction_with_budget(
-        &mut self,
-        budget: &mut u32,
-        opcode: Opcode,
-    ) -> ControlFlow<CompletionRecord> {
-        let frame = self.vm.frame_mut();
-        let pc = frame.pc as usize;
-
-        OPCODE_HANDLERS_BUDGET[opcode as usize](self, pc, budget)
     }
 }
 


### PR DESCRIPTION
According to flame graph on my machine, `execute_bytecode_instruction` is not inlined even in release mode (actually `release-dbg`).
Perhaps a `#[inline]` could fix that already, but I do not really see a point in keeping these functions.