### PR TITLE
fix(bench): enable intl_bundled feature for boa_engine

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 publish = false
 
 [dependencies]
-boa_engine.workspace = true
+boa_engine = { workspace = true, features = ["intl_bundled"] }
 boa_runtime.workspace = true
 
 [dev-dependencies]


### PR DESCRIPTION
After #4898, running cargo bench -p boa_benches without --features boa_engine/intl_bundled panics with "Intl is not defined" since the Intl benchmark scripts require the intl feature to be enabled.
This adds intl_bundled as a default feature for boa_benches so `cargo bench -p boa_benches` works without any panics message: "Intl is not defined".