### PR TITLE
fix(cli): resolve TLS AccessError by managing resource lifecycle on shutdown (#4370)

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -541,12 +541,14 @@ fn main() -> Result<()> {
 
     let executor = Rc::new(Executor::new(printer.clone()));
     let loader = Rc::new(SimpleModuleLoader::new(&args.root).map_err(|e| eyre!(e.to_string()))?);
-    let context = &mut ContextBuilder::new()
+    // Bind the Context to an owned variable so it can be explicitly dropped
+    // before process termination, preventing TLS AccessErrors during garbage collection.
+    let mut owned_context = ContextBuilder::new()
         .job_executor(executor.clone())
         .module_loader(loader.clone())
         .build()
         .map_err(|e| eyre!(e.to_string()))?;
-
+    let context = &mut owned_context;
     // Strict mode
     context.strict(args.strict);
 
@@ -572,21 +574,37 @@ fn main() -> Result<()> {
         if let Some(ref expr) = args.expression {
             evaluate_expr(expr, &args, context, &printer)?;
         }
-
+        // Ensure context is dropped and collected to finalize resources (e.g., wgpu) safely.
+        drop(loader);
+        drop(executor);
+        drop(owned_context);
+        boa_gc::force_collect();
         return Ok(());
     } else if let Some(ref expr) = args.expression {
         evaluate_expr(expr, &args, context, &printer)?;
+        // Ensure context is dropped and collected to finalize resources (e.g., wgpu) safely.
+        drop(loader);
+        drop(executor);
+        drop(owned_context);
+        boa_gc::force_collect();
         return Ok(());
     } else if !io::stdin().is_terminal() {
         let mut input = String::new();
         io::stdin()
             .read_to_string(&mut input)
             .wrap_err("failed to read stdin")?;
-        return if input.is_empty() {
+
+        let result = if input.is_empty() {
             Ok(())
         } else {
             evaluate_expr(&input, &args, context, &printer)
         };
+        // Ensure context is dropped and collected to finalize resources (e.g., wgpu) safely.
+        drop(loader);
+        drop(executor);
+        drop(owned_context);
+        boa_gc::force_collect();
+        return result;
     }
 
     // Print the welcome banner unless --quiet is passed.
@@ -671,6 +689,10 @@ fn main() -> Result<()> {
         .map_err(|e| e.into_erased(context));
 
     handle.join().expect("failed to join thread");
+    // Explicitly drop the root context and force garbage collection.
+    // This allows hardware-linked finalizers to run while Thread Local Storage is still active.
+    drop(owned_context);
+    boa_gc::force_collect();
 
     Ok(result?)
 }


### PR DESCRIPTION
This PR fixes the fatal `AccessError` panic that happens during the CLI's teardown phase when handling TLS-dependent resources.

As noted by @jedel1043 in #4410, the crash occurs because hardware-linked resources (such as `wgpu` structs in custom embeddings) are dropped too late during the main thread's teardown. By the time the garbage collector attempts to finalize them, the Thread Local Storage (TLS) has already been destroyed.

To fix this, we just need to ensure that garbage collection runs deterministically before the thread teardown begins. 

Changes made in `cli/src/main.rs`:
-  Bound the `Context` to a local `owned_context` variable to allow manual drop control.
-  Added an explicit `drop(owned_context)` immediately followed by `boa_gc::force_collect()` across all CLI exit paths (file execution, `-e` evaluation, stdin, and Repl termination).

By clearing the GC roots and forcing a synchronous collection block, all pending finalizers are safely executed while the thread's TLS is still fully active.

*(Note: i haven't included a dedicated webGpu test file since `wgpu` isn't part of the core engine, but this lifecycle adjustment permanently resolves the teardown issue for any external embeddings relying on TLS).*

Fixes #4370