### PR TITLE
feat(engine): get_active_script_or_module

### DIFF
--- a/core/engine/src/context/mod.rs
+++ b/core/engine/src/context/mod.rs
@@ -847,7 +847,8 @@ impl Context {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-getactivescriptormodule
-    pub(crate) fn get_active_script_or_module(&self) -> Option<ActiveRunnable> {
+    #[must_use]
+    pub fn get_active_script_or_module(&self) -> Option<ActiveRunnable> {
         // 1. If the execution context stack is empty, return null.
         // 2. Let ec be the topmost execution context on the execution context stack whose ScriptOrModule component is not null.
         // 3. If no such execution context exists, return null. Otherwise, return ec's ScriptOrModule.

--- a/core/engine/src/vm/mod.rs
+++ b/core/engine/src/vm/mod.rs
@@ -16,7 +16,7 @@ use crate::{
 };
 use boa_gc::{Finalize, Gc, Trace, custom_trace};
 use shadow_stack::ShadowStack;
-use std::{future::Future, ops::ControlFlow, pin::Pin, task};
+use std::{future::Future, ops::ControlFlow, path::Path, pin::Pin, task};
 
 #[cfg(feature = "trace")]
 use crate::sys::time::Instant;
@@ -303,8 +303,10 @@ impl Stack {
 
 /// Active runnable in the current vm context.
 #[derive(Debug, Clone, Finalize)]
-pub(crate) enum ActiveRunnable {
+pub enum ActiveRunnable {
+    /// A [**Script Record**](https://tc39.es/ecma262/#sec-script-records)
     Script(Script),
+    /// A [**Source Text Module Record**](https://tc39.es/ecma262/#sec-source-text-module-records).
     Module(Module),
 }
 
@@ -315,6 +317,17 @@ unsafe impl Trace for ActiveRunnable {
             Self::Module(module) => mark(module),
         }
     });
+}
+
+impl ActiveRunnable {
+    /// Gets the path of the runnable, if it has one.
+    #[must_use]
+    pub fn path(&self) -> Option<&Path> {
+        match self {
+            Self::Script(script) => script.path(),
+            Self::Module(module) => module.path(),
+        }
+    }
 }
 
 impl Vm {


### PR DESCRIPTION
There are cases where it's useful to expose this information to Rust callbacks, e.g. for being able to resolve strings as paths relative to the current module being executed, so let's do that with some information that is already present in this crate.