### PR TITLE
Add Rust unit tests for Promise.allSettled and Promise.race

### DIFF
--- a/core/engine/src/builtins/promise/tests.rs
+++ b/core/engine/src/builtins/promise/tests.rs
@@ -58,3 +58,43 @@ fn promise_any_resolves_first_success() {
         TestAction::assert_eq("val", 2),
     ]);
 }
+
+#[test]
+fn promise_all_settled_resolves_results() {
+    run_test_actions([
+        TestAction::run(indoc! {r#"
+            var values = [];
+            Promise.allSettled([
+                Promise.resolve(1),
+                Promise.reject(2)
+            ]).then(results => {
+                values = [
+                    results[0].status,
+                    results[0].value,
+                    results[1].status,
+                    results[1].reason
+                ];
+            });
+        "#}),
+        TestAction::inspect_context(|ctx| ctx.run_jobs().unwrap()),
+        TestAction::assert_eq("values[0]", crate::js_string!("fulfilled")),
+        TestAction::assert_eq("values[1]", 1),
+        TestAction::assert_eq("values[2]", crate::js_string!("rejected")),
+        TestAction::assert_eq("values[3]", 2),
+    ]);
+}
+
+#[test]
+fn promise_race_resolves_first() {
+    run_test_actions([
+        TestAction::run(indoc! {r#"
+            var val = null;
+            Promise.race([
+                Promise.resolve(10),
+                Promise.resolve(20)
+            ]).then(v => { val = v; });
+        "#}),
+        TestAction::inspect_context(|ctx| ctx.run_jobs().unwrap()),
+        TestAction::assert_eq("val", 10),
+    ]);
+}


### PR DESCRIPTION
This Pull Request adds Rust-level unit tests for two Promise combinators that currently lack direct coverage in the engine tests.

It changes the following:

* Adds a unit test verifying the correct settlement behavior of `Promise.allSettled`, ensuring fulfilled and rejected promises produce the expected result objects.
* Adds a unit test verifying the resolution behavior of `Promise.race`, confirming that the first resolved promise determines the result.
* Improves internal engine reliability by expanding coverage for Promise combinator behavior and helping prevent regressions.

Both tests follow the existing testing conventions used in `core/engine/src/builtins/promise/tests.rs` and use the standard `run_test_actions` harness with `run_jobs()` to process the Promise job queue.

All tests pass successfully with:

<img width="863" height="235" alt="Screenshot 2026-03-06 at 5 28 56 PM" src="https://github.com/user-attachments/assets/5d141c71-7365-4beb-8992-58be8b3e1ae7" />

cargo fmt
cargo clippy --all-targets --all-features -- -D warnings
cargo test
