### PR TITLE
perf: optimize `JsSharedArrayBuffer::to_vec`

### DIFF
--- a/core/engine/src/builtins/array_buffer/utils.rs
+++ b/core/engine/src/builtins/array_buffer/utils.rs
@@ -81,7 +81,23 @@ impl SliceRef<'_> {
     pub(crate) fn to_vec(self) -> Vec<u8> {
         match self {
             Self::Slice(s) => s.to_vec(),
-            Self::AtomicSlice(s) => s.iter().map(|a| a.load(Ordering::SeqCst)).collect(),
+            Self::AtomicSlice(s) => {
+                let count = s.len();
+                let mut target = Vec::with_capacity(count);
+                // SAFETY: we only copy `count` bytes, which should be in bounds
+                // for both the target buffer and the source atomic slice.
+                // `target` also has enough capacity for `count` elements and
+                // all its elements are initialized by `memcpy`.
+                unsafe {
+                    memcpy(
+                        BytesConstPtr::AtomicBytes(s.as_ptr()),
+                        BytesMutPtr::Bytes(target.as_mut_ptr()),
+                        count,
+                    );
+                    target.set_len(s.len());
+                }
+                target
+            }
         }
     }
 

--- a/core/engine/src/object/builtins/jssharedarraybuffer.rs
+++ b/core/engine/src/object/builtins/jssharedarraybuffer.rs
@@ -1,7 +1,10 @@
 //! A Rust API wrapper for Boa's `SharedArrayBuffer` Builtin ECMAScript Object
 use crate::{
-    Context, JsResult, JsValue, builtins::array_buffer::SharedArrayBuffer, error::JsNativeError,
-    object::JsObject, value::TryFromJs,
+    Context, JsResult, JsValue,
+    builtins::array_buffer::{SharedArrayBuffer, utils::SliceRef},
+    error::JsNativeError,
+    object::JsObject,
+    value::TryFromJs,
 };
 use boa_gc::{Finalize, Trace};
 use std::{ops::Deref, sync::atomic::Ordering};
@@ -103,12 +106,10 @@ impl JsSharedArrayBuffer {
     /// ```
     #[must_use]
     pub fn to_vec(&self) -> Vec<u8> {
-        self.borrow()
-            .data()
-            .bytes(Ordering::SeqCst)
-            .iter()
-            .map(|a| a.load(Ordering::SeqCst))
-            .collect()
+        let obj = self.borrow();
+        let src = obj.data().bytes(Ordering::SeqCst);
+        let src = SliceRef::AtomicSlice(src);
+        src.to_vec()
     }
 
     /// Gets the raw buffer of this `JsSharedArrayBuffer`.


### PR DESCRIPTION
Just a small optimization for `to_vec` that uses `memcpy`.