### PR TITLE
fix(promise): set [[PromiseIsHandled]] correctly

### DIFF
--- a/core/engine/src/builtins/promise/mod.rs
+++ b/core/engine/src/builtins/promise/mod.rs
@@ -1904,11 +1904,11 @@ impl Promise {
                 context
                     .job_executor()
                     .enqueue_job(reject_job.into(), context);
-
-                // 12. Set promise.[[PromiseIsHandled]] to true.
-                promise.borrow_mut().data_mut().handled = true;
             }
         }
+
+        // 12. Set promise.[[PromiseIsHandled]] to true.
+        promise.borrow_mut().data_mut().handled = true;
 
         // 13. If resultCapability is undefined, then
         //   a. Return undefined.


### PR DESCRIPTION
## Summary

This PR fixes how `[[PromiseIsHandled]]` is set in `Promise::perform_promise_then`.
According to the ECMAScript spec, step 12 of **PerformPromiseThen** must run unconditionally.
Currently, Boa sets `handled = true` only inside the **Rejected** branch, which means pending promises with a `.catch()` attached can still be reported as unhandled later.

Example of the previous placement:

```rust
PromiseState::Rejected(ref reason) => {
    // ...
    promise.borrow_mut().data_mut().handled = true;
}
```

Because of this, promises that register a handler while still pending may incorrectly trigger the host rejection tracker.

## Steps to Reproduce

Example JavaScript:

```javascript
const p = new Promise((_, reject) => {
  Promise.resolve().then(() => reject("oops"));
});
```

p.catch(() => {});

**Expected behavior:**
-The rejection is handled, so no unhandled-rejection tracking should occur.

**Actual behavior before this fix:**
-The host rejection tracker may fire because [[PromiseIsHandled]] was never set while the promise was pending.

## Impact

Handled rejections can be reported as **unhandled**.
Hosts relying on `HostPromiseRejectionTracker` may emit incorrect warnings or test failures.
This mostly affects the common case where `.catch()` is attached before the promise settles.

## Fix

Move the assignment of `[[PromiseIsHandled]]` so it runs after the match block, ensuring it applies regardless of the promise state.

```rust
// Step 12. Set promise.[[PromiseIsHandled]] to true.
promise.borrow_mut().data_mut().handled = true;
```

This aligns the implementation with ECMAScript §27.2.5.4.1 PerformPromiseThen step 12.

## Result

-`[[PromiseIsHandled]]` is now set correctly for pending, fulfilled, and rejected promises.
-Handled rejections no longer trigger spurious unhandled-rejection tracking.
-Behavior now matches the ECMAScript specification.