### PR TITLE
feat(runtime): add Response.ok getter per Fetch Standard §7.1

### DIFF
--- a/core/runtime/src/fetch/response.rs
+++ b/core/runtime/src/fetch/response.rs
@@ -177,6 +177,12 @@ impl JsResponse {
     }
 
     #[boa(getter)]
+    fn ok(&self) -> bool {
+        let status = self.status();
+        (200..=299).contains(&status)
+    }
+
+    #[boa(getter)]
     fn status_text(&self) -> JsString {
         if let Some(status) = self.status {
             JsString::from(status.canonical_reason().unwrap_or_else(|| status.as_str()))


### PR DESCRIPTION
## Summary

Adds the `Response.ok` read-only getter to `JsResponse` in `boa_runtime`,
aligning with the Fetch Standard §7.1.

## Changes

- **response.rs**: Added `#[boa(getter)] fn ok()` - returns `true` if
  status is in the range 200–299, `false` otherwise (including no status).

## Behavior
```js
const res = new Response('body', { status: 200 });
console.log(res.ok); // true

const err = new Response('body', { status: 404 });
console.log(err.ok); // false
```

## Testing

- [x] `cargo check -p boa_runtime` passes
- [x] `cargo clippy --all-features --all-targets -- -D warnings` passes (0 warnings)
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo test -p boa_runtime` passes (70/70)

## Spec Reference

- https://fetch.spec.whatwg.org/#dom-response-ok