### PR TITLE
test(builtins): add comprehensive tests for Set.prototype.intersection

### DIFF
--- a/core/engine/src/builtins/set/tests.rs
+++ b/core/engine/src/builtins/set/tests.rs
@@ -465,7 +465,8 @@ fn intersection_this_not_a_set() {
     )]);
 }
 
-/// Set.prototype.intersection — other is not a valid Set-like object → \#[test]
+/// Set.prototype.intersection — other is not a valid Set-like object → \
+#[test]
 fn intersection_other_not_set_like() {
     run_test_actions([
         // Primitive value — GetSetRecord rejects non-objects.


### PR DESCRIPTION
This Pull Request adds comprehensive test coverage for the recently implemented `Set.prototype.intersection` method. There is no specific issue tied to this, but it improves the engine's local test suite as part of my GSoC 2026 preparation.

It changes the following:

- Adds happy-path test cases for `intersection` (both directions, self-intersection, disjoint sets, and empty sets) in `boa_engine/src/builtins/set/tests.rs`.
- Adds `TypeError` validation tests for when `this` is not a Set.
- Adds `TypeError` validation tests for when the `other` argument is a non-iterable primitive or is missing required Set-like properties (`size`, `has`, `keys`).

*(Note: All tests pass locally, and code has been formatted with `cargo fmt` and checked with `cargo clippy`).*