### PR TITLE
Fix stale return value leakage in indirect eval constructor binding (#4350)

### DIFF
--- a/core/engine/src/builtins/function/mod.rs
+++ b/core/engine/src/builtins/function/mod.rs
@@ -1028,6 +1028,7 @@ pub(crate) fn function_call(
     }
 
     context.vm.push_frame(frame);
+    context.vm.set_return_value(JsValue::undefined());
 
     let context = context.context();
 
@@ -1167,6 +1168,7 @@ fn function_construct(
     }
 
     context.vm.push_frame(frame);
+    context.vm.set_return_value(JsValue::undefined());
 
     let mut last_env = 0;
 

--- a/core/engine/src/tests/env.rs
+++ b/core/engine/src/tests/env.rs
@@ -47,3 +47,50 @@ fn with_env_not_panic() {
         "k is not defined",
     )]);
 }
+
+#[test]
+// https://github.com/boa-dev/boa/issues/4350
+fn indirect_eval_function_var_binding_4350() {
+    run_test_actions([TestAction::assert_eq(
+        indoc! {r#"
+            var t = [];
+
+            var s1 = `
+            function core() { t.push(1) }
+
+            core.prototype.a = function () { t.push(2) }
+            core.prototype.b = function () { t.push(3) }
+            `;
+            var s2 = `
+            function core() { t.push(1) }
+
+            core.prototype.a = function () { t.push(2) }
+            core.prototype.b = function () { t.push(3) }
+            var core = new core();
+            `;
+            var s3 = `
+            function core() { t.push(1) }
+            var core = new core();
+            `;
+
+            function run_ctx(s) {
+                (1,eval)(s);
+            }
+
+            function test() {
+                run_ctx(s1);
+                var core1 = new core();
+
+                run_ctx(s2);
+                var core2 = core;
+
+                run_ctx(s3);
+                var core3 = core;
+                return [core1, core2, core3].toString();
+            }
+
+            test();
+        "#},
+        js_str!("[object Object],[object Object],[object Object]"),
+    )]);
+}


### PR DESCRIPTION
# PR Description

## Summary
This PR fixes issue #4350, where indirect eval could leave `core` bound to a function instead of the object instance after:
- function declaration
- prototype assignments
- `var core = new core();`

In the failing case, the second value became a function (for example `function () { t.push(3) }`) instead of an object.

## Root Cause
A stale VM return accumulator value could leak into ordinary call/construct frame execution in specific eval completion paths.  
That stale value could then affect constructor return handling and produce an incorrect final binding value.

## Fix
- Reset the VM return accumulator to `undefined` when entering ordinary function call frames.
- Reset the VM return accumulator to `undefined` when entering ordinary function construct frames.
- Add a regression test that reproduces #4350 exactly.

## Validation
Passed:
1. `cargo test -p boa_engine indirect_eval_function_var_binding_4350 -- --nocapture`
2. `cargo test -p boa_engine empty_return_values -- --nocapture`
3. `cargo test -p boa_engine tests::env:: -- --nocapture`

## Result
The repro now evaluates to:
`[object Object],[object Object],[object Object]`

instead of returning a function in the second position.