### PR TITLE
feat(error): harden JsNativeError public API surface

### DIFF
--- a/core/engine/src/builtins/uri/mod.rs
+++ b/core/engine/src/builtins/uri/mod.rs
@@ -587,6 +587,6 @@ mod tests {
         let s = js_string!("%E7%9A%8");
         let err = decode(&s, |_| false).expect_err("should error on incomplete escape");
         let native = err.as_native().expect("error should be native");
-        assert!(matches!(native.kind, JsNativeErrorKind::Uri));
+        assert!(matches!(native.kind(), JsNativeErrorKind::Uri));
     }
 }

--- a/core/engine/src/error/mod.rs
+++ b/core/engine/src/error/mod.rs
@@ -202,9 +202,8 @@ macro_rules! js_error {
 ///     .with_cause(cause)
 ///     .into();
 ///
-/// assert!(native_error.as_native().is_some());
-///
-/// let kind = &native_error.as_native().unwrap().kind;
+/// let native = native_error.as_native().unwrap();
+/// let kind = native.kind();
 /// assert!(matches!(kind, JsNativeErrorKind::Type));
 /// ```
 #[derive(Debug, Clone, Trace, Finalize)]
@@ -557,7 +556,7 @@ impl JsError {
     /// // then, try to recover the original
     /// let error = JsError::from_opaque(error_val).try_native(context).unwrap();
     ///
-    /// assert!(matches!(error.kind, JsNativeErrorKind::Type));
+    /// assert!(matches!(error.kind(), JsNativeErrorKind::Type));
     /// assert_eq!(error.message(), "type error!");
     /// ```
     pub fn try_native(&self, context: &mut Context) -> Result<JsNativeError, TryNativeError> {
@@ -951,7 +950,7 @@ impl<T> From<T> for IgnoreEq<T> {
 /// # use boa_engine::{JsNativeError, JsNativeErrorKind};
 /// let native_error = JsNativeError::uri().with_message("cannot decode uri");
 ///
-/// match native_error.kind {
+/// match native_error.kind() {
 ///     JsNativeErrorKind::Uri => { /* handle URI error*/ }
 ///     _ => unreachable!(),
 /// }
@@ -961,7 +960,7 @@ impl<T> From<T> for IgnoreEq<T> {
 #[derive(Clone, Finalize, Error, PartialEq, Eq)]
 pub struct JsNativeError {
     /// The kind of native error (e.g. `TypeError`, `SyntaxError`, etc.)
-    pub kind: JsNativeErrorKind,
+    kind: JsNativeErrorKind,
     message: Cow<'static, str>,
     #[source]
     cause: Option<Box<JsError>>,
@@ -1023,6 +1022,13 @@ impl JsNativeError {
     /// Default `UriError` kind `JsNativeError`.
     pub const URI: Self = Self::uri();
 
+    /// Returns the kind of this native error.
+    #[must_use]
+    #[inline]
+    pub const fn kind(&self) -> &JsNativeErrorKind {
+        &self.kind
+    }
+
     /// Creates a new `JsNativeError` from its `kind`, `message` and (optionally) its `cause`.
     #[cfg_attr(feature = "native-backtrace", track_caller)]
     const fn new(
@@ -1061,8 +1067,8 @@ impl JsNativeError {
     /// let error = JsNativeError::aggregate(inner_errors);
     ///
     /// assert!(matches!(
-    ///     error.kind,
-    ///     JsNativeErrorKind::Aggregate(ref errors) if errors.len() == 2
+    ///     error.kind(),
+    ///     JsNativeErrorKind::Aggregate(errors) if errors.len() == 2
     /// ));
     /// ```
     #[must_use]
@@ -1091,7 +1097,7 @@ impl JsNativeError {
     /// # use boa_engine::{JsNativeError, JsNativeErrorKind};
     /// let error = JsNativeError::error();
     ///
-    /// assert!(matches!(error.kind, JsNativeErrorKind::Error));
+    /// assert!(matches!(error.kind(), JsNativeErrorKind::Error));
     /// ```
     #[must_use]
     #[inline]
@@ -1115,7 +1121,7 @@ impl JsNativeError {
     /// # use boa_engine::{JsNativeError, JsNativeErrorKind};
     /// let error = JsNativeError::eval();
     ///
-    /// assert!(matches!(error.kind, JsNativeErrorKind::Eval));
+    /// assert!(matches!(error.kind(), JsNativeErrorKind::Eval));
     /// ```
     #[must_use]
     #[inline]
@@ -1139,7 +1145,7 @@ impl JsNativeError {
     /// # use boa_engine::{JsNativeError, JsNativeErrorKind};
     /// let error = JsNativeError::range();
     ///
-    /// assert!(matches!(error.kind, JsNativeErrorKind::Range));
+    /// assert!(matches!(error.kind(), JsNativeErrorKind::Range));
     /// ```
     #[must_use]
     #[inline]
@@ -1163,7 +1169,7 @@ impl JsNativeError {
     /// # use boa_engine::{JsNativeError, JsNativeErrorKind};
     /// let error = JsNativeError::reference();
     ///
-    /// assert!(matches!(error.kind, JsNativeErrorKind::Reference));
+    /// assert!(matches!(error.kind(), JsNativeErrorKind::Reference));
     /// ```
     #[must_use]
     #[inline]
@@ -1187,7 +1193,7 @@ impl JsNativeError {
     /// # use boa_engine::{JsNativeError, JsNativeErrorKind};
     /// let error = JsNativeError::syntax();
     ///
-    /// assert!(matches!(error.kind, JsNativeErrorKind::Syntax));
+    /// assert!(matches!(error.kind(), JsNativeErrorKind::Syntax));
     /// ```
     #[must_use]
     #[inline]
@@ -1211,7 +1217,7 @@ impl JsNativeError {
     /// # use boa_engine::{JsNativeError, JsNativeErrorKind};
     /// let error = JsNativeError::typ();
     ///
-    /// assert!(matches!(error.kind, JsNativeErrorKind::Type));
+    /// assert!(matches!(error.kind(), JsNativeErrorKind::Type));
     /// ```
     #[must_use]
     #[inline]
@@ -1235,7 +1241,7 @@ impl JsNativeError {
     /// # use boa_engine::{JsNativeError, JsNativeErrorKind};
     /// let error = JsNativeError::uri();
     ///
-    /// assert!(matches!(error.kind, JsNativeErrorKind::Uri));
+    /// assert!(matches!(error.kind(), JsNativeErrorKind::Uri));
     /// ```
     #[must_use]
     #[inline]

--- a/core/engine/src/lib.rs
+++ b/core/engine/src/lib.rs
@@ -499,7 +499,7 @@ fn run_test_actions_with(actions: impl IntoIterator<Item = TestAction>, context:
                     ),
                 };
 
-                assert_eq!(&native.kind, &kind, "{}", fmt_test(&source, i));
+                assert_eq!(native.kind(), &kind, "{}", fmt_test(&source, i));
                 assert_eq!(native.message(), message, "{}", fmt_test(&source, i));
                 i += 1;
             }

--- a/core/runtime/src/lib.rs
+++ b/core/runtime/src/lib.rs
@@ -394,7 +394,7 @@ pub(crate) mod test {
                         ),
                     };
 
-                    assert_eq!(&native.kind, &kind, "{}", fmt_test(&source, i));
+                    assert_eq!(native.kind(), &kind, "{}", fmt_test(&source, i));
                     assert_eq!(native.message(), message, "{}", fmt_test(&source, i));
                     i += 1;
                 }

--- a/tests/tester/src/exec/mod.rs
+++ b/tests/tester/src/exec/mod.rs
@@ -597,7 +597,7 @@ impl Test {
 /// Returns `true` if `error` is a `target_type` error.
 fn is_error_type(error: &JsError, target_type: ErrorType, context: &mut Context) -> bool {
     if let Ok(error) = error.try_native(context) {
-        match &error.kind {
+        match error.kind() {
             JsNativeErrorKind::Syntax if target_type == ErrorType::SyntaxError => {}
             JsNativeErrorKind::Reference if target_type == ErrorType::ReferenceError => {}
             JsNativeErrorKind::Range if target_type == ErrorType::RangeError => {}


### PR DESCRIPTION
This Pull Request fixes/closes #4981.

It changes the following:

* Make `JsNativeError::kind` a private field instead of `pub`.
* Add a `JsNativeError::kind(&self) -> &JsNativeErrorKind` accessor as the stable API.
* Update internal usages (engine tests, runtime tests, URI tests, tester helpers, docs/examples) to call `kind()` instead of reading the field directly.

Testing:

* `cargo test -p boa_engine`