### PR TITLE
fix(object/remaining): convert panics to EngineError::Panic using js_expect

### DIFF
--- a/core/engine/src/object/internal_methods/string.rs
+++ b/core/engine/src/object/internal_methods/string.rs
@@ -1,5 +1,5 @@
 use crate::{
-    Context, JsResult, JsString,
+    Context, JsExpect, JsResult, JsString,
     object::{JsData, JsObject},
     property::{PropertyDescriptor, PropertyKey},
 };
@@ -90,7 +90,7 @@ pub(crate) fn string_exotic_own_property_keys(
     // 3. Assert: Type(str) is String.
     let string = obj
         .downcast_ref::<JsString>()
-        .expect("string exotic method should only be callable from string objects")
+        .js_expect("string exotic method should only be callable from string objects")?
         .clone();
     // 4. Let len be the length of str.
     let len = string.len();

--- a/core/engine/src/object/operations.rs
+++ b/core/engine/src/object/operations.rs
@@ -458,7 +458,7 @@ impl JsObject {
         let result = context.run().consume();
         context.vm.host_call_depth = context.vm.host_call_depth.saturating_sub(1);
 
-        context.vm.pop_frame().expect("frame must exist");
+        context.vm.pop_frame().js_expect("frame must exist")?;
 
         result
     }
@@ -500,7 +500,7 @@ impl JsObject {
             let result = context.vm.stack.pop();
             return Ok(result
                 .as_object()
-                .expect("construct value should be an object")
+                .js_expect("construct value should be an object")?
                 .clone());
         }
 
@@ -514,9 +514,12 @@ impl JsObject {
         let result = context.run().consume();
         context.vm.host_call_depth = context.vm.host_call_depth.saturating_sub(1);
 
-        context.vm.pop_frame().expect("frame must exist");
+        context.vm.pop_frame().js_expect("frame must exist")?;
 
-        Ok(result?.as_object().expect("should be an object").clone())
+        Ok(result?
+            .as_object()
+            .js_expect("should be an object")?
+            .clone())
     }
 
     /// Make the object [`sealed`][IntegrityLevel::Sealed] or [`frozen`][IntegrityLevel::Frozen].
@@ -1270,7 +1273,7 @@ impl JsObject {
     ) -> JsResult<()> {
         let constructor_function = constructor
             .downcast_ref::<OrdinaryFunction>()
-            .expect("class constructor must be function object");
+            .js_expect("class constructor must be function object")?;
 
         // 1. Let methods be the value of constructor.[[PrivateMethods]].
         // 2. For each PrivateElement method of methods, do


### PR DESCRIPTION

Part of #3241. It changes the following:

`core/engine/src/object/operations.rs`: converted 4 panics (pop_frame assertions, construct value assertions) to use `js_expect`.
`core/engine/src/object/internal_methods/string.rs`: converted 1 panic (string exotic downcast assertion) to use `js_expect`.

This completes all real panics in `object/`. The remaining `.expect()`/`.unwrap()` calls in `object/` are either in `#[cfg(test)]` blocks, `///` doc comment examples, or intentional invariant assertions in non-`JsResult` contexts (borrow guards, `!` operations) and are left as-is.