### PR TITLE
Add Rust-level tests for Promise.all and Promise.any

### DIFF
--- a/core/engine/src/builtins/promise/tests.rs
+++ b/core/engine/src/builtins/promise/tests.rs
@@ -17,3 +17,44 @@ fn promise() {
         TestAction::assert_eq("count", 3),
     ]);
 }
+
+#[test]
+fn promise_all_resolves_values() {
+    run_test_actions([
+        TestAction::run(indoc! {r#"
+            var values = [];
+            var p = Promise.all([Promise.resolve(1), Promise.resolve(2)]);
+            p.then(v => { values = v; });
+        "#}),
+        TestAction::inspect_context(|ctx| ctx.run_jobs().unwrap()),
+        TestAction::assert_eq("values.length", 2),
+        TestAction::assert_eq("values[0]", 1),
+        TestAction::assert_eq("values[1]", 2),
+    ]);
+}
+
+#[test]
+fn promise_all_rejects() {
+    run_test_actions([
+        TestAction::run(indoc! {r#"
+            var err = null;
+            var p = Promise.all([Promise.resolve(1), Promise.reject(2)]);
+            p.catch(e => { err = e; });
+        "#}),
+        TestAction::inspect_context(|ctx| ctx.run_jobs().unwrap()),
+        TestAction::assert_eq("err", 2),
+    ]);
+}
+
+#[test]
+fn promise_any_resolves_first_success() {
+    run_test_actions([
+        TestAction::run(indoc! {r#"
+            var val = null;
+            var p = Promise.any([Promise.reject(1), Promise.resolve(2)]);
+            p.then(v => { val = v; });
+        "#}),
+        TestAction::inspect_context(|ctx| ctx.run_jobs().unwrap()),
+        TestAction::assert_eq("val", 2),
+    ]);
+}


### PR DESCRIPTION
This PR adds Rust-level unit tests for Promise combinators.

Currently `core/engine/src/builtins/promise/tests.rs` only contains a
basic Promise test and does not cover combinators such as `Promise.all`
or `Promise.any`.

While these behaviors are validated through test262, localized Rust
tests improve debugging, provide faster CI feedback, and help prevent
regressions when modifying the Promise implementation.

This PR introduces tests for:

- Promise.all resolution behavior
- Promise.all rejection propagation
- Promise.any first-success resolution

No runtime behavior is modified. This change only adds tests.