### PR TITLE
fix(promise): set [[PromiseIsHandled]] unconditionally

### DIFF
--- a/core/engine/src/builtins/promise/tests.rs
+++ b/core/engine/src/builtins/promise/tests.rs
@@ -1,10 +1,11 @@
 use std::{cell::Cell, rc::Rc};
 
 use crate::{
-    Context, JsObject, TestAction, run_test_actions, run_test_actions_with,
+    Context, JsObject, TestAction,
     builtins::Promise,
     builtins::promise::OperationType,
     context::{ContextBuilder, HostHooks},
+    run_test_actions, run_test_actions_with,
 };
 use indoc::indoc;
 


### PR DESCRIPTION
# Summary

This PR fixes how `[[PromiseIsHandled]]` is set inside `Promise::perform_promise_then` in
`core/engine/src/builtins/promise/mod.rs`.

Previously, the flag `handled = true` was only set when the promise was already **Rejected**.
However, the ECMAScript specification requires this step to run **for all states** (Pending, Fulfilled, Rejected).

Because of this, if a `.catch()` handler was attached while the promise was still **pending**, Boa could still trigger a false **unhandled rejection** event later.

Example pattern that triggers it:

```javascript
const p = new Promise((_, reject) => {
  setTimeout(() => reject("fail"), 10);
});

p.catch(() => {}); // handler attached before rejection
```

# Steps to Reproduce

1. Create a promise that rejects asynchronously.
2. Attach `.catch()` before the rejection occurs.
3. Run the event loop or microtasks.

Expected:

* The rejection is handled and no unhandled rejection event fires.

Actual (before fix):

* `HostPromiseRejectionTracker("reject")` may fire even though the promise has a handler.

# Impact

* False **unhandled rejection** events can be reported.
* Hosts relying on rejection tracking may show incorrect warnings or errors.
* This breaks the expected behavior for handled promises.

# Fix

Move the `handled = true` assignment so it runs **after the state match**, making it unconditional.

This ensures `[[PromiseIsHandled]]` is set whenever `.then()` or `.catch()` is registered.

# Result

* Pending promises with handlers are correctly marked as handled.
* No more false unhandled rejection events.
* Behavior now aligns with the ECMAScript specification.

