### PR TITLE
perf(intl): cache resolvedOptions result on DateTimeFormat

### DIFF
--- a/benches/scripts/intl/datetimeformat_resolved_options.js
+++ b/benches/scripts/intl/datetimeformat_resolved_options.js
@@ -1,12 +1,12 @@
 const kIterationCount = 1000;
 const fmt = new Intl.DateTimeFormat("en-US", {
-    dateStyle: "full",
-    timeStyle: "short",
-    timeZone: "UTC",
+  dateStyle: "full",
+  timeStyle: "short",
+  timeZone: "UTC",
 });
 
 function main() {
   for (let i = 0; i < kIterationCount; i++) {
-      fmt.resolvedOptions();
+    fmt.resolvedOptions();
   }
 }

--- a/benches/scripts/intl/datetimeformat_resolved_options.js
+++ b/benches/scripts/intl/datetimeformat_resolved_options.js
@@ -1,0 +1,12 @@
+const kIterationCount = 1000;
+const fmt = new Intl.DateTimeFormat("en-US", {
+    dateStyle: "full",
+    timeStyle: "short",
+    timeZone: "UTC",
+});
+
+function main() {
+  for (let i = 0; i < kIterationCount; i++) {
+      fmt.resolvedOptions();
+  }
+}

--- a/core/engine/src/builtins/intl/date_time_format/mod.rs
+++ b/core/engine/src/builtins/intl/date_time_format/mod.rs
@@ -91,6 +91,7 @@ pub(crate) struct DateTimeFormat {
     fieldset: CompositeFieldSet,
     formatter: DateTimeFormatter<CompositeFieldSet>,
     bound_format: Option<JsFunction>,
+    resolved_options: Option<JsObject>,
 }
 
 impl Service for DateTimeFormat {
@@ -374,8 +375,9 @@ impl DateTimeFormat {
         //       a. Set dtf to ? UnwrapDateTimeFormat(dtf).
         // 3. Perform ? RequireInternalSlot(dtf, [[InitializedDateTimeFormat]]).
         let dtf_object = unwrap_date_time_format(this, context)?;
-        let dtf = dtf_object.borrow();
-        let dtf = dtf.data();
+        if let Some(cached) = dtf_object.borrow().data().resolved_options.clone() {
+            return Ok(cached.into());
+        }
 
         // 4. Let options be OrdinaryObjectCreate(%Object.prototype%).
         // 5. For each row of Table 15, except the header row, in table order, do
@@ -397,85 +399,93 @@ impl DateTimeFormat {
         //              a. Assert: conversion is number.
         //              b. Set v to 𝔽(v).
         //          ii. Perform ! CreateDataPropertyOrThrow(options, p, v).
-        let mut options = ObjectInitializer::new(context);
-        options.property(
-            js_string!("locale"),
-            js_string!(dtf.locale.to_string()),
-            Attribute::all(),
-        );
+        let result = {
+            let dtf = dtf_object.borrow();
+            let dtf = dtf.data();
 
-        if let Some(ca) = &dtf.calendar_algorithm {
+            let mut options = ObjectInitializer::new(context);
             options.property(
-                js_string!("calendar"),
-                js_string!(ca.as_str()),
+                js_string!("locale"),
+                js_string!(dtf.locale.to_string()),
                 Attribute::all(),
             );
-        }
 
-        if let Some(nu) = &dtf.numbering_system {
-            options.property(
-                js_string!("numberingSystem"),
-                js_string!(nu.as_str()),
-                Attribute::all(),
-            );
-        }
-
-        let time_zone_str = match &dtf.time_zone {
-            FormatTimeZone::UtcOffset(offset) => {
-                let seconds = offset.to_seconds();
-                let hours = seconds / 3600;
-                let minutes = (seconds.abs() % 3600) / 60;
-                format!("{hours:+03}:{minutes:02}")
+            if let Some(ca) = &dtf.calendar_algorithm {
+                options.property(
+                    js_string!("calendar"),
+                    js_string!(ca.as_str()),
+                    Attribute::all(),
+                );
             }
-            FormatTimeZone::Identifier((tz, _id)) => tz.to_string(),
+
+            if let Some(nu) = &dtf.numbering_system {
+                options.property(
+                    js_string!("numberingSystem"),
+                    js_string!(nu.as_str()),
+                    Attribute::all(),
+                );
+            }
+
+            let time_zone_str = match &dtf.time_zone {
+                FormatTimeZone::UtcOffset(offset) => {
+                    let seconds = offset.to_seconds();
+                    let hours = seconds / 3600;
+                    let minutes = (seconds.abs() % 3600) / 60;
+                    format!("{hours:+03}:{minutes:02}")
+                }
+                FormatTimeZone::Identifier((tz, _id)) => tz.to_string(),
+            };
+            options.property(
+                js_string!("timeZone"),
+                js_string!(time_zone_str),
+                Attribute::all(),
+            );
+
+            if let Some(hc) = &dtf.hour_cycle {
+                options.property(
+                    js_string!("hourCycle"),
+                    js_string!(hc.as_str()),
+                    Attribute::all(),
+                );
+                //h11/h12 -> true, h23/h24 -> false , because its h12 conversion time
+                let hour12 = matches!(hc, IcuHourCycle::H11 | IcuHourCycle::H12);
+                options.property(js_string!("hour12"), hour12, Attribute::all());
+            }
+
+            if let Some(ds) = dtf.date_style {
+                let ds_str = match ds {
+                    DateStyle::Full => "full",
+                    DateStyle::Long => "long",
+                    DateStyle::Medium => "medium",
+                    DateStyle::Short => "short",
+                };
+                options.property(
+                    js_string!("dateStyle"),
+                    js_string!(ds_str),
+                    Attribute::all(),
+                );
+            }
+
+            if let Some(ts) = dtf.time_style {
+                let ts_str = match ts {
+                    TimeStyle::Full => "full",
+                    TimeStyle::Long => "long",
+                    TimeStyle::Medium => "medium",
+                    TimeStyle::Short => "short",
+                };
+                options.property(
+                    js_string!("timeStyle"),
+                    js_string!(ts_str),
+                    Attribute::all(),
+                );
+            }
+
+            options.build()
         };
-        options.property(
-            js_string!("timeZone"),
-            js_string!(time_zone_str),
-            Attribute::all(),
-        );
-
-        if let Some(hc) = &dtf.hour_cycle {
-            options.property(
-                js_string!("hourCycle"),
-                js_string!(hc.as_str()),
-                Attribute::all(),
-            );
-            //h11/h12 -> true, h23/h24 -> false , because its h12 conversion time
-            let hour12 = matches!(hc, IcuHourCycle::H11 | IcuHourCycle::H12);
-            options.property(js_string!("hour12"), hour12, Attribute::all());
-        }
-
-        if let Some(ds) = dtf.date_style {
-            let ds_str = match ds {
-                DateStyle::Full => "full",
-                DateStyle::Long => "long",
-                DateStyle::Medium => "medium",
-                DateStyle::Short => "short",
-            };
-            options.property(
-                js_string!("dateStyle"),
-                js_string!(ds_str),
-                Attribute::all(),
-            );
-        }
-
-        if let Some(ts) = dtf.time_style {
-            let ts_str = match ts {
-                TimeStyle::Full => "full",
-                TimeStyle::Long => "long",
-                TimeStyle::Medium => "medium",
-                TimeStyle::Short => "short",
-            };
-            options.property(
-                js_string!("timeStyle"),
-                js_string!(ts_str),
-                Attribute::all(),
-            );
-        }
 
         // 6. Return options.
-        Ok(options.build().into())
+        dtf_object.borrow_mut().data_mut().resolved_options = Some(result.clone());
+        Ok(result.into())
     }
 }
 
@@ -856,6 +866,7 @@ fn create_date_time_format(
             fieldset,
             formatter,
             bound_format: None,
+            resolved_options: None,
         },
     ))
 }


### PR DESCRIPTION
Intl.DateTimeFormat.prototype.resolvedOptions() previously rebuilt a new JS object on every call, re-allocating strings for locale, calendar, numberingSystem, timeZone, hourCycle, dateStyle, timeStyle each time, even though none of these values can change after construction.
This PR caches the result on first call and returns the cached JsObject on subsequent calls.

**Before cached:**
<img width="717" height="158" alt="Screenshot from 2026-03-13 16-08-40" src="https://github.com/user-attachments/assets/95b33ec7-bf76-4b51-a4c9-6dc912098d80" />

**After cached: (~10x faster)**
<img width="643" height="138" alt="image" src="https://github.com/user-attachments/assets/7e3430cb-6970-476c-a8e8-c5e2d6a18aa6" />

