### PR TITLE
cli: return non-zero for uncaught runtime exceptions

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -30,6 +30,9 @@ futures-lite.workspace = true
 async-channel.workspace = true
 rustls.workspace = true
 
+[dev-dependencies]
+assert_cmd = "2.0.16"
+
 [features]
 default = [
     "boa_engine/annex-b",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -30,9 +30,6 @@ futures-lite.workspace = true
 async-channel.workspace = true
 rustls.workspace = true
 
-[dev-dependencies]
-assert_cmd = "2.0.16"
-
 [features]
 default = [
     "boa_engine/annex-b",

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -12,6 +12,9 @@ mod executor;
 mod helper;
 mod logger;
 
+#[cfg(test)]
+use assert_cmd as _;
+
 use crate::executor::Executor;
 use crate::logger::SharedExternalPrinterLogger;
 use async_channel::Sender;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -512,7 +512,7 @@ fn evaluate_file(
         }
         Err(v) => {
             printer.print(uncaught_error(&v));
-            return Err(v.into_erased(context).into());
+            return Err(eyre!("execution failed"));
         }
     }
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -411,15 +411,22 @@ fn evaluate_expr(
                     let result = script.evaluate(context);
                     if let Err(err) = context.run_jobs() {
                         printer.print(uncaught_job_error(&err));
+                        return Err(err.into_erased(context).into());
                     }
                     result
                 };
                 match result {
                     Ok(v) => printer.print(format!("{}\n", v.display())),
-                    Err(ref v) => printer.print(uncaught_error(v)),
+                    Err(v) => {
+                        printer.print(uncaught_error(&v));
+                        return Err(v.into_erased(context).into());
+                    }
                 }
             }
-            Err(ref v) => printer.print(uncaught_error(v)),
+            Err(v) => {
+                printer.print(uncaught_error(&v));
+                return Err(v.into_erased(context).into());
+            }
         }
     }
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -503,7 +503,10 @@ fn evaluate_file(
                 println!("{}", v.display());
             }
         }
-        Err(v) => printer.print(uncaught_error(&v)),
+        Err(v) => {
+            printer.print(uncaught_error(&v));
+            return Err(v.into_erased(context).into());
+        }
     }
 
     Ok(())

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -12,9 +12,6 @@ mod executor;
 mod helper;
 mod logger;
 
-#[cfg(test)]
-use assert_cmd as _;
-
 use crate::executor::Executor;
 use crate::logger::SharedExternalPrinterLogger;
 use async_channel::Sender;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -411,7 +411,7 @@ fn evaluate_expr(
                     let result = script.evaluate(context);
                     if let Err(err) = context.run_jobs() {
                         printer.print(uncaught_job_error(&err));
-                        return Err(err.into_erased(context).into());
+                        return Err(eyre!("execution failed"));
                     }
                     result
                 };
@@ -419,13 +419,13 @@ fn evaluate_expr(
                     Ok(v) => printer.print(format!("{}\n", v.display())),
                     Err(v) => {
                         printer.print(uncaught_error(&v));
-                        return Err(v.into_erased(context).into());
+                        return Err(eyre!("execution failed"));
                     }
                 }
             }
             Err(v) => {
                 printer.print(uncaught_error(&v));
-                return Err(v.into_erased(context).into());
+                return Err(eyre!("parsing failed"));
             }
         }
     }

--- a/cli/tests/exit_code.rs
+++ b/cli/tests/exit_code.rs
@@ -1,0 +1,19 @@
+use assert_cmd::Command;
+
+#[test]
+fn stdin_uncaught_error_exits_non_zero() {
+    Command::cargo_bin("boa")
+        .expect("boa binary should build")
+        .write_stdin("throw Error('nooo')")
+        .assert()
+        .failure();
+}
+
+#[test]
+fn expression_uncaught_error_exits_non_zero() {
+    Command::cargo_bin("boa")
+        .expect("boa binary should build")
+        .args(["-e", "throw Error('nooo')"])
+        .assert()
+        .failure();
+}

--- a/cli/tests/exit_code.rs
+++ b/cli/tests/exit_code.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs, unused_crate_dependencies)]
+
 use assert_cmd::Command;
 
 #[test]

--- a/cli/tests/exit_code.rs
+++ b/cli/tests/exit_code.rs
@@ -1,21 +1,40 @@
-#![allow(missing_docs, unused_crate_dependencies)]
+#![allow(missing_docs)]
 
-use assert_cmd::Command;
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+fn boa_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_boa")
+}
 
 #[test]
 fn stdin_uncaught_error_exits_non_zero() {
-    Command::cargo_bin("boa")
-        .expect("boa binary should build")
-        .write_stdin("throw Error('nooo')")
-        .assert()
-        .failure();
+    let mut child = Command::new(boa_bin())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("boa binary should build");
+
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin should be piped")
+        .write_all(b"throw Error('nooo')")
+        .expect("stdin write should succeed");
+
+    let status = child.wait().expect("boa should exit");
+    assert!(!status.success(), "expected non-zero exit for uncaught stdin error");
 }
 
 #[test]
 fn expression_uncaught_error_exits_non_zero() {
-    Command::cargo_bin("boa")
-        .expect("boa binary should build")
+    let status = Command::new(boa_bin())
         .args(["-e", "throw Error('nooo')"])
-        .assert()
-        .failure();
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .expect("boa should run");
+
+    assert!(!status.success(), "expected non-zero exit for uncaught -e error");
 }

--- a/cli/tests/exit_code.rs
+++ b/cli/tests/exit_code.rs
@@ -1,7 +1,9 @@
 #![allow(missing_docs)]
 
+use std::fs;
 use std::io::Write;
 use std::process::{Command, Stdio};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 fn boa_bin() -> &'static str {
     env!("CARGO_BIN_EXE_boa")
@@ -37,4 +39,28 @@ fn expression_uncaught_error_exits_non_zero() {
         .expect("boa should run");
 
     assert!(!status.success(), "expected non-zero exit for uncaught -e error");
+}
+
+#[test]
+fn file_uncaught_error_exits_non_zero() {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("time should be monotonic")
+        .as_nanos();
+    let script_path = std::env::temp_dir().join(format!("boa-exit-code-{unique}.js"));
+    fs::write(&script_path, "throw Error('nooo')\n").expect("temp script should be writable");
+
+    let status = Command::new(boa_bin())
+        .arg(&script_path)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .expect("boa should run");
+
+    let _ = fs::remove_file(&script_path);
+
+    assert!(
+        !status.success(),
+        "expected non-zero exit for uncaught file execution error"
+    );
 }


### PR DESCRIPTION
This Pull Request fixes/closes #4962.

It changes the following:

- Return an error from `evaluate_file` when script execution raises an uncaught runtime exception.
- Preserve existing uncaught error printing, but propagate the failure so the CLI process exits non-zero.
- Keep successful file execution behavior unchanged.

## Validation

- Not run locally in this environment because the Rust toolchain (`cargo`) is unavailable.
- Behavioral check is directly aligned with issue reproduction: uncaught runtime errors now flow through an error return path instead of being swallowed with `Ok(())`.
