### PR TITLE
feat(gc): make WeakMap::get return a reference instead of cloning

### DIFF
--- a/core/engine/src/builtins/weak_map/mod.rs
+++ b/core/engine/src/builtins/weak_map/mod.rs
@@ -192,7 +192,7 @@ impl WeakMap {
         // 5. For each Record { [[Key]], [[Value]] } p of entries, do
         // a. If p.[[Key]] is not empty and SameValue(p.[[Key]], key) is true, return p.[[Value]].
         // 6. Return undefined.
-        Ok(map.get(key.inner()).unwrap_or_default())
+        Ok(map.get(key.inner()).as_deref().cloned().unwrap_or_default())
     }
 
     /// `WeakMap.prototype.has ( key )`
@@ -319,7 +319,7 @@ impl WeakMap {
         // 4. For each Record { [[Key]], [[Value]] } p of M.[[WeakMapData]]
         if let Some(existing) = map.borrow().data().get(key.inner()) {
             // a. If p.[[Key]] is not empty and SameValue(p.[[Key]], key) is true, return p.[[Value]].
-            return Ok(existing);
+            return Ok((*existing).clone());
         }
 
         // 5-6. Insert the new record with provided value and return it.
@@ -380,7 +380,7 @@ impl WeakMap {
         // 5. For each Record { [[Key]], [[Value]] } p of M.[[WeakMapData]]
         if let Some(existing) = map.borrow().data().get(key_obj.inner()) {
             // a. If p.[[Key]] is not empty and SameValue(p.[[Key]], key) is true, return p.[[Value]].
-            return Ok(existing);
+            return Ok((*existing).clone());
         }
 
         // 6. Let value be ? Call(callback, undefined, « key »).

--- a/core/gc/src/pointers/ephemeron.rs
+++ b/core/gc/src/pointers/ephemeron.rs
@@ -22,6 +22,19 @@ pub struct Ephemeron<K: Trace + ?Sized + 'static, V: Trace + 'static> {
     inner_ptr: NonNull<EphemeronBox<K, V>>,
 }
 
+impl<K: Trace + ?Sized, V: Trace> Ephemeron<K, V> {
+    /// Returns a reference to the stored value or `None` if the key was garbage collected.
+    ///
+    /// The caller must hold the enclosing [`GcRef`][crate::GcRef] borrow for the lifetime of the
+    /// returned reference.
+    #[must_use]
+    pub fn value_ref(&self) -> Option<&V> {
+        // SAFETY: this is safe because `Ephemeron` is tracked to always point to a valid pointer
+        // `inner_ptr`
+        unsafe { self.inner_ptr.as_ref().value() }
+    }
+}
+
 impl<K: Trace + ?Sized, V: Trace + Clone> Ephemeron<K, V> {
     /// Gets the stored value of this `Ephemeron`, or `None` if the key was already garbage collected.
     ///

--- a/core/gc/src/pointers/weak_map.rs
+++ b/core/gc/src/pointers/weak_map.rs
@@ -6,7 +6,7 @@ use hashbrown::{
     hash_table::{Entry as RawEntry, Iter as RawIter},
 };
 
-use crate::{Allocator, Ephemeron, Finalize, Gc, GcRefCell, Trace, custom_trace};
+use crate::{Allocator, Ephemeron, Finalize, Gc, GcRef, GcRefCell, Trace, custom_trace};
 use std::{fmt, hash::BuildHasher, marker::PhantomData};
 
 /// A map that holds weak references to its keys and is traced by the garbage collector.
@@ -40,7 +40,9 @@ impl<K: Trace + ?Sized, V: Trace + Clone> WeakMap<K, V> {
     pub fn remove(&mut self, key: &Gc<K>) -> Option<V> {
         self.inner.borrow_mut().remove(key)
     }
+}
 
+impl<K: Trace + ?Sized, V: Trace> WeakMap<K, V> {
     /// Returns `true` if the map contains a value for the specified key.
     #[must_use]
     #[inline]
@@ -51,8 +53,8 @@ impl<K: Trace + ?Sized, V: Trace + Clone> WeakMap<K, V> {
     /// Returns a reference to the value corresponding to the key.
     #[must_use]
     #[inline]
-    pub fn get(&self, key: &Gc<K>) -> Option<V> {
-        self.inner.borrow().get(key)
+    pub fn get(&self, key: &Gc<K>) -> Option<GcRef<'_, V>> {
+        GcRef::try_map(self.inner.borrow(), |map: &RawWeakMap<K, V>| map.get(key))
     }
 }
 
@@ -222,6 +224,28 @@ where
 impl<K, V, S> RawWeakMap<K, V, S>
 where
     K: Trace + ?Sized + 'static,
+    V: Trace + 'static,
+    S: BuildHasher,
+{
+    /// Returns a reference to the value corresponding to the supplied key.
+    pub(crate) fn get(&self, k: &Gc<K>) -> Option<&V> {
+        if self.table.is_empty() {
+            None
+        } else {
+            let hash = make_hash_from_gc(&self.hash_builder, k);
+            self.table.find(hash, equivalent_key(k))?.value_ref()
+        }
+    }
+
+    /// Returns `true` if the map contains a value for the specified key.
+    pub(crate) fn contains_key(&self, k: &Gc<K>) -> bool {
+        self.get(k).is_some()
+    }
+}
+
+impl<K, V, S> RawWeakMap<K, V, S>
+where
+    K: Trace + ?Sized + 'static,
     V: Trace + Clone + 'static,
     S: BuildHasher,
 {
@@ -273,22 +297,6 @@ where
     pub(crate) fn shrink_to(&mut self, min_capacity: usize) {
         self.table
             .shrink_to(min_capacity, make_hasher::<_, V, S>(&self.hash_builder));
-    }
-
-    /// Returns the value corresponding to the supplied key.
-    // TODO: make this return a reference instead of cloning.
-    pub(crate) fn get(&self, k: &Gc<K>) -> Option<V> {
-        if self.table.is_empty() {
-            None
-        } else {
-            let hash = make_hash_from_gc(&self.hash_builder, k);
-            self.table.find(hash, equivalent_key(k))?.value()
-        }
-    }
-
-    /// Returns `true` if the map contains a value for the specified key.
-    pub(crate) fn contains_key(&self, k: &Gc<K>) -> bool {
-        self.get(k).is_some()
     }
 
     // Inserts a key-value pair into the map.


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request fixes/closes #{issue_num}.

It changes the following:

`WeakMap::get` now returns an `Option<GcRef<'_, V>>` instead of `Option<V>`