### PR TITLE
fix(builtins/array,string/mod.rs): convert panics to EngineError::Panic using js_expect

### DIFF
--- a/core/engine/src/builtins/array/from_async.rs
+++ b/core/engine/src/builtins/array/from_async.rs
@@ -7,7 +7,8 @@ use crate::builtins::promise::ResolvingFunctions;
 use crate::native_function::{CoroutineState, NativeCoroutine};
 use crate::object::{JsFunction, JsPromise};
 use crate::{
-    Context, JsArgs, JsError, JsNativeError, JsObject, JsResult, JsSymbol, JsValue, js_string,
+    Context, JsArgs, JsError, JsExpect, JsNativeError, JsObject, JsResult, JsSymbol, JsValue,
+    js_string,
 };
 use std::cell::Cell;
 
@@ -185,7 +186,7 @@ impl Array {
             resolvers
                 .reject
                 .call(&JsValue::undefined(), &[err.into_opaque(context)?], context)
-                .expect("resolving functions cannot fail");
+                .js_expect("resolving functions cannot fail")?;
         }
 
         // 5. Return promiseCapability.[[Promise]].
@@ -313,7 +314,7 @@ fn from_async_iterator(
                             .resolvers
                             .resolve
                             .call(&JsValue::undefined(), &[a.into()], context)
-                            .expect("resolving functions cannot fail");
+                            .js_expect("resolving functions cannot fail")?;
 
                         return Ok(CoroutineState::Done);
                     }
@@ -454,7 +455,7 @@ fn from_async_iterator(
                 .resolvers
                 .reject
                 .call(&JsValue::undefined(), &[err.into_opaque(context)?], context)
-                .expect("resolving functions cannot fail");
+                .js_expect("resolving functions cannot fail")?;
             Ok(CoroutineState::Done)
         }
     }
@@ -523,7 +524,7 @@ fn from_array_like(
                             .resolvers
                             .resolve
                             .call(&JsValue::undefined(), &[a.into()], context)
-                            .expect("resolving functions cannot fail");
+                            .js_expect("resolving functions cannot fail")?;
 
                         return Ok(CoroutineState::Done);
                     }
@@ -615,7 +616,7 @@ fn from_array_like(
                 .resolvers
                 .reject
                 .call(&JsValue::undefined(), &[err.into_opaque(context)?], context)
-                .expect("resolving functions cannot fail");
+                .js_expect("resolving functions cannot fail")?;
             Ok(CoroutineState::Done)
         }
     }

--- a/core/engine/src/builtins/array/mod.rs
+++ b/core/engine/src/builtins/array/mod.rs
@@ -13,7 +13,7 @@ use boa_gc::{Finalize, Trace};
 use thin_vec::ThinVec;
 
 use crate::{
-    Context, JsArgs, JsResult, JsString,
+    Context, JsArgs, JsExpect, JsResult, JsString,
     builtins::{BuiltInObject, Number, iterable::if_abrupt_close_iterator},
     context::intrinsics::{Intrinsics, StandardConstructor, StandardConstructors},
     error::JsNativeError,
@@ -228,23 +228,20 @@ impl BuiltInConstructor for Array {
         // 4. If numberOfArgs = 0, then
         if number_of_args == 0 {
             // 4.a. Return ! ArrayCreate(0, proto).
-            Ok(Self::array_create(0, Some(prototype), context)
-                .expect("this ArrayCreate call must not fail")
-                .into())
+            Ok(Self::array_create(0, Some(prototype), context)?.into())
         // 5. Else if numberOfArgs = 1, then
         } else if number_of_args == 1 {
             // a. Let len be values[0].
             let len = &args[0];
             // b. Let array be ! ArrayCreate(0, proto).
-            let array = Self::array_create(0, Some(prototype), context)
-                .expect("this ArrayCreate call must not fail");
+            let array = Self::array_create(0, Some(prototype), context)?;
             // c. If Type(len) is not Number, then
             #[allow(clippy::if_not_else)]
             let int_len = if !len.is_number() {
                 // i. Perform ! CreateDataPropertyOrThrow(array, "0", len).
                 array
                     .create_data_property_or_throw(0, len.clone(), context)
-                    .expect("this CreateDataPropertyOrThrow call must not fail");
+                    .js_expect("this CreateDataPropertyOrThrow call must not fail")?;
                 // ii. Let intLen be 1𝔽.
                 1
             // d. Else,
@@ -252,7 +249,7 @@ impl BuiltInConstructor for Array {
                 // i. Let intLen be ! ToUint32(len).
                 let int_len = len
                     .to_u32(context)
-                    .expect("this ToUint32 call must not fail");
+                    .js_expect("this ToUint32 call must not fail")?;
                 // ii. If SameValueZero(intLen, len) is false, throw a RangeError exception.
                 if !JsValue::same_value_zero(&int_len.into(), len) {
                     return Err(JsNativeError::range()
@@ -264,7 +261,7 @@ impl BuiltInConstructor for Array {
             // e. Perform ! Set(array, "length", intLen, true).
             array
                 .set(StaticJsStrings::LENGTH, int_len, true, context)
-                .expect("this Set call must not fail");
+                .js_expect("this Set call must not fail")?;
             // f. Return array.
             Ok(array.into())
         // 6. Else,
@@ -562,7 +559,7 @@ impl Array {
             // 7. Let arrayLike be ! ToObject(items).
             let array_like = items
                 .to_object(context)
-                .expect("should not fail according to spec");
+                .js_expect("should not fail according to spec")?;
 
             // 8. Let len be ? LengthOfArrayLike(arrayLike).
             let len = array_like.length_of_array_like(context)?;
@@ -798,7 +795,7 @@ impl Array {
             if spreadable {
                 // item is guaranteed to be an object since is_concat_spreadable checks it,
                 // so we can call `.unwrap()`
-                let item = item.as_object().expect("guaranteed to be an object");
+                let item = item.as_object().js_expect("guaranteed to be an object")?;
                 // i. Let k be 0.
                 // ii. Let len be ? LengthOfArrayLike(E).
                 let len = item.length_of_array_like(context)?;
@@ -1166,7 +1163,7 @@ impl Array {
 
             // d. Perform ! CreateDataPropertyOrThrow(A, Pk, fromValue).
             a.create_data_property_or_throw(i, from_value, context)
-                .expect("cannot fail per the spec");
+                .js_expect("cannot fail per the spec")?;
 
             // e. Set k to k + 1.
         }
@@ -1908,7 +1905,7 @@ impl Array {
                 // v. If shouldFlatten is true
                 if should_flatten {
                     // For `should_flatten` to be true, element must be an object.
-                    let element = element.as_object().expect("must be an object");
+                    let element = element.as_object().js_expect("must be an object")?;
 
                     // 1. If depth is +Infinity let newDepth be +Infinity
                     let new_depth = if depth == u64::MAX {
@@ -2457,7 +2454,7 @@ impl Array {
 
             //     c. Perform ! CreateDataPropertyOrThrow(A, Pi, iValue).
             arr.create_data_property_or_throw(i, value, context)
-                .expect("cannot fail for a newly created array");
+                .js_expect("cannot fail for a newly created array")?;
 
             //     d. Set i to i + 1.
             i += 1;
@@ -2468,7 +2465,7 @@ impl Array {
             //     a. Let Pi be ! ToString(𝔽(i)).
             //     b. Perform ! CreateDataPropertyOrThrow(A, Pi, E).
             arr.create_data_property_or_throw(i, item, context)
-                .expect("cannot fail for a newly created array");
+                .js_expect("cannot fail for a newly created array")?;
 
             //     c. Set i to i + 1.
             i += 1;
@@ -2486,7 +2483,7 @@ impl Array {
 
             //     d. Perform ! CreateDataPropertyOrThrow(A, Pi, fromValue).
             arr.create_data_property_or_throw(i, from_value, context)
-                .expect("cannot fail for a newly created array");
+                .js_expect("cannot fail for a newly created array")?;
 
             //     e. Set i to i + 1.
             i += 1;
@@ -2785,7 +2782,7 @@ impl Array {
         for (i, item) in sorted.into_iter().enumerate() {
             //     a. Perform ! CreateDataPropertyOrThrow(A, ! ToString(𝔽(j)), sortedList[j]).
             arr.create_data_property_or_throw(i, item, context)
-                .expect("cannot fail for a newly created array");
+                .js_expect("cannot fail for a newly created array")?;
 
             //     b. Set j to j + 1.
         }
@@ -3200,7 +3197,7 @@ impl Array {
             // d. Perform ! CreateDataPropertyOrThrow(A, Pk, fromValue).
             new_array
                 .create_data_property_or_throw(k, from_value, context)
-                .expect("cannot fail for a newly created array");
+                .js_expect("cannot fail for a newly created array")?;
 
             // e. Set k to k + 1.
         }
@@ -3490,7 +3487,7 @@ fn array_exotic_define_own_property(
             let old_len = old_len_desc
                 .expect_value()
                 .to_u32(context)
-                .expect("this ToUint32 call must not fail");
+                .js_expect("this ToUint32 call must not fail")?;
 
             // g. If index ≥ oldLen and oldLenDesc.[[Writable]] is false, return false.
             if index >= old_len && !old_len_desc.expect_writable() {
@@ -3623,7 +3620,7 @@ fn array_set_length(
         new_len_desc.clone().build(),
         context,
     )
-    .expect("this OrdinaryDefineOwnProperty call must not fail")
+    .js_expect("this OrdinaryDefineOwnProperty call must not fail")?
     {
         return Ok(false);
     }
@@ -3660,7 +3657,7 @@ fn array_set_length(
                 new_len_desc.build(),
                 context,
             )
-            .expect("this OrdinaryDefineOwnProperty call must not fail");
+            .js_expect("this OrdinaryDefineOwnProperty call must not fail")?;
 
             // iv. Return false.
             return Ok(false);
@@ -3677,7 +3674,7 @@ fn array_set_length(
             PropertyDescriptor::builder().writable(false).build(),
             context,
         )
-        .expect("this OrdinaryDefineOwnProperty call must not fail");
+        .js_expect("this OrdinaryDefineOwnProperty call must not fail")?;
 
         // b. Assert: succeeded is true.
         debug_assert!(succeeded);

--- a/core/engine/src/builtins/string/mod.rs
+++ b/core/engine/src/builtins/string/mod.rs
@@ -10,7 +10,7 @@
 //! [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String
 
 use crate::{
-    Context, JsArgs, JsResult, JsString, JsValue,
+    Context, JsArgs, JsExpect, JsResult, JsString, JsValue,
     builtins::{Array, BuiltInObject, Number, RegExp},
     context::intrinsics::{Intrinsics, StandardConstructor, StandardConstructors},
     error::JsNativeError,
@@ -1218,7 +1218,7 @@ impl String {
                     replace_str,
                     context,
                 )
-                .expect("GetSubstitution should never fail here."),
+                .js_expect("GetSubstitution should never fail here.")?,
             };
 
             // d. Set result to the string-concatenation of result, preserved, and replacement.
@@ -1348,7 +1348,7 @@ impl String {
         } else {
             JsValue::new(num_pos)
                 .to_integer_or_infinity(context)
-                .expect("Already called `to_number so this must not fail.")
+                .js_expect("Already called `to_number so this must not fail.")?
         };
 
         // 7. Let len be the length of S.
@@ -1426,7 +1426,7 @@ impl String {
                 let collator = object
                     .as_ref()
                     .and_then(|o| o.downcast_ref::<Collator>())
-                    .expect("constructor must return a `Collator` object");
+                    .js_expect("constructor must return a `Collator` object")?;
 
                 let s = s.iter().collect::<Vec<_>>();
                 let that_value = that_value.iter().collect::<Vec<_>>();
@@ -2727,7 +2727,7 @@ pub(crate) fn get_substitution(
                         // a. Assert: Type(namedCaptures) is Object.
                         let named_captures = named_captures
                             .as_object()
-                            .expect("should be an object according to spec");
+                            .js_expect("should be an object according to spec")?;
 
                         // b. Scan until the next > U+003E (GREATER-THAN SIGN).
                         let mut group_name = vec![];


### PR DESCRIPTION
Part of #3241.

It changes the following:
* `core/engine/src/builtins/array/mod.rs`: converted 20 panics (`ArrayCreate`, `CreateDataPropertyOrThrow`, `ToUint32`, `Set`, `ToObject`, `as_object`, `OrdinaryDefineOwnProperty`) to use `?` or `js_expect`
* `core/engine/src/builtins/array/from_async.rs`: converted 5 panics (resolve/reject `.call()` on promise resolving functions) to use `js_expect`
* `core/engine/src/builtins/string/mod.rs`: converted 4 panics (`GetSubstitution`, `to_integer_or_infinity`, `downcast_ref::<Collator>`, `as_object` in `get_substitution`) to use `js_expect`