### PR TITLE
Fix f64 to f16 conversion for subnormal boundary rounding

### DIFF
--- a/core/engine/src/builtins/math/mod.rs
+++ b/core/engine/src/builtins/math/mod.rs
@@ -480,7 +480,7 @@ impl Math {
         // 4. Let n16 be the result of converting n to IEEE 754-2019 binary16 format using roundTiesToEven mode.
         // 5. Let n64 be the result of converting n16 to IEEE 754-2019 binary64 format.
         // 6. Return the ECMAScript Number value corresponding to n64.
-        Ok(float16::f16::from_f64(num).to_f64().into())
+        Ok(crate::value::f64_to_f16(num).to_f64().into())
     }
 
     /// Get the nearest 32-bit single precision float representation of a number.

--- a/core/engine/src/value/mod.rs
+++ b/core/engine/src/value/mod.rs
@@ -1424,7 +1424,7 @@ impl JsValue {
     /// Converts a value to a 16-bit floating point.
     #[cfg(feature = "float16")]
     pub fn to_f16(&self, context: &mut Context) -> JsResult<float16::f16> {
-        self.to_number(context).map(float16::f16::from_f64)
+        self.to_number(context).map(f64_to_f16)
     }
 
     /// Converts a value to a 32 bit floating point.
@@ -1634,6 +1634,109 @@ impl JsValue {
         self.as_object()
             .as_ref()
             .map_or(Ok(false), JsObject::is_array_abstract)
+    }
+}
+
+/// Converts an `f64` to an `f16` using IEEE 754 roundTiesToEven.
+///
+/// This is a custom implementation that fixes a subnormal rounding bug in the
+/// `float16` crate v0.1.5, where certain values near the smallest f16 subnormal
+/// boundary are incorrectly rounded.
+#[cfg(feature = "float16")]
+pub(crate) fn f64_to_f16(value: f64) -> float16::f16 {
+    // IEEE 754 binary64: 1 sign + 11 exponent + 52 mantissa
+    // IEEE 754 binary16: 1 sign + 5 exponent + 10 mantissa
+    const F64_MAN_MASK: u64 = 0x000F_FFFF_FFFF_FFFF;
+    const F64_EXP_BIAS: i64 = 1023;
+
+    const F16_EXP_BIAS: i64 = 15;
+    const F16_MAN_BITS: u32 = 10;
+    // Max unbiased exponent for f16 normals (also equals F16_EXP_BIAS by coincidence).
+    const F16_MAX_EXP: i64 = 15;
+    const F16_MIN_EXP: i64 = -14; // smallest normal exponent
+
+    // f16 bit patterns
+    const F16_INF: u16 = 0x7C00;
+    const F16_QNAN: u16 = 0x7E00; // canonical quiet NaN
+
+    let bits = value.to_bits();
+    let sign = ((bits >> 63) & 1) as u16;
+    let f64_exp = ((bits >> 52) & 0x7FF) as i64;
+    let f64_man = bits & F64_MAN_MASK;
+
+    let f16_sign = sign << 15;
+
+    // NaN or Infinity
+    if f64_exp == 0x7FF {
+        return if f64_man != 0 {
+            float16::f16::from_bits(f16_sign | F16_QNAN)
+        } else {
+            float16::f16::from_bits(f16_sign | F16_INF)
+        };
+    }
+
+    // Zero (includes -0) or f64 subnormal (too tiny for f16, rounds to zero)
+    if f64_exp == 0 {
+        return float16::f16::from_bits(f16_sign);
+    }
+
+    let unbiased_exp = f64_exp - F64_EXP_BIAS;
+    let full_man = f64_man | (1u64 << 52); // implicit leading 1
+
+    // Overflow to f16 infinity.
+    // Any unbiased exponent > 15 overflows. Values at exponent 15 may also
+    // overflow via mantissa rounding, which is handled in the normal path below.
+    if unbiased_exp > F16_MAX_EXP {
+        return float16::f16::from_bits(f16_sign | F16_INF);
+    }
+
+    if unbiased_exp >= F16_MIN_EXP {
+        // Normal f16 range: truncate mantissa from 52 to 10 bits with rounding.
+        let shift = 52 - F16_MAN_BITS; // 42
+        let round_bits = full_man & ((1u64 << shift) - 1);
+        let halfway = 1u64 << (shift - 1);
+
+        let mut f16_man = (full_man >> shift) as u16 & 0x03FF;
+        let mut f16_exp = (unbiased_exp + F16_EXP_BIAS) as u16;
+
+        // Round ties to even
+        if round_bits > halfway || (round_bits == halfway && (f16_man & 1) != 0) {
+            f16_man += 1;
+            if f16_man > 0x03FF {
+                // Mantissa overflow: increment exponent
+                f16_man = 0;
+                f16_exp += 1;
+                if f16_exp >= 0x1F {
+                    return float16::f16::from_bits(f16_sign | F16_INF);
+                }
+            }
+        }
+
+        float16::f16::from_bits(f16_sign | (f16_exp << 10) | f16_man)
+    } else {
+        // Subnormal f16 range (or rounds to zero).
+        // In f16 subnormal: value = 2^(-14) * (mantissa / 2^10).
+        // Shift = 52 - 10 + 14 - unbiased_exp = 56 - unbiased_exp.
+        let shift = (F16_MIN_EXP - unbiased_exp + 52 - F16_MAN_BITS as i64) as u32;
+
+        if shift >= 64 {
+            return float16::f16::from_bits(f16_sign);
+        }
+
+        let round_bits = full_man & ((1u64 << shift) - 1);
+        let halfway = 1u64 << (shift - 1);
+        let mut f16_man = (full_man >> shift) as u16 & 0x03FF;
+
+        // Round ties to even
+        if round_bits > halfway || (round_bits == halfway && (f16_man & 1) != 0) {
+            f16_man += 1;
+            if f16_man > 0x03FF {
+                // Rounded up from max subnormal to smallest normal
+                return float16::f16::from_bits(f16_sign | (1u16 << 10));
+            }
+        }
+
+        float16::f16::from_bits(f16_sign | f16_man)
     }
 }
 


### PR DESCRIPTION
This Pull Request fixes incorrect `f64` to `f16` (Float16) conversion that caused 9 test262 failures.

It changes the following:

- Added a custom `f64_to_f16()` function in `core/engine/src/value/mod.rs` that correctly implements IEEE 754 binary16 conversion with roundTiesToEven, fixing a subnormal boundary rounding bug in the `float16` crate v0.1.5 where `2.980232238769532e-8` was incorrectly rounded to `0` instead of `5.960464477539063e-8` (smallest f16 subnormal).
- Updated `Math.f16round` in `core/engine/src/builtins/math/mod.rs` to use `f64_to_f16()` instead of `float16::f16::from_f64()`.
- Updated `JsValue::to_f16()` in `core/engine/src/value/mod.rs` to use `f64_to_f16()`, which propagates the fix to all Float16Array operations (fill, map, set, constructors, DefineOwnProperty, DataView.setFloat16).
