### PR TITLE
feat(console): implement console.table() and add tests

### DIFF
--- a/core/runtime/src/console/mod.rs
+++ b/core/runtime/src/console/mod.rs
@@ -429,6 +429,11 @@ impl Console {
             0,
         )
         .function(
+            console_method(Self::table, state.clone(), logger.clone()),
+            js_string!("table"),
+            0,
+        )
+        .function(
             console_method(Self::dir, state.clone(), logger.clone()),
             js_string!("dir"),
             0,
@@ -915,6 +920,48 @@ impl Console {
             &console.state,
             context,
         )?;
+        Ok(JsValue::undefined())
+    }
+
+    /// `console.table(data)`
+    ///
+    /// Displays tabular data as a table.
+    ///
+    /// More information:
+    ///  - [MDN documentation][mdn]
+    ///
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/API/console/table
+    fn table(
+        _: &JsValue,
+        args: &[JsValue],
+        console: &Self,
+        logger: &impl Logger,
+        context: &mut Context,
+    ) -> JsResult<JsValue> {
+        let data = args.get_or_undefined(0);
+
+        let Some(obj) = data.as_object() else {
+            logger.info(data.display().to_string(), &console.state, context)?;
+            return Ok(JsValue::undefined());
+        };
+
+        let keys = obj.own_property_keys(context)?;
+        let mut output = String::new();
+
+        output.push_str("index | value\n");
+        output.push_str("----------------\n");
+
+        for key in keys {
+            let value = obj.get(key.clone(), context)?;
+
+            let key_str = key.to_string();
+            let val_str = value.display().to_string();
+
+            output.push_str(&format!("{key_str} | {val_str}\n"));
+        }
+
+        logger.info(output, &console.state, context)?;
+
         Ok(JsValue::undefined())
     }
 }

--- a/core/runtime/src/console/tests.rs
+++ b/core/runtime/src/console/tests.rs
@@ -375,3 +375,84 @@ fn trace_with_stack_trace() {
         "# }
     );
 }
+
+#[test]
+fn console_table_basic_object() {
+    let mut context = Context::default();
+    let logger = RecordingLogger::default();
+
+    Console::register_with_logger(logger.clone(), &mut context).unwrap();
+
+    run_test_actions_with(
+        [TestAction::run(indoc! {r#"
+                console.table({ a: 1, b: 2 });
+            "#})],
+        &mut context,
+    );
+
+    let logs = logger.log.borrow().clone();
+
+    assert!(logs.contains("index | value"));
+    assert!(logs.contains("a | 1"));
+    assert!(logs.contains("b | 2"));
+}
+
+#[test]
+fn console_table_non_object() {
+    let mut context = Context::default();
+    let logger = RecordingLogger::default();
+
+    Console::register_with_logger(logger.clone(), &mut context).unwrap();
+
+    run_test_actions_with(
+        [TestAction::run(indoc! {r#"
+                console.table(42);
+            "#})],
+        &mut context,
+    );
+
+    let logs = logger.log.borrow().clone();
+
+    assert!(logs.contains("42"));
+}
+
+#[test]
+fn console_table_array() {
+    let mut context = Context::default();
+    let logger = RecordingLogger::default();
+
+    Console::register_with_logger(logger.clone(), &mut context).unwrap();
+
+    run_test_actions_with(
+        [TestAction::run(indoc! {r#"
+                console.table([1,2,3]);
+            "#})],
+        &mut context,
+    );
+
+    let logs = logger.log.borrow().clone();
+
+    assert!(logs.contains("0"));
+    assert!(logs.contains("1"));
+    assert!(logs.contains("2"));
+}
+
+#[test]
+fn console_table_nested_object_edge_case() {
+    let mut context = Context::default();
+    let logger = RecordingLogger::default();
+
+    Console::register_with_logger(logger.clone(), &mut context).unwrap();
+
+    run_test_actions_with(
+        [TestAction::run(indoc! {r#"
+                console.table({ x: { y: 1 }, z: 2 });
+            "#})],
+        &mut context,
+    );
+
+    let logs = logger.log.borrow().clone();
+
+    assert!(logs.contains("x"));
+    assert!(logs.contains("z"));
+}


### PR DESCRIPTION
This PR adds an implementation of `console.table()` fixes/closes #307

Changes:
- Added `console.table()` method in `core/runtime/src/console/mod.rs`
- Iterates over object's own property keys and prints them in a simple table format
- Logs non-object values directly
- Registered the method in the console API

Tests:
- Added tests in `core/runtime/src/console/tests.rs`
- Covers:
  - basic object input
  - array input
  - non-object input
  - nested object edge case

All existing tests pass (`cargo test`).