### PR TITLE
fix: check extensibility in DefinePrivateField opcode

### DIFF
--- a/core/engine/src/vm/opcode/set/private.rs
+++ b/core/engine/src/vm/opcode/set/private.rs
@@ -56,9 +56,9 @@ impl DefinePrivateField {
     pub(crate) fn operation(
         (object, value, index): (RegisterOperand, RegisterOperand, IndexOperand),
         context: &mut Context,
-    ) {
-        let object = context.vm.get_register(object.into());
-        let value = context.vm.get_register(value.into());
+    ) -> JsResult<()> {
+        let object = context.vm.get_register(object.into()).clone();
+        let value = context.vm.get_register(value.into()).clone();
         let name = context
             .vm
             .frame()
@@ -69,10 +69,9 @@ impl DefinePrivateField {
             .as_object()
             .expect("class prototype must be an object");
 
-        object.borrow_mut().append_private_element(
-            object.private_name(name),
-            PrivateElement::Field(value.clone()),
-        );
+        let name = object.private_name(name);
+        object.private_field_add(&name, value, context)?;
+        Ok(())
     }
 }
 

--- a/test262_config.toml
+++ b/test262_config.toml
@@ -56,10 +56,6 @@ features = [
     # https://github.com/tc39/proposal-immutable-arraybuffer
     "immutable-arraybuffer",
 
-    # Non-extensible Applies to Private
-    # https://github.com/tc39/proposal-nonextensible-applies-to-private
-    "nonextensible-applies-to-private",
-
     ### Non-standard
     "caller",
 ]


### PR DESCRIPTION
This Pull Request fixes the DefinePrivateField VM opcode to comply with the nonextensible-applies-to-private proposal.

It changes the following:

- DefinePrivateField now calls private_field_add() instead of append_private_element(), properly checking IsExtensible(O) per the PrivateFieldAdd spec algorithm
