### PR TITLE
Remove unused `All` variant from `FormatDefaults` enum

### DIFF
--- a/core/engine/src/builtins/intl/date_time_format/mod.rs
+++ b/core/engine/src/builtins/intl/date_time_format/mod.rs
@@ -689,10 +689,8 @@ pub(crate) enum FormatType {
     Any,
 }
 
-#[allow(unused)] // All is currently unused, potentially remove.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub(crate) enum FormatDefaults {
     Date,
     Time,
-    All,
 }


### PR DESCRIPTION
## Summary

This pull request removes the unused `All` variant from the `FormatDefaults` enum in `mod.rs`.

The `All` variant was marked as unused and had no references in the codebase. Removing it helps simplify the enum and improves overall code maintainability.

## Changes

- Removed the `All` variant from the `FormatDefaults` enum in `mod.rs`.
- Verified that no other parts of the codebase reference this variant.

Closes #4901 

## Testing

- Successfully built the project using:

```bash
cargo build

