### PR TITLE
feat: support symbols as weak collection keys (CanBeHeldWeakly)

### DIFF
--- a/core/engine/src/builtins/symbol/mod.rs
+++ b/core/engine/src/builtins/symbol/mod.rs
@@ -88,6 +88,16 @@ impl GlobalSymbolRegistry {
     }
 }
 
+/// Returns `true` if the given symbol was created by `Symbol.for()` and is
+/// therefore part of the global symbol registry.
+///
+/// Per ECMAScript §20.4.5.1 `KeyForSymbol`, a symbol that is in the
+/// `GlobalSymbolRegistry` is not suitable for use as a weak reference key
+/// (see §9.13 `CanBeHeldWeakly`).
+pub(crate) fn is_registered_symbol(sym: &JsSymbol) -> bool {
+    GLOBAL_SYMBOL_REGISTRY.get_key(sym).is_some()
+}
+
 /// The internal representation of a `Symbol` object.
 #[derive(Debug, Clone, Copy)]
 pub struct Symbol;

--- a/core/engine/src/builtins/weak/mod.rs
+++ b/core/engine/src/builtins/weak/mod.rs
@@ -1,5 +1,51 @@
-//! Boa's implementation of ECMAScript's `WeakRef` object.
+//! Boa's implementation of ECMAScript's `WeakRef` object and related helpers.
 
 mod weak_ref;
 
 pub(crate) use weak_ref::WeakRef;
+
+use crate::{
+    builtins::symbol::is_registered_symbol, object::JsObject, symbol::JsSymbol, value::JsValue,
+};
+
+/// A value that has passed the [`CanBeHeldWeakly`][spec] check.
+///
+/// This enum is produced by [`can_be_held_weakly`] and ensures callers
+/// always route object vs. symbol storage without repeated `if/else` chains.
+///
+/// [spec]: https://tc39.es/ecma262/#sec-canbeheldweakly
+pub(crate) enum WeakKey {
+    Object(JsObject),
+    Symbol(JsSymbol),
+}
+
+/// Abstract operation [`CanBeHeldWeakly ( v )`][spec].
+///
+/// If `v` is suitable for use as a weak reference key, returns a
+/// [`WeakKey`] wrapping the concrete object or symbol.  Returns `None`
+/// for registered symbols, primitives, and other non-weakly-holdable values.
+///
+/// Per the spec:
+/// 1. If `v` is an Object, return **true**.
+/// 2. If `v` is a Symbol and `KeyForSymbol(v)` is **undefined**, return **true**.
+/// 3. Return **false**.
+///
+/// [spec]: https://tc39.es/ecma262/#sec-canbeheldweakly
+pub(crate) fn can_be_held_weakly(v: &JsValue) -> Option<WeakKey> {
+    // 1. If v is an Object, return true.
+    if let Some(obj) = v.as_object() {
+        return Some(WeakKey::Object(obj.clone()));
+    }
+
+    // 2. If v is a Symbol and KeyForSymbol(v) is undefined, return true.
+    if let Some(weak) = v
+        .as_symbol()
+        .filter(|sym| !is_registered_symbol(sym))
+        .map(WeakKey::Symbol)
+    {
+        return Some(weak);
+    }
+
+    // 3. Return false.
+    None
+}

--- a/core/engine/src/builtins/weak/weak_ref.rs
+++ b/core/engine/src/builtins/weak/weak_ref.rs
@@ -1,8 +1,11 @@
 use boa_gc::{Finalize, Trace, WeakGc};
 
 use crate::{
-    Context, JsArgs, JsNativeError, JsResult, JsString, JsValue,
-    builtins::{BuiltInBuilder, BuiltInConstructor, BuiltInObject, IntrinsicObject},
+    Context, JsArgs, JsData, JsNativeError, JsResult, JsString, JsValue,
+    builtins::{
+        BuiltInBuilder, BuiltInConstructor, BuiltInObject, IntrinsicObject,
+        weak::{WeakKey, can_be_held_weakly},
+    },
     context::intrinsics::{Intrinsics, StandardConstructor, StandardConstructors},
     js_string,
     object::{ErasedVTableObject, JsObject, internal_methods::get_prototype_from_constructor},
@@ -12,10 +15,36 @@ use crate::{
     symbol::JsSymbol,
 };
 
+/// Internal target of a `WeakRef`: either a GC-weak object reference or a symbol.
+///
+/// Symbols are not GC-traced (they use `Arc`), so they cannot use `WeakGc`.
+/// Non-registered symbols hold a strong `JsSymbol` reference; their lifetime
+/// is tied to the `WeakRef` instance itself, which matches spec intent since
+/// well-known symbols are effectively immortal and user-created symbols are
+/// unique identity values.
+#[derive(Clone, Trace, Finalize, JsData)]
+pub(crate) enum WeakRefTarget {
+    Object(WeakGc<ErasedVTableObject>),
+    /// Note: `deref()` always succeeds for symbol targets because symbols
+    /// are `Arc`-based and cannot be garbage-collected.
+    #[unsafe_ignore_trace]
+    Symbol(JsSymbol),
+}
+
+impl std::fmt::Debug for WeakRefTarget {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Object(_) => f.debug_tuple("Object").field(&"<weak>").finish(),
+            Self::Symbol(sym) => f.debug_tuple("Symbol").field(sym).finish(),
+        }
+    }
+}
+
 /// Boa's implementation of ECMAScript's `WeakRef` builtin object.
 ///
-/// The `WeakRef` is a way to refer to a target object without rooting the target and thus preserving it in garbage
-/// collection. A `WeakRef` will allow the user to dereference the target as long as the target object has not been
+/// The `WeakRef` is a way to refer to a target object or symbol without rooting
+/// the target and thus preserving it in garbage collection. A `WeakRef` will
+/// allow the user to dereference the target as long as the target has not been
 /// collected by the garbage collector.
 ///
 /// More Information:
@@ -65,36 +94,56 @@ impl BuiltInConstructor for WeakRef {
         args: &[JsValue],
         context: &mut Context,
     ) -> JsResult<JsValue> {
-        // If NewTarget is undefined, throw a TypeError exception.
+        // 1. If NewTarget is undefined, throw a TypeError exception.
         if new_target.is_undefined() {
             return Err(JsNativeError::typ()
                 .with_message("WeakRef: cannot call constructor without `new`")
                 .into());
         }
 
-        // 2. If target is not an Object, throw a TypeError exception.
-        let target = args.first().and_then(JsValue::as_object).ok_or_else(|| {
+        // 2. If CanBeHeldWeakly(target) is false, throw a TypeError exception.
+        let target = args.get_or_undefined(0);
+        let weak_key = can_be_held_weakly(target).ok_or_else(|| {
             JsNativeError::typ().with_message(format!(
-                "WeakRef: expected target argument of type `object`, got target of type `{}`",
-                args.get_or_undefined(0).type_of()
+                "WeakRef: invalid target type `{}`: cannot be held weakly",
+                target.type_of()
             ))
         })?;
 
         // 3. Let weakRef be ? OrdinaryCreateFromConstructor(NewTarget, "%WeakRef.prototype%", « [[WeakRefTarget]] »).
-        // 5. Set weakRef.[[WeakRefTarget]] to target.
         let prototype =
             get_prototype_from_constructor(new_target, StandardConstructors::weak_ref, context)?;
-        let weak_ref = JsObject::from_proto_and_data_with_shared_shape(
-            context.root_shape(),
-            prototype,
-            WeakGc::new(target.inner()),
-        );
 
         // 4. Perform AddToKeptObjects(target).
-        context.kept_alive.push(target.clone());
-
+        // 5. Set weakRef.[[WeakRefTarget]] to target.
         // 6. Return weakRef.
-        Ok(weak_ref.into())
+        match weak_key {
+            WeakKey::Object(obj) => {
+                let weak_ref = JsObject::from_proto_and_data_with_shared_shape(
+                    context.root_shape(),
+                    prototype,
+                    WeakRefTarget::Object(WeakGc::new(obj.inner())),
+                );
+
+                // Step 4: AddToKeptObjects — prevents GC from collecting `target`
+                // before the next synchronous completion.
+                context.kept_alive.push(obj.clone());
+
+                Ok(weak_ref.into())
+            }
+            WeakKey::Symbol(sym) => {
+                let weak_ref = JsObject::from_proto_and_data_with_shared_shape(
+                    context.root_shape(),
+                    prototype,
+                    WeakRefTarget::Symbol(sym),
+                );
+
+                // Note: AddToKeptObjects is not needed for symbols because they
+                // are not GC-managed (`Arc`-based) and cannot be collected.
+
+                Ok(weak_ref.into())
+            }
+        }
     }
 }
 
@@ -102,7 +151,7 @@ impl WeakRef {
     /// Method [`WeakRef.prototype.deref ( )`][spec].
     ///
     /// If the referenced object hasn't been collected, this method promotes a `WeakRef` into a
-    /// proper [`JsObject`], or returns `undefined` otherwise.
+    /// proper [`JsObject`] or returns the symbol, or returns `undefined` otherwise.
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-weak-ref.prototype.deref
     pub(crate) fn deref(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
@@ -111,7 +160,7 @@ impl WeakRef {
         let object = this.as_object();
         let weak_ref = object
             .as_ref()
-            .and_then(JsObject::downcast_ref::<WeakGc<ErasedVTableObject>>)
+            .and_then(JsObject::downcast_ref::<WeakRefTarget>)
             .ok_or_else(|| {
                 JsNativeError::typ().with_message(
                     "WeakRef.prototype.deref: expected `this` to be a `WeakRef` object",
@@ -119,22 +168,29 @@ impl WeakRef {
             })?;
 
         // 3. Return WeakRefDeref(weakRef).
-
-        // `WeakRefDeref`
         // https://tc39.es/ecma262/multipage/managing-memory.html#sec-weakrefderef
-        // 1. Let target be weakRef.[[WeakRefTarget]].
-        // 2. If target is not empty, then
-        if let Some(object) = weak_ref.upgrade() {
-            let object = JsObject::from(object);
+        match &*weak_ref {
+            WeakRefTarget::Object(weak_gc) => {
+                // 1. Let target be weakRef.[[WeakRefTarget]].
+                // 2. If target is not empty, then
+                if let Some(object) = weak_gc.upgrade() {
+                    let object = JsObject::from(object);
 
-            // a. Perform AddToKeptObjects(target).
-            context.kept_alive.push(object.clone());
+                    // a. Perform AddToKeptObjects(target).
+                    context.kept_alive.push(object.clone());
 
-            // b. Return target.
-            Ok(object.into())
-        } else {
-            // 3. Return undefined.
-            Ok(JsValue::undefined())
+                    // b. Return target.
+                    Ok(object.into())
+                } else {
+                    // 3. Return undefined.
+                    Ok(JsValue::undefined())
+                }
+            }
+            WeakRefTarget::Symbol(sym) => {
+                // Symbols are `Arc`-based and cannot be garbage-collected,
+                // so they always resolve successfully.
+                Ok(sym.clone().into())
+            }
         }
     }
 }
@@ -165,5 +221,23 @@ mod tests {
             }),
             TestAction::assert_eq("ptr.deref()", JsValue::undefined()),
         ]);
+    }
+
+    #[test]
+    fn weak_ref_symbol_target() {
+        run_test_actions([TestAction::assert(indoc! {r#"
+                    let sym = Symbol("test");
+                    let wr = new WeakRef(sym);
+                    wr.deref() === sym
+                "#})]);
+    }
+
+    #[test]
+    fn weak_ref_rejects_registered_symbol() {
+        run_test_actions([TestAction::assert_native_error(
+            "new WeakRef(Symbol.for('registered'))",
+            crate::JsNativeErrorKind::Type,
+            "WeakRef: invalid target type `symbol`: cannot be held weakly",
+        )]);
     }
 }

--- a/core/engine/src/builtins/weak_map/mod.rs
+++ b/core/engine/src/builtins/weak_map/mod.rs
@@ -7,11 +7,15 @@
 //! [spec]: https://tc39.es/ecma262/#sec-weakmap-objects
 //! [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakMap
 
+use std::collections::HashMap;
+
+use crate::JsData;
 use crate::{
     Context, JsArgs, JsNativeError, JsResult, JsString, JsValue,
     builtins::{
         BuiltInBuilder, BuiltInConstructor, BuiltInObject, IntrinsicObject,
         map::add_entries_from_iterable,
+        weak::{WeakKey, can_be_held_weakly},
     },
     context::intrinsics::{Intrinsics, StandardConstructor, StandardConstructors},
     js_string,
@@ -23,7 +27,32 @@ use crate::{
 };
 use boa_gc::{Finalize, Trace};
 
-pub(crate) type NativeWeakMap = boa_gc::WeakMap<ErasedVTableObject, JsValue>;
+/// Native data for `WeakMap` objects with dual storage:
+/// - `objects`: GC-backed weak map for object keys (uses ephemerons)
+/// - `symbols`: regular `HashMap` for symbol keys (symbols use `Arc`, not GC)
+#[derive(Trace, Finalize, JsData)]
+pub(crate) struct NativeWeakMap {
+    objects: boa_gc::WeakMap<ErasedVTableObject, JsValue>,
+    #[unsafe_ignore_trace]
+    symbols: HashMap<u64, (JsSymbol, JsValue)>,
+}
+
+impl NativeWeakMap {
+    pub(crate) fn new() -> Self {
+        Self {
+            objects: boa_gc::WeakMap::new(),
+            symbols: HashMap::new(),
+        }
+    }
+}
+
+impl std::fmt::Debug for NativeWeakMap {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("NativeWeakMap")
+            .field("symbols", &self.symbols)
+            .finish_non_exhaustive()
+    }
+}
 
 #[derive(Debug, Trace, Finalize)]
 pub(crate) struct WeakMap;
@@ -114,7 +143,7 @@ impl BuiltInConstructor for WeakMap {
         let adder = map
             .get(js_string!("set"), context)?
             .as_function()
-            .ok_or_else(|| JsNativeError::typ().with_message("WeakMap: 'add' is not a function"))?;
+            .ok_or_else(|| JsNativeError::typ().with_message("WeakMap: 'set' is not a function"))?;
 
         // 7. Return ? AddEntriesFromIterable(map, iterable, adder).
         add_entries_from_iterable(&map, iterable, &adder, context)
@@ -146,18 +175,22 @@ impl WeakMap {
             })?;
 
         // 3. Let entries be M.[[WeakMapData]].
-        // 4. If key is not an Object, return false.
-        let Some(key) = args.get_or_undefined(0).as_object() else {
+        // 4. If CanBeHeldWeakly(key) is false, return false.
+        let key = args.get_or_undefined(0);
+        let Some(weak_key) = can_be_held_weakly(key) else {
             return Ok(false.into());
         };
 
         // 5. For each Record { [[Key]], [[Value]] } p of entries, do
-        // a. If p.[[Key]] is not empty and SameValue(p.[[Key]], key) is true, then
-        // i. Set p.[[Key]] to empty.
-        // ii. Set p.[[Value]] to empty.
-        // iii. Return true.
+        //   a. If p.[[Key]] is not empty and SameValue(p.[[Key]], key) is true, then
+        //     i. Set p.[[Key]] to empty.
+        //     ii. Set p.[[Value]] to empty.
+        //     iii. Return true.
         // 6. Return false.
-        Ok(map.remove(key.inner()).is_some().into())
+        match weak_key {
+            WeakKey::Object(obj) => Ok(map.objects.remove(obj.inner()).is_some().into()),
+            WeakKey::Symbol(sym) => Ok(map.symbols.remove(&sym.hash()).is_some().into()),
+        }
     }
 
     /// `WeakMap.prototype.get ( key )`
@@ -184,15 +217,24 @@ impl WeakMap {
             })?;
 
         // 3. Let entries be M.[[WeakMapData]].
-        // 4. If key is not an Object, return undefined.
-        let Some(key) = args.get_or_undefined(0).as_object() else {
+        // 4. If CanBeHeldWeakly(key) is false, return undefined.
+        let key = args.get_or_undefined(0);
+        let Some(weak_key) = can_be_held_weakly(key) else {
             return Ok(JsValue::undefined());
         };
 
         // 5. For each Record { [[Key]], [[Value]] } p of entries, do
-        // a. If p.[[Key]] is not empty and SameValue(p.[[Key]], key) is true, return p.[[Value]].
+        //   a. If p.[[Key]] is not empty and SameValue(p.[[Key]], key) is true,
+        //      return p.[[Value]].
         // 6. Return undefined.
-        Ok(map.get(key.inner()).unwrap_or_default())
+        match weak_key {
+            WeakKey::Object(obj) => Ok(map.objects.get(obj.inner()).unwrap_or_default()),
+            WeakKey::Symbol(sym) => Ok(map
+                .symbols
+                .get(&sym.hash())
+                .map(|(_, v)| v.clone())
+                .unwrap_or_default()),
+        }
     }
 
     /// `WeakMap.prototype.has ( key )`
@@ -219,15 +261,20 @@ impl WeakMap {
             })?;
 
         // 3. Let entries be M.[[WeakMapData]].
-        // 4. If key is not an Object, return false.
-        let Some(key) = args.get_or_undefined(0).as_object() else {
+        // 4. If CanBeHeldWeakly(key) is false, return false.
+        let key = args.get_or_undefined(0);
+        let Some(weak_key) = can_be_held_weakly(key) else {
             return Ok(false.into());
         };
 
         // 5. For each Record { [[Key]], [[Value]] } p of entries, do
-        // a. If p.[[Key]] is not empty and SameValue(p.[[Key]], key) is true, return true.
+        //   a. If p.[[Key]] is not empty and SameValue(p.[[Key]], key) is true,
+        //      return true.
         // 6. Return false.
-        Ok(map.contains_key(key.inner()).into())
+        match weak_key {
+            WeakKey::Object(obj) => Ok(map.objects.contains_key(obj.inner()).into()),
+            WeakKey::Symbol(sym) => Ok(map.symbols.contains_key(&sym.hash()).into()),
+        }
     }
 
     /// `WeakMap.prototype.set ( key, value )`
@@ -254,25 +301,33 @@ impl WeakMap {
             })?;
 
         // 3. Let entries be M.[[WeakMapData]].
-        // 4. If key is not an Object, throw a TypeError exception.
+        // 4. If CanBeHeldWeakly(key) is false, throw a TypeError exception.
         let key = args.get_or_undefined(0);
-        let Some(key) = key.as_object() else {
-            return Err(JsNativeError::typ()
-                .with_message(format!(
-                    "WeakMap.set: expected target argument of type `object`, got target of type `{}`",
-                    key.type_of()
-                )).into());
-        };
+        let weak_key = can_be_held_weakly(key).ok_or_else(|| {
+            JsNativeError::typ().with_message(format!(
+                "WeakMap.set: invalid key type `{}`: cannot be held weakly",
+                key.type_of()
+            ))
+        })?;
+
+        let value = args.get_or_undefined(1).clone();
 
         // 5. For each Record { [[Key]], [[Value]] } p of entries, do
-        // a. If p.[[Key]] is not empty and SameValue(p.[[Key]], key) is true, then
-        // i. Set p.[[Value]] to value.
-        // ii. Return M.
+        //   a. If p.[[Key]] is not empty and SameValue(p.[[Key]], key) is true, then
+        //     i. Set p.[[Value]] to value.
+        //     ii. Return M.
         // 6. Let p be the Record { [[Key]]: key, [[Value]]: value }.
         // 7. Append p to entries.
-        map.insert(key.inner(), args.get_or_undefined(1).clone());
-
         // 8. Return M.
+        match weak_key {
+            WeakKey::Object(obj) => {
+                map.objects.insert(obj.inner(), value);
+            }
+            WeakKey::Symbol(sym) => {
+                map.symbols.insert(sym.hash(), (sym, value));
+            }
+        }
+
         Ok(this.clone())
     }
 
@@ -303,31 +358,44 @@ impl WeakMap {
             })?;
 
         // 3. If CanBeHeldWeakly(key) is false, throw a TypeError exception.
-        // TODO: Implement proper CanBeHeldWeakly once available. For now, only
-        //       objects are accepted as keys; symbols should be allowed in the
-        //       future according to the proposal.
         let key_val = args.get_or_undefined(0);
-        let Some(key) = key_val.as_object() else {
-            return Err(JsNativeError::typ()
-                .with_message(format!(
-                    "WeakMap.getOrInsert: expected target argument of type `object`, got target of type `{}`",
-                    key_val.type_of()
-                ))
-                .into());
-        };
+        let weak_key = can_be_held_weakly(key_val).ok_or_else(|| {
+            JsNativeError::typ().with_message(format!(
+                "WeakMap.getOrInsert: invalid key type `{}`: cannot be held weakly",
+                key_val.type_of()
+            ))
+        })?;
 
-        // 4. For each Record { [[Key]], [[Value]] } p of M.[[WeakMapData]]
-        if let Some(existing) = map.borrow().data().get(key.inner()) {
-            // a. If p.[[Key]] is not empty and SameValue(p.[[Key]], key) is true, return p.[[Value]].
-            return Ok(existing);
+        // 4. For each Record { [[Key]], [[Value]] } p of M.[[WeakMapData]], do
+        //   a. If p.[[Key]] is not empty and SameValue(p.[[Key]], key) is true,
+        //      return p.[[Value]].
+        // 5. Let p be the Record { [[Key]]: key, [[Value]]: value }.
+        // 6. Append p to M.[[WeakMapData]].
+        // 7. Return value.
+        match weak_key {
+            WeakKey::Object(obj) => {
+                if let Some(existing) = map.borrow().data().objects.get(obj.inner()) {
+                    return Ok(existing);
+                }
+                let value = args.get_or_undefined(1).clone();
+                map.borrow_mut()
+                    .data_mut()
+                    .objects
+                    .insert(obj.inner(), value.clone());
+                Ok(value)
+            }
+            WeakKey::Symbol(sym) => {
+                if let Some((_, existing)) = map.borrow().data().symbols.get(&sym.hash()) {
+                    return Ok(existing.clone());
+                }
+                let value = args.get_or_undefined(1).clone();
+                map.borrow_mut()
+                    .data_mut()
+                    .symbols
+                    .insert(sym.hash(), (sym, value.clone()));
+                Ok(value)
+            }
         }
-
-        // 5-6. Insert the new record with provided value and return it.
-        let value = args.get_or_undefined(1).clone();
-        map.borrow_mut()
-            .data_mut()
-            .insert(key.inner(), value.clone());
-        Ok(value)
     }
 
     /// `WeakMap.prototype.getOrInsertComputed ( key, callback )`
@@ -357,44 +425,68 @@ impl WeakMap {
             })?;
 
         // 3. If CanBeHeldWeakly(key) is false, throw a TypeError exception.
-        // TODO: Implement proper CanBeHeldWeakly once available. For now, only
-        //       objects are accepted as keys; symbols should be allowed in the
-        //       future according to the proposal.
         let key_value = args.get_or_undefined(0).clone();
-        let Some(key_obj) = key_value.as_object() else {
-            return Err(JsNativeError::typ()
-                .with_message(format!(
-                    "WeakMap.getOrInsertComputed: expected target argument of type `object`, got target of type `{}`",
-                    key_value.type_of()
-                ))
-                .into());
-        };
+        let weak_key = can_be_held_weakly(&key_value).ok_or_else(|| {
+            JsNativeError::typ().with_message(format!(
+                "WeakMap.getOrInsertComputed: invalid key type `{}`: cannot be held weakly",
+                key_value.type_of()
+            ))
+        })?;
 
         // 4. If IsCallable(callback) is false, throw a TypeError exception.
         let Some(callback_fn) = args.get_or_undefined(1).as_callable() else {
             return Err(JsNativeError::typ()
-                .with_message("Method WeakMap.prototype.getOrInsertComputed called with non-callable callback function")
+                .with_message("WeakMap.getOrInsertComputed: callback is not a function")
                 .into());
         };
 
-        // 5. For each Record { [[Key]], [[Value]] } p of M.[[WeakMapData]]
-        if let Some(existing) = map.borrow().data().get(key_obj.inner()) {
-            // a. If p.[[Key]] is not empty and SameValue(p.[[Key]], key) is true, return p.[[Value]].
-            return Ok(existing);
-        }
-
+        // 5. For each Record { [[Key]], [[Value]] } p of M.[[WeakMapData]], do
+        //   a. If p.[[Key]] is not empty and SameValue(p.[[Key]], key) is true,
+        //      return p.[[Value]].
         // 6. Let value be ? Call(callback, undefined, « key »).
-        // 7. NOTE: The WeakMap may have been modified during execution of callback.
-        let value = callback_fn.call(
-            &JsValue::undefined(),
-            std::slice::from_ref(&key_value),
-            context,
-        )?;
+        // 7. NOTE: The callback may have already inserted an entry for key.
+        // 8. For each Record { [[Key]], [[Value]] } p of M.[[WeakMapData]], do
+        //   a. If p.[[Key]] is not empty and SameValue(p.[[Key]], key) is true, then
+        //     i. Set p.[[Value]] to value.
+        //     ii. Return value.
+        // 9. Let p be the Record { [[Key]]: key, [[Value]]: value }.
+        // 10. Append p to M.[[WeakMapData]].
+        // 11. Return value.
+        match weak_key {
+            WeakKey::Object(obj) => {
+                if let Some(existing) = map.borrow().data().objects.get(obj.inner()) {
+                    return Ok(existing);
+                }
 
-        // 8-10. Insert or update the entry and return value.
-        map.borrow_mut()
-            .data_mut()
-            .insert(key_obj.inner(), value.clone());
-        Ok(value)
+                let value = callback_fn.call(
+                    &JsValue::undefined(),
+                    std::slice::from_ref(&key_value),
+                    context,
+                )?;
+
+                map.borrow_mut()
+                    .data_mut()
+                    .objects
+                    .insert(obj.inner(), value.clone());
+                Ok(value)
+            }
+            WeakKey::Symbol(sym) => {
+                if let Some((_, existing)) = map.borrow().data().symbols.get(&sym.hash()) {
+                    return Ok(existing.clone());
+                }
+
+                let value = callback_fn.call(
+                    &JsValue::undefined(),
+                    std::slice::from_ref(&key_value),
+                    context,
+                )?;
+
+                map.borrow_mut()
+                    .data_mut()
+                    .symbols
+                    .insert(sym.hash(), (sym, value.clone()));
+                Ok(value)
+            }
+        }
     }
 }

--- a/core/engine/src/builtins/weak_map/tests.rs
+++ b/core/engine/src/builtins/weak_map/tests.rs
@@ -25,25 +25,25 @@ fn get_or_insert_computed_requires_callable() {
     run_test_actions([TestAction::assert_native_error(
         "new WeakMap().getOrInsertComputed({}, undefined)",
         JsNativeErrorKind::Type,
-        "Method WeakMap.prototype.getOrInsertComputed called with non-callable callback function",
+        "WeakMap.getOrInsertComputed: callback is not a function",
     )]);
 }
 
 #[test]
-fn get_or_insert_requires_object_key() {
+fn get_or_insert_requires_weakly_holdable_key() {
     run_test_actions([TestAction::assert_native_error(
         "new WeakMap().getOrInsert('x', 1)",
         JsNativeErrorKind::Type,
-        "WeakMap.getOrInsert: expected target argument of type `object`, got target of type `string`",
+        "WeakMap.getOrInsert: invalid key type `string`: cannot be held weakly",
     )]);
 }
 
 #[test]
-fn get_or_insert_computed_requires_object_key() {
+fn get_or_insert_computed_requires_weakly_holdable_key() {
     run_test_actions([TestAction::assert_native_error(
         "new WeakMap().getOrInsertComputed('x', () => 1)",
         JsNativeErrorKind::Type,
-        "WeakMap.getOrInsertComputed: expected target argument of type `object`, got target of type `string`",
+        "WeakMap.getOrInsertComputed: invalid key type `string`: cannot be held weakly",
     )]);
 }
 
@@ -112,4 +112,106 @@ fn get_or_insert_computed_this_not_weakmap() {
         JsNativeErrorKind::Type,
         "WeakMap.getOrInsertComputed: called with non-object value",
     )]);
+}
+
+// --- Symbol key tests ---
+
+#[test]
+fn symbol_key_set_get_has_delete() {
+    run_test_actions([
+        TestAction::run(
+            r#"
+            let sym = Symbol("test");
+            let wm = new WeakMap();
+            wm.set(sym, 42);
+        "#,
+        ),
+        TestAction::assert("wm.has(sym)"),
+        TestAction::assert_eq("wm.get(sym)", 42),
+        TestAction::assert("wm.delete(sym)"),
+        TestAction::assert("!wm.has(sym)"),
+        TestAction::assert_eq("wm.get(sym)", crate::JsValue::undefined()),
+    ]);
+}
+
+#[test]
+fn symbol_key_registered_rejected() {
+    run_test_actions([TestAction::assert_native_error(
+        "new WeakMap().set(Symbol.for('registered'), 1)",
+        JsNativeErrorKind::Type,
+        "WeakMap.set: invalid key type `symbol`: cannot be held weakly",
+    )]);
+}
+
+#[test]
+fn symbol_key_well_known_accepted() {
+    run_test_actions([
+        TestAction::run(
+            r#"
+            let wm = new WeakMap();
+            wm.set(Symbol.iterator, "iter_value");
+        "#,
+        ),
+        TestAction::assert("wm.has(Symbol.iterator)"),
+        TestAction::assert_eq("wm.get(Symbol.iterator)", js_str!("iter_value")),
+    ]);
+}
+
+#[test]
+fn symbol_key_get_or_insert() {
+    run_test_actions([
+        TestAction::run(
+            r#"
+            let sym = Symbol("goi");
+            let wm = new WeakMap();
+        "#,
+        ),
+        TestAction::assert_eq("wm.getOrInsert(sym, 99)", 99),
+        TestAction::assert("wm.has(sym)"),
+        TestAction::assert_eq("wm.getOrInsert(sym, 200)", 99), // existing value returned
+    ]);
+}
+
+#[test]
+fn symbol_key_get_or_insert_computed() {
+    run_test_actions([
+        TestAction::run(
+            r#"
+            let sym = Symbol("goic");
+            let wm = new WeakMap();
+            let calls = 0;
+        "#,
+        ),
+        TestAction::assert_eq(
+            "wm.getOrInsertComputed(sym, (k) => { calls++; return 77; })",
+            77,
+        ),
+        TestAction::assert_eq("calls", 1),
+        TestAction::assert_eq(
+            "wm.getOrInsertComputed(sym, (k) => { calls++; return 88; })",
+            77,
+        ),
+        TestAction::assert_eq("calls", 1), // callback not called on hit
+    ]);
+}
+
+#[test]
+fn primitives_still_rejected() {
+    run_test_actions([
+        TestAction::assert_native_error(
+            "new WeakMap().set(42, 'v')",
+            JsNativeErrorKind::Type,
+            "WeakMap.set: invalid key type `number`: cannot be held weakly",
+        ),
+        TestAction::assert_native_error(
+            "new WeakMap().set('str', 'v')",
+            JsNativeErrorKind::Type,
+            "WeakMap.set: invalid key type `string`: cannot be held weakly",
+        ),
+        TestAction::assert_native_error(
+            "new WeakMap().set(true, 'v')",
+            JsNativeErrorKind::Type,
+            "WeakMap.set: invalid key type `boolean`: cannot be held weakly",
+        ),
+    ]);
 }

--- a/core/engine/src/builtins/weak_set/mod.rs
+++ b/core/engine/src/builtins/weak_set/mod.rs
@@ -7,9 +7,15 @@
 //! [spec]: https://tc39.es/ecma262/#sec-weakset-objects
 //! [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakSet
 
+use std::collections::HashMap;
+
+use crate::JsData;
 use crate::{
     Context, JsArgs, JsNativeError, JsResult, JsString, JsValue,
-    builtins::{BuiltInBuilder, BuiltInConstructor, BuiltInObject, IntrinsicObject},
+    builtins::{
+        BuiltInBuilder, BuiltInConstructor, BuiltInObject, IntrinsicObject,
+        weak::{WeakKey, can_be_held_weakly},
+    },
     context::intrinsics::{Intrinsics, StandardConstructor, StandardConstructors},
     js_string,
     object::{ErasedVTableObject, JsObject, internal_methods::get_prototype_from_constructor},
@@ -22,10 +28,40 @@ use boa_gc::{Finalize, Trace};
 
 use super::iterable::IteratorHint;
 
-pub(crate) type NativeWeakSet = boa_gc::WeakMap<ErasedVTableObject, ()>;
+/// Native data for `WeakSet` objects with dual storage:
+/// - `objects`: GC-backed weak map for object values (uses ephemerons)
+/// - `symbols`: regular `HashMap` for symbol values (symbols use `Arc`, not GC).
+///   Keyed by `JsSymbol::hash()` (guaranteed unique) and stores the `JsSymbol`
+///   to keep the identity alive.
+#[derive(Trace, Finalize, JsData)]
+pub(crate) struct NativeWeakSet {
+    objects: boa_gc::WeakMap<ErasedVTableObject, ()>,
+    #[unsafe_ignore_trace]
+    symbols: HashMap<u64, JsSymbol>,
+}
+
+impl NativeWeakSet {
+    pub(crate) fn new() -> Self {
+        Self {
+            objects: boa_gc::WeakMap::new(),
+            symbols: HashMap::new(),
+        }
+    }
+}
+
+impl std::fmt::Debug for NativeWeakSet {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("NativeWeakSet")
+            .field("symbols", &self.symbols)
+            .finish_non_exhaustive()
+    }
+}
 
 #[derive(Debug, Trace, Finalize)]
 pub(crate) struct WeakSet;
+
+#[cfg(test)]
+mod tests;
 
 impl IntrinsicObject for WeakSet {
     fn get(intrinsics: &Intrinsics) -> JsObject {
@@ -127,7 +163,7 @@ impl BuiltInConstructor for WeakSet {
 impl WeakSet {
     /// `WeakSet.prototype.add( value )`
     ///
-    /// The `add()` method appends a new object to the end of a `WeakSet` object.
+    /// The `add()` method appends a new value to the end of a `WeakSet` object.
     ///
     /// More information:
     ///  - [ECMAScript reference][spec]
@@ -150,28 +186,28 @@ impl WeakSet {
                 JsNativeError::typ().with_message("WeakSet.add: called with non-object value")
             })?;
 
-        // 3. If Type(value) is not Object, throw a TypeError exception.
+        // 3. If CanBeHeldWeakly(value) is false, throw a TypeError exception.
         let value = args.get_or_undefined(0);
-        let Some(value) = value.as_object() else {
-            return Err(JsNativeError::typ()
-                .with_message(format!(
-                    "WeakSet.add: expected target argument of type `object`, got target of type `{}`",
-                    value.type_of()
-                )).into());
-        };
+        let weak_key = can_be_held_weakly(value).ok_or_else(|| {
+            JsNativeError::typ().with_message(format!(
+                "WeakSet.add: invalid value type `{}`: cannot be held weakly",
+                value.type_of()
+            ))
+        })?;
 
-        // 4. Let entries be the List that is S.[[WeakSetData]].
-        // 5. For each element e of entries, do
-        if set.contains_key(value.inner()) {
-            // a. If e is not empty and SameValue(e, value) is true, then
-            // i. Return S.
-            return Ok(this.clone());
+        // 4. For each element e of S.[[WeakSetData]], do
+        //   a. If e is not empty and SameValue(e, value) is true, return S.
+        // 5. Append value to S.[[WeakSetData]].
+        // 6. Return S.
+        match weak_key {
+            WeakKey::Object(obj) => {
+                set.objects.insert(obj.inner(), ());
+            }
+            WeakKey::Symbol(sym) => {
+                set.symbols.insert(sym.hash(), sym);
+            }
         }
 
-        // 6. Append value as the last element of entries.
-        set.insert(value.inner(), ());
-
-        // 7. Return S.
         Ok(this.clone())
     }
 
@@ -200,24 +236,26 @@ impl WeakSet {
                 JsNativeError::typ().with_message("WeakSet.delete: called with non-object value")
             })?;
 
-        // 3. If Type(value) is not Object, return false.
+        // 3. If CanBeHeldWeakly(value) is false, return false.
         let value = args.get_or_undefined(0);
-        let Some(value) = value.as_object() else {
+        let Some(weak_key) = can_be_held_weakly(value) else {
             return Ok(false.into());
         };
 
-        // 4. Let entries be the List that is S.[[WeakSetData]].
-        // 5. For each element e of entries, do
-        // a. If e is not empty and SameValue(e, value) is true, then
-        // i. Replace the element of entries whose value is e with an element whose value is empty.
-        // ii. Return true.
-        // 6. Return false.
-        Ok(set.remove(value.inner()).is_some().into())
+        // 4. For each element e of S.[[WeakSetData]], do
+        //   a. If e is not empty and SameValue(e, value) is true, then
+        //     i. Replace e in S.[[WeakSetData]] with empty.
+        //     ii. Return true.
+        // 5. Return false.
+        match weak_key {
+            WeakKey::Object(obj) => Ok(set.objects.remove(obj.inner()).is_some().into()),
+            WeakKey::Symbol(sym) => Ok(set.symbols.remove(&sym.hash()).is_some().into()),
+        }
     }
 
     /// `WeakSet.prototype.has( value )`
     ///
-    /// The `has()` method returns a boolean indicating whether an object exists in a `WeakSet` or not.
+    /// The `has()` method returns a boolean indicating whether a value exists in a `WeakSet` or not.
     ///
     /// More information:
     ///  - [ECMAScript reference][spec]
@@ -240,16 +278,18 @@ impl WeakSet {
                 JsNativeError::typ().with_message("WeakSet.has: called with non-object value")
             })?;
 
-        // 3. Let entries be the List that is S.[[WeakSetData]].
-        // 4. If Type(value) is not Object, return false.
+        // 3. If CanBeHeldWeakly(value) is false, return false.
         let value = args.get_or_undefined(0);
-        let Some(value) = value.as_object() else {
+        let Some(weak_key) = can_be_held_weakly(value) else {
             return Ok(false.into());
         };
 
-        // 5. For each element e of entries, do
-        // a. If e is not empty and SameValue(e, value) is true, return true.
-        // 6. Return false.
-        Ok(set.contains_key(value.inner()).into())
+        // 4. For each element e of S.[[WeakSetData]], do
+        //   a. If e is not empty and SameValue(e, value) is true, return true.
+        // 5. Return false.
+        match weak_key {
+            WeakKey::Object(obj) => Ok(set.objects.contains_key(obj.inner()).into()),
+            WeakKey::Symbol(sym) => Ok(set.symbols.contains_key(&sym.hash()).into()),
+        }
     }
 }

--- a/core/engine/src/builtins/weak_set/tests.rs
+++ b/core/engine/src/builtins/weak_set/tests.rs
@@ -1,0 +1,81 @@
+use crate::{JsNativeErrorKind, TestAction, run_test_actions};
+
+#[test]
+fn add_has_delete_object() {
+    run_test_actions([
+        TestAction::run(
+            r#"
+            let ws = new WeakSet();
+            let obj = {};
+            ws.add(obj);
+        "#,
+        ),
+        TestAction::assert("ws.has(obj)"),
+        TestAction::assert("ws.delete(obj)"),
+        TestAction::assert("!ws.has(obj)"),
+    ]);
+}
+
+#[test]
+fn symbol_add_has_delete() {
+    run_test_actions([
+        TestAction::run(
+            r#"
+            let ws = new WeakSet();
+            let sym = Symbol("test");
+            ws.add(sym);
+        "#,
+        ),
+        TestAction::assert("ws.has(sym)"),
+        TestAction::assert("ws.delete(sym)"),
+        TestAction::assert("!ws.has(sym)"),
+    ]);
+}
+
+#[test]
+fn symbol_registered_rejected() {
+    run_test_actions([TestAction::assert_native_error(
+        "new WeakSet().add(Symbol.for('registered'))",
+        JsNativeErrorKind::Type,
+        "WeakSet.add: invalid value type `symbol`: cannot be held weakly",
+    )]);
+}
+
+#[test]
+fn symbol_well_known_accepted() {
+    run_test_actions([
+        TestAction::run("let ws = new WeakSet(); ws.add(Symbol.iterator);"),
+        TestAction::assert("ws.has(Symbol.iterator)"),
+    ]);
+}
+
+#[test]
+fn primitives_rejected() {
+    run_test_actions([
+        TestAction::assert_native_error(
+            "new WeakSet().add(42)",
+            JsNativeErrorKind::Type,
+            "WeakSet.add: invalid value type `number`: cannot be held weakly",
+        ),
+        TestAction::assert_native_error(
+            "new WeakSet().add('str')",
+            JsNativeErrorKind::Type,
+            "WeakSet.add: invalid value type `string`: cannot be held weakly",
+        ),
+        TestAction::assert_native_error(
+            "new WeakSet().add(true)",
+            JsNativeErrorKind::Type,
+            "WeakSet.add: invalid value type `boolean`: cannot be held weakly",
+        ),
+    ]);
+}
+
+#[test]
+fn delete_non_weakly_holdable_returns_false() {
+    run_test_actions([TestAction::assert("!new WeakSet().delete(42)")]);
+}
+
+#[test]
+fn has_non_weakly_holdable_returns_false() {
+    run_test_actions([TestAction::assert("!new WeakSet().has('str')")]);
+}

--- a/test262_config.toml
+++ b/test262_config.toml
@@ -9,7 +9,6 @@ features = [
 
     "FinalizationRegistry",
     "IsHTMLDDA",
-    "symbols-as-weakmap-keys",
     "Intl.DisplayNames",
     "Intl.RelativeTimeFormat",
     "Intl-enumeration",


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request implements ECMAScript §9.13 [`CanBeHeldWeakly(v)`](https://tc39.es/ecma262/#sec-canbeheldweakly), enabling non-registered symbols as keys in `WeakMap`, values in `WeakSet`, and targets in `WeakRef`.

It changes the following:

- Add `is_registered_symbol()` in `builtins/symbol` to check if a symbol is in the `GlobalSymbolRegistry`
- Add `WeakKey` enum and `can_be_held_weakly()` returning `Option<WeakKey>` in `builtins/weak/mod.rs`
- Introduce `NativeWeakMap` with dual storage — GC `WeakMap` for objects, `HashMap<u64, (JsSymbol, JsValue)>` for symbols
- Introduce `NativeWeakSet` with dual storage — GC `WeakMap` for objects, `HashMap<u64, JsSymbol>` for symbols
- Add `WeakRefTarget` enum in `WeakRef` supporting both `WeakGc` objects and `Arc`-based symbols
- Update all `WeakMap`/`WeakSet`/`WeakRef` methods to use `WeakKey` match pattern
- Remove `symbols-as-weakmap-keys` from `test262_config.toml` ignored features
- Add unit tests for symbol keys/values in WeakMap (6), WeakSet (7, new file), WeakRef (2)

### Design Notes

Symbols in Boa use `Arc` (not GC-traced), so they cannot be stored in `boa_gc::WeakMap` directly. The dual-storage approach separates object keys (GC ephemerons) from symbol keys (regular `HashMap` keyed by guaranteed-unique `JsSymbol::hash()`).
