### PR TITLE
fix(builtins/regexp,async-generator): convert panics to EngineError::Panic using js_expect

### DIFF
--- a/core/engine/src/builtins/async_generator/mod.rs
+++ b/core/engine/src/builtins/async_generator/mod.rs
@@ -6,7 +6,7 @@
 //! [spec]: https://tc39.es/ecma262/#sec-asyncgenerator-objects
 
 use crate::{
-    Context, JsArgs, JsData, JsError, JsResult, JsString,
+    Context, JsArgs, JsData, JsError, JsExpect, JsResult, JsString,
     builtins::{
         Promise,
         generator::GeneratorContext,
@@ -126,7 +126,7 @@ impl AsyncGenerator {
             &context.intrinsics().constructors().promise().constructor(),
             context,
         )
-        .expect("cannot fail with promise constructor");
+        .js_expect("cannot fail with promise constructor")?;
 
         // 3. Let result be Completion(AsyncGeneratorValidate(generator, empty)).
         // 4. IfAbruptRejectPromise(result, promiseCapability).
@@ -152,10 +152,11 @@ impl AsyncGenerator {
             let iterator_result = create_iter_result_object(JsValue::undefined(), true, context);
 
             // b. Perform ! Call(promiseCapability.[[Resolve]], undefined, « iteratorResult »).
-            promise_capability
-                .resolve()
-                .call(&JsValue::undefined(), &[iterator_result], context)
-                .expect("cannot fail per spec");
+            promise_capability.resolve().call(
+                &JsValue::undefined(),
+                &[iterator_result],
+                context,
+            )?;
 
             // c. Return promiseCapability.[[Promise]].
             return Ok(promise_capability.promise().clone().into());
@@ -198,7 +199,7 @@ impl AsyncGenerator {
             &context.intrinsics().constructors().promise().constructor(),
             context,
         )
-        .expect("cannot fail with promise constructor");
+        .js_expect("cannot fail with promise constructor")?;
 
         // 3. Let result be Completion(AsyncGeneratorValidate(generator, empty)).
         // 4. IfAbruptRejectPromise(result, promiseCapability).
@@ -264,7 +265,7 @@ impl AsyncGenerator {
             &context.intrinsics().constructors().promise().constructor(),
             context,
         )
-        .expect("cannot fail with promise constructor");
+        .js_expect("cannot fail with promise constructor")?;
 
         // 3. Let result be Completion(AsyncGeneratorValidate(generator, empty)).
         // 4. IfAbruptRejectPromise(result, promiseCapability).
@@ -300,14 +301,11 @@ impl AsyncGenerator {
         // 7. If state is completed, then
         if state == AsyncGeneratorState::Completed {
             // a. Perform ! Call(promiseCapability.[[Reject]], undefined, « exception »).
-            promise_capability
-                .reject()
-                .call(
-                    &JsValue::undefined(),
-                    &[args.get_or_undefined(0).clone()],
-                    context,
-                )
-                .expect("cannot fail per spec");
+            promise_capability.reject().call(
+                &JsValue::undefined(),
+                &[args.get_or_undefined(0).clone()],
+                context,
+            )?;
 
             // b. Return promiseCapability.[[Promise]].
             return Ok(promise_capability.promise().clone().into());
@@ -360,9 +358,9 @@ impl AsyncGenerator {
     /// More information:
     ///  - [ECMAScript reference][spec]
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics if the async generator request queue of `generator` is empty.
+    /// Returns `EngineError::Panic` if the async generator request queue of `generator` is empty.
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-asyncgeneratorcompletestep
     pub(crate) fn complete_step(
@@ -380,7 +378,7 @@ impl AsyncGenerator {
             .data_mut()
             .queue
             .pop_front()
-            .expect("1. Assert: generator.[[AsyncGeneratorQueue]] is not empty.");
+            .js_expect("1. Assert: generator.[[AsyncGeneratorQueue]] is not empty.")?;
 
         // 4. Let promiseCapability be next.[[Capability]].
         let promise_capability = &next.capability;
@@ -390,10 +388,11 @@ impl AsyncGenerator {
             // 6. If completion is a throw completion, then
             Err(e) => {
                 // a. Perform ! Call(promiseCapability.[[Reject]], undefined, « value »).
-                promise_capability
-                    .reject()
-                    .call(&JsValue::undefined(), &[e.into_opaque(context)?], context)
-                    .expect("cannot fail per spec");
+                promise_capability.reject().call(
+                    &JsValue::undefined(),
+                    &[e.into_opaque(context)?],
+                    context,
+                )?;
             }
 
             // 7. Else,
@@ -419,10 +418,11 @@ impl AsyncGenerator {
                 };
 
                 // d. Perform ! Call(promiseCapability.[[Resolve]], undefined, « iteratorResult »).
-                promise_capability
-                    .resolve()
-                    .call(&JsValue::undefined(), &[iterator_result], context)
-                    .expect("cannot fail per spec");
+                promise_capability.resolve().call(
+                    &JsValue::undefined(),
+                    &[iterator_result],
+                    context,
+                )?;
             }
         }
         // 8. Return unused.
@@ -434,9 +434,9 @@ impl AsyncGenerator {
     /// More information:
     ///  - [ECMAScript reference][spec]
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics if `generator` is neither in the `SuspendedStart` nor in the `SuspendedYield` states.
+    /// Returns `EngineError::Panic` if `generator` is neither in the `SuspendedStart` nor in the `SuspendedYield` states.
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-asyncgeneratorresume
     pub(crate) fn resume(
@@ -456,7 +456,7 @@ impl AsyncGenerator {
             .data_mut()
             .context
             .take()
-            .expect("generator context cannot be empty here");
+            .js_expect("generator context cannot be empty here")?;
 
         // 5. Set generator.[[AsyncGeneratorState]] to executing.
         generator.borrow_mut().data_mut().state = AsyncGeneratorState::Executing;
@@ -489,9 +489,9 @@ impl AsyncGenerator {
     /// More information:
     ///  - [ECMAScript reference][spec]
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics if `generator` is not in the `DrainingQueue` state.
+    /// Returns `EngineError::Panic` if `generator` is not in the `DrainingQueue` state.
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-asyncgeneratorawaitreturn
     pub(crate) fn await_return(
@@ -521,7 +521,8 @@ impl AsyncGenerator {
         let promise = match promise_completion {
             Ok(value) => value
                 .downcast::<Promise>()
-                .expect("%Promise% constructor must always return a Promise object"),
+                .ok()
+                .js_expect("%Promise% constructor must always return a Promise object")?,
             // 8. If promiseCompletion is an abrupt completion, then
             Err(e) => {
                 // a. Perform AsyncGeneratorCompleteStep(generator, promiseCompletion, true).
@@ -615,9 +616,9 @@ impl AsyncGenerator {
     /// More information:
     ///  - [ECMAScript reference][spec]
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics if `generator` is not in the `DrainingQueue` state.
+    /// Returns `EngineError::Panic` if `generator` is not in the `DrainingQueue` state.
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-asyncgeneratordrainqueue
     pub(crate) fn drain_queue(
@@ -649,7 +650,7 @@ impl AsyncGenerator {
                 .data()
                 .queue
                 .front()
-                .expect("must have entry")
+                .js_expect("must have entry")?
                 .completion
                 .clone();
 

--- a/core/engine/src/builtins/regexp/mod.rs
+++ b/core/engine/src/builtins/regexp/mod.rs
@@ -1220,12 +1220,10 @@ impl RegExp {
         let a = Array::array_create(n + 1, None, context)?;
 
         // 22. Perform ! CreateDataPropertyOrThrow(A, "index", 𝔽(lastIndex)).
-        a.create_data_property_or_throw(js_string!("index"), last_index, context)
-            .expect("this CreateDataPropertyOrThrow call must not fail");
+        a.create_data_property_or_throw(js_string!("index"), last_index, context)?;
 
         // 23. Perform ! CreateDataPropertyOrThrow(A, "input", S).
-        a.create_data_property_or_throw(js_string!("input"), input.clone(), context)
-            .expect("this CreateDataPropertyOrThrow call must not fail");
+        a.create_data_property_or_throw(js_string!("input"), input.clone(), context)?;
 
         // 24. Let match be the Match Record { [[StartIndex]]: lastIndex, [[EndIndex]]: e }.
         // Immediately convert it to an array according to 22.2.7.7 GetMatchIndexPair(S, match)
@@ -1240,16 +1238,13 @@ impl RegExp {
         let indices = Array::array_create(n + 1, None, context)?;
 
         // 27. Append match to indices.
-        indices
-            .create_data_property_or_throw(0, match_record, context)
-            .expect("this CreateDataPropertyOrThrow call must not fail");
+        indices.create_data_property_or_throw(0, match_record, context)?;
 
         // 28. Let matchedSubstr be GetMatchString(S, match).
         let matched_substr = input.get_expect((last_index as usize)..(e));
 
         // 29. Perform ! CreateDataPropertyOrThrow(A, "0", matchedSubstr).
-        a.create_data_property_or_throw(0, matched_substr, context)
-            .expect("this CreateDataPropertyOrThrow call must not fail");
+        a.create_data_property_or_throw(0, matched_substr, context)?;
 
         let named_groups = match_value
             .named_groups()
@@ -1275,37 +1270,37 @@ impl RegExp {
                 if let Some(range) = range {
                     let value = input.get_expect(range.clone());
 
-                    groups
-                        .create_data_property_or_throw(name.clone(), value, context)
-                        .expect("this CreateDataPropertyOrThrow call must not fail");
+                    groups.create_data_property_or_throw(name.clone(), value, context)?;
 
                     // 22.2.7.8 MakeMatchIndicesIndexPairArray ( S, indices, groupNames, hasGroups )
                     // a. Let matchIndices be indices[i].
                     // b. If matchIndices is not undefined, then
                     // i. Let matchIndexPair be GetMatchIndexPair(S, matchIndices).
                     // d. Perform ! CreateDataPropertyOrThrow(A, ! ToString(𝔽(i)), matchIndexPair).
-                    group_names
-                        .create_data_property_or_throw(
-                            name.clone(),
-                            Array::create_array_from_list(
-                                [range.start.into(), range.end.into()],
-                                context,
-                            ),
+                    group_names.create_data_property_or_throw(
+                        name.clone(),
+                        Array::create_array_from_list(
+                            [range.start.into(), range.end.into()],
                             context,
-                        )
-                        .expect("this CreateDataPropertyOrThrow call must not fail");
+                        ),
+                        context,
+                    )?;
                 } else {
-                    groups
-                        .create_data_property_or_throw(name.clone(), JsValue::undefined(), context)
-                        .expect("this CreateDataPropertyOrThrow call must not fail");
+                    groups.create_data_property_or_throw(
+                        name.clone(),
+                        JsValue::undefined(),
+                        context,
+                    )?;
 
                     // 22.2.7.8 MakeMatchIndicesIndexPairArray ( S, indices, groupNames, hasGroups )
                     // c. Else,
                     // i. Let matchIndexPair be undefined.
                     // d. Perform ! CreateDataPropertyOrThrow(A, ! ToString(𝔽(i)), matchIndexPair).
-                    group_names
-                        .create_data_property_or_throw(name, JsValue::undefined(), context)
-                        .expect("this CreateDataPropertyOrThrow call must not fail");
+                    group_names.create_data_property_or_throw(
+                        name,
+                        JsValue::undefined(),
+                        context,
+                    )?;
                 }
             }
 
@@ -1317,13 +1312,10 @@ impl RegExp {
 
         // 22.2.7.8 MakeMatchIndicesIndexPairArray ( S, indices, groupNames, hasGroups )
         // 8. Perform ! CreateDataPropertyOrThrow(A, "groups", groups).
-        indices
-            .create_data_property_or_throw(js_string!("groups"), group_names, context)
-            .expect("this CreateDataPropertyOrThrow call must not fail");
+        indices.create_data_property_or_throw(js_string!("groups"), group_names, context)?;
 
         // 32. Perform ! CreateDataPropertyOrThrow(A, "groups", groups).
-        a.create_data_property_or_throw(js_string!("groups"), groups, context)
-            .expect("this CreateDataPropertyOrThrow call must not fail");
+        a.create_data_property_or_throw(js_string!("groups"), groups, context)?;
 
         // 27. For each integer i such that i ≥ 1 and i ≤ n, in ascending order, do
         for i in 1..=n {
@@ -1338,8 +1330,7 @@ impl RegExp {
             });
 
             // e. Perform ! CreateDataPropertyOrThrow(A, ! ToString(𝔽(i)), capturedValue).
-            a.create_data_property_or_throw(i, captured_value.clone(), context)
-                .expect("this CreateDataPropertyOrThrow call must not fail");
+            a.create_data_property_or_throw(i, captured_value.clone(), context)?;
 
             // 22.2.7.8 MakeMatchIndicesIndexPairArray ( S, indices, groupNames, hasGroups )
             if has_indices {
@@ -1353,9 +1344,7 @@ impl RegExp {
                 });
 
                 // d. Perform ! CreateDataPropertyOrThrow(A, ! ToString(𝔽(i)), matchIndexPair).
-                indices
-                    .create_data_property_or_throw(i, indices_range, context)
-                    .expect("this CreateDataPropertyOrThrow call must not fail");
+                indices.create_data_property_or_throw(i, indices_range, context)?;
             }
         }
 
@@ -1363,8 +1352,7 @@ impl RegExp {
         // a. Let indicesArray be MakeMatchIndicesIndexPairArray(S, indices, groupNames, hasGroups).
         // b. Perform ! CreateDataPropertyOrThrow(A, "indices", indicesArray).
         if has_indices {
-            a.create_data_property_or_throw(js_string!("indices"), indices, context)
-                .expect("this CreateDataPropertyOrThrow call must not fail");
+            a.create_data_property_or_throw(js_string!("indices"), indices, context)?;
         }
 
         // 35. Return A.
@@ -1416,7 +1404,7 @@ impl RegExp {
         rx.set(js_string!("lastIndex"), 0, true, context)?;
 
         // c. Let A be ! ArrayCreate(0).
-        let a = Array::array_create(0, None, context).expect("this ArrayCreate call must not fail");
+        let a = Array::array_create(0, None, context)?;
 
         // d. Let n be 0.
         let mut n = 0;
@@ -1433,8 +1421,7 @@ impl RegExp {
                 let match_str = result.get(0, context)?.to_string(context)?;
 
                 // 2. Perform ! CreateDataPropertyOrThrow(A, ! ToString(𝔽(n)), matchStr).
-                a.create_data_property_or_throw(n, match_str.clone(), context)
-                    .expect("this CreateDataPropertyOrThrow call must not fail");
+                a.create_data_property_or_throw(n, match_str.clone(), context)?;
 
                 // 3. If matchStr is the empty String, then
                 if match_str.is_empty() {
@@ -1925,7 +1912,7 @@ impl RegExp {
         )?;
 
         // 11. Let A be ! ArrayCreate(0).
-        let a = Array::array_create(0, None, context).expect("this ArrayCreate call must not fail");
+        let a = Array::array_create(0, None, context)?;
 
         // 12. Let lengthA be 0.
         let mut length_a = 0;
@@ -1957,8 +1944,7 @@ impl RegExp {
             }
 
             // c. Perform ! CreateDataPropertyOrThrow(A, "0", S).
-            a.create_data_property_or_throw(0, arg_str, context)
-                .expect("this CreateDataPropertyOrThrow call must not fail");
+            a.create_data_property_or_throw(0, arg_str, context)?;
 
             // d. Return A.
             return Ok(a.into());
@@ -1997,8 +1983,7 @@ impl RegExp {
                     let arg_str_substring = arg_str.get_expect(p as usize..q as usize);
 
                     // 2. Perform ! CreateDataPropertyOrThrow(A, ! ToString(𝔽(lengthA)), T).
-                    a.create_data_property_or_throw(length_a, arg_str_substring, context)
-                        .expect("this CreateDataPropertyOrThrow call must not fail");
+                    a.create_data_property_or_throw(length_a, arg_str_substring, context)?;
 
                     // 3. Set lengthA to lengthA + 1.
                     length_a += 1;
@@ -2024,8 +2009,7 @@ impl RegExp {
                         let next_capture = result.get(i, context)?;
 
                         // b. Perform ! CreateDataPropertyOrThrow(A, ! ToString(𝔽(lengthA)), nextCapture).
-                        a.create_data_property_or_throw(length_a, next_capture, context)
-                            .expect("this CreateDataPropertyOrThrow call must not fail");
+                        a.create_data_property_or_throw(length_a, next_capture, context)?;
 
                         // d. Set lengthA to lengthA + 1.
                         length_a += 1;
@@ -2048,8 +2032,7 @@ impl RegExp {
         let arg_str_substring = arg_str.get_expect(p as usize..size as usize);
 
         // 21. Perform ! CreateDataPropertyOrThrow(A, ! ToString(𝔽(lengthA)), T).
-        a.create_data_property_or_throw(length_a, arg_str_substring, context)
-            .expect("this CreateDataPropertyOrThrow call must not fail");
+        a.create_data_property_or_throw(length_a, arg_str_substring, context)?;
 
         // 22. Return A.
         Ok(a.into())


### PR DESCRIPTION
Part of #3241.

It changes the following:
* `core/engine/src/builtins/regexp/mod.rs`: converted 21 panics (18× `CreateDataPropertyOrThrow`, 2× `ArrayCreate`, 1× `downcast_mut` in annex-b compile) to use `?` (already `JsResult`) or `js_expect` (for `Option`)
* `core/engine/src/builtins/async_generator/mod.rs`: converted 11 panics (3× `PromiseCapability::new`, 4× `.call()` on resolve/reject, 1× `queue.pop_front()`, 1× `context.take()`, 1× `downcast::<Promise>()`, 1× `queue.front()`) to use `js_expect` or `?`

Also updates `# Panics` doc comments to `# Errors` on `complete_step`, `resume`, and related functions since they now propagate via `JsResult` instead of panickingg.