### PR TITLE
chore(parser): remove unused UTF16CodeUnitsBuffer::to_string_lossy

### DIFF
--- a/core/parser/src/lexer/string.rs
+++ b/core/parser/src/lexer/string.rs
@@ -45,10 +45,6 @@ pub(crate) enum StringTerminator {
 pub(crate) trait UTF16CodeUnitsBuffer {
     /// Encodes the code point to UTF-16 code units and push to the buffer.
     fn push_code_point(&mut self, code_point: u32);
-
-    /// Decodes the buffer into a String and replace the invalid data with the replacement character (U+FFFD).
-    #[allow(dead_code)]
-    fn to_string_lossy(&self) -> String;
 }
 
 impl UTF16CodeUnitsBuffer for Vec<u16> {
@@ -67,10 +63,6 @@ impl UTF16CodeUnitsBuffer for Vec<u16> {
             .expect("decoded an u32 into two u16.");
         self.push(cu1);
         self.push(cu2);
-    }
-
-    fn to_string_lossy(&self) -> String {
-        String::from_utf16_lossy(self.as_slice())
     }
 }
 


### PR DESCRIPTION
# chore(parser): remove unused UTF16CodeUnitsBuffer::to_string_lossy

## Summary

Removes dead code from the string literal lexer. The `UTF16CodeUnitsBuffer` trait and its `Vec<u16>` implementation contained a `to_string_lossy()` method that was never called anywhere in the codebase.

## Motivation

Dead code increases maintenance burden, adds cognitive load for contributors, and can cause confusion about the intended API surface. The removed method was explicitly flagged with `#[allow(dead_code)]`, indicating it was a known removal candidate. The trait exists to extend buffer types for storing UTF-16 code units during string literal lexing—the only method actually used is `push_code_point()`, which encodes code points into the buffer. The string lexer passes the raw `Vec<u16>` slice to `interner.get_or_intern(&lit[..])`, which handles UTF-16 internally; no conversion to `String` via `to_string_lossy` is required.

## Changes

| Category   | Description |
|-----------|-------------|
| **Removed** | `to_string_lossy(&self) -> String` from `UTF16CodeUnitsBuffer` trait |
| **Removed** | `to_string_lossy` implementation for `Vec<u16>` |
| **Cleaned** | Associated doc comment and `#[allow(dead_code)]` attribute |

## Technical Details

- **File modified:** `core/parser/src/lexer/string.rs`
- **Lines changed:** 8 lines removed
- **Behavioral impact:** None — the removed code had no call sites

The `UTF16CodeUnitsBuffer` trait now exposes only `push_code_point()`, which is the sole method used during string literal lexing. The `StringLiteral` lexer continues to use `take_string_characters()` which returns `(Vec<u16>, Span, EscapeSequence)` and passes the buffer directly to the interner.

## Testing

- [x] `cargo test -p boa_parser` — all 297 tests pass
- [x] Includes `check_string`, `string_unicode`, `string_with_single_escape`, `check_template_literal_simple`
- [x] `cargo build` — successful compilation
