### PR TITLE
fix(job): resolve 100% CPU usage when idling on future timeouts

### DIFF
--- a/core/engine/src/job.rs
+++ b/core/engine/src/job.rs
@@ -49,6 +49,7 @@ use std::mem;
 use std::rc::Rc;
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
+use std::task::Poll;
 use std::{cell::RefCell, collections::VecDeque, fmt::Debug, future::Future, pin::Pin};
 
 /// An ECMAScript [Job Abstract Closure].
@@ -774,24 +775,39 @@ impl JobExecutor for SimpleJobExecutor {
                 && self.generic_jobs.borrow().is_empty();
 
             if no_live_work && !self.timeout_jobs.borrow().is_empty() {
-                // Only future-scheduled timeout jobs remain.  Sleep until the
+                // Only future-scheduled timeout jobs remain. Idle until the
                 // earliest one is due instead of busy-spinning.
-                let sleep_dur = {
-                    let now = context.borrow().clock().now();
-                    self.timeout_jobs
-                        .borrow()
-                        .keys()
-                        .next()
-                        .map(|&deadline| time::Duration::from(deadline - now))
-                };
-                if let Some(dur) = sleep_dur {
+                let now = context.borrow().clock().now();
+                let deadline = self
+                    .timeout_jobs
+                    .borrow()
+                    .keys()
+                    .next()
+                    .copied()
+                    .filter(|&d| d > now);
+
+                if let Some(deadline) = deadline {
+                    let dur = time::Duration::from(deadline - now);
                     if !dur.is_zero() {
-                        let (tx, rx) = oneshot::channel::<()>();
+                        let (tx, mut rx) = oneshot::channel::<()>();
                         std::thread::spawn(move || {
                             std::thread::sleep(dur);
                             let _ = tx.send(());
                         });
-                        let _ = rx.await;
+                        // Re-check the clock on every poll so that mock clocks
+                        // (e.g. FixedClock used in tests) can advance past the
+                        // deadline without waiting for real-time sleep to complete.
+                        std::future::poll_fn(|cx| {
+                            let now = context.borrow().clock().now();
+                            if now >= deadline {
+                                return Poll::Ready(());
+                            }
+                            match Pin::new(&mut rx).poll(cx) {
+                                Poll::Ready(_) => Poll::Ready(()),
+                                Poll::Pending => Poll::Pending,
+                            }
+                        })
+                        .await;
                     }
                 }
             } else {


### PR DESCRIPTION
## Summary
This PR fixes a performance bug where the `SimpleJobExecutor` pins a CPU core at 100% while waiting for a `setTimeout` or `setInterval` delay. The issue occurs because the executor doesn't have a way to "sleep" when there are no active async jobs to poll, causing it to spin in a tight loop until the timer expires.

## Steps to Reproduce
Run any script with a `setTimeout` delay:

```javascript
setTimeout(() => console.log("Done"), 5000);

```

During the 5 second wait, the engine burns 100% of a CPU core despite having no work to do.

## Problem

The current `run_jobs_async` loop has a logic gap. We prevent the loop from terminating (because a timeout is pending), but we only yield execution if there are active async futures. If the async group is empty, the engine falls into a "tight spin" ; it stays awake but has nothing to execute, leading to unnecessary high CPU usage.

## Fix

I updated the loop guards to recognize the "idle wait" state. If the sync queues are empty and no async work is active, the executor now calculates the time remaining until the next scheduled `TimeoutJob` and parks the thread until that deadline.

## Result

* CPU usage during timer delays drops from 100% to effectively 0%.
* Periodic tasks (like heartbeats) now consume negligible resources between ticks.
* The engine is now stable for long running server or embedded usage.

This fix significantly improves the efficiency of the `SimpleJobExecutor` for any host environment using standard JS timers.
