### PR TITLE
feat(intl): implement Number.prototype.toLocaleString with Intl support

### DIFF
--- a/core/engine/src/builtins/number/mod.rs
+++ b/core/engine/src/builtins/number/mod.rs
@@ -291,23 +291,51 @@ impl Number {
     ///
     /// The `toLocaleString()` method returns a string with a language-sensitive representation of this number.
     ///
-    /// Note that while this technically conforms to the Ecma standard, it does no actual
-    /// internationalization logic.
-    ///
     /// More information:
     ///  - [ECMAScript reference][spec]
     ///  - [MDN documentation][mdn]
     ///
-    /// [spec]: https://tc39.es/ecma262/#sec-number.prototype.tolocalestring
+    /// [spec]: https://tc39.es/ecma402/#sup-number.prototype.tolocalestring
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toLocaleString
     #[allow(clippy::wrong_self_convention)]
+    #[allow(
+        unused_variables,
+        reason = "`args` and `context` are used if the `intl` feature is enabled"
+    )]
     pub(crate) fn to_locale_string(
         this: &JsValue,
-        _: &[JsValue],
-        _: &mut Context,
+        args: &[JsValue],
+        context: &mut Context,
     ) -> JsResult<JsValue> {
-        let this_num = Self::this_number_value(this)?;
-        Ok(JsValue::new(js_string!(this_num)))
+        // 1. Let x be ? ThisNumberValue(this value).
+        let x = Self::this_number_value(this)?;
+
+        #[cfg(feature = "intl")]
+        {
+            use fixed_decimal::{Decimal, FloatPrecision};
+
+            use crate::builtins::intl::NumberFormat;
+
+            if !x.is_finite() {
+                return Ok(JsValue::new(js_string!(x)));
+            }
+
+            let locales = args.get_or_undefined(0).clone();
+            let options = args.get_or_undefined(1).clone();
+
+            // 2. Let numberFormat be ? Construct(%Intl.NumberFormat%, « locales, options »).
+            let number_format = NumberFormat::new(&locales, &options, context)?;
+            let mut x = Decimal::try_from_f64(x, FloatPrecision::RoundTrip)
+                .map_err(|err| JsNativeError::range().with_message(err.to_string()))?;
+
+            // 3. Return FormatNumeric(numberFormat, ! ToIntlMathematicalValue(x)).
+            Ok(js_string!(number_format.format(&mut x).to_string()).into())
+        }
+
+        #[cfg(not(feature = "intl"))]
+        {
+            Ok(JsValue::new(js_string!(x)))
+        }
     }
 
     /// `flt_str_to_exp` - used in `to_precision`

--- a/core/engine/src/builtins/number/tests.rs
+++ b/core/engine/src/builtins/number/tests.rs
@@ -167,13 +167,30 @@ fn issue_2609() {
 
 #[test]
 fn to_locale_string() {
-    // TODO: We don't actually do any locale checking here
-    // To honor the spec we should print numbers according to user locale.
     run_test_actions([
         TestAction::assert_eq("Number().toLocaleString()", js_str!("0")),
         TestAction::assert_eq("Number(5).toLocaleString()", js_str!("5")),
-        TestAction::assert_eq("Number('345600').toLocaleString()", js_str!("345600")),
         TestAction::assert_eq("Number(-25).toLocaleString()", js_str!("-25")),
+        TestAction::assert_eq("NaN.toLocaleString()", js_str!("NaN")),
+        TestAction::assert_eq("Infinity.toLocaleString()", js_str!("Infinity")),
+        TestAction::assert_eq("(-Infinity).toLocaleString()", js_str!("-Infinity")),
+    ]);
+}
+
+#[test]
+#[cfg(feature = "intl")]
+fn to_locale_string_intl() {
+    run_test_actions([
+        TestAction::assert_eq("(345600).toLocaleString('en-US')", js_str!("345,600")),
+        TestAction::assert_eq("(1234.5).toLocaleString('de-DE')", js_str!("1.234,5")),
+        TestAction::assert_eq(
+            "(1000).toLocaleString('en-US', { useGrouping: false })",
+            js_str!("1000"),
+        ),
+        TestAction::assert_eq(
+            "(12.3).toLocaleString('en-US', { minimumFractionDigits: 2 })",
+            js_str!("12.30"),
+        ),
     ]);
 }
 


### PR DESCRIPTION
This Pull Request fixes/closes #5074.

It changes the following:

- Implement `Number.prototype.toLocaleString([locales [, options]])` using `Intl.NumberFormat` when the `intl` feature is enabled, following the same pattern as `BigInt.prototype.toLocaleString`.
- Return `"NaN"`, `"Infinity"`, and `"-Infinity"` for non-finite values instead of going through `Decimal::try_from_f64`.
- Keep the existing fallback behaviour (simple number string conversion) when the `intl` feature is disabled.
- Add shared tests for 0, 5, -25, NaN, Infinity, -Infinity.
- Add `#[cfg(feature = "intl")]` tests for locale formatting (`en-US`, `de-DE`) and options (`useGrouping`, `minimumFractionDigits`).

Testing:

- `cargo test -p boa_engine --lib -- number::tests::to_locale_string` (without intl)
- `cargo test -p boa_engine --features intl_bundled --lib -- number::tests::to_locale_string` (with intl)