### PR TITLE
Add CI for 32-bit Linux target & cleanup PR action

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -74,7 +74,7 @@ jobs:
           - os: ubuntu-latest
     steps:
       - name: Set environment
-        if: matrix.os != 'windows-latest'
+        if: ${{ matrix.os != 'windows-latest' }}
         # Setting `RUSTFLAGS` overrides any flags set on .cargo/config.toml, so we need to
         # set the target flags instead which are cumulative.
         # Track https://github.com/rust-lang/cargo/issues/5376
@@ -82,7 +82,7 @@ jobs:
           target=$(rustc -vV | awk '/^host/ { print $2 }' | tr '[:lower:]' '[:upper:]' | tr '-' '_')
           echo "CARGO_TARGET_${target}_RUSTFLAGS=$W_FLAGS" >> $GITHUB_ENV
       - name: Set environment
-        if: matrix.os == "windows-latest"
+        if: ${{ matrix.os == "windows-latest" }}
         run: |
           $target = (rustc -vV | Select-String '^host') -replace '^host:\s+', '' | ForEach-Object { $_.ToUpper().Replace('-', '_') }
           "CARGO_TARGET_${target}_RUSTFLAGS=$env:W_FLAGS" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -65,11 +65,6 @@ jobs:
     timeout-minutes: 60
     env:
       RUSTUP_WINDOWS_PATH_ADD_BIN: 1
-      # TODO: Make a small Rust tool that does this
-      CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_RUSTFLAGS: ${{ (github.ref == 'refs/heads/main' || github.base_ref == 'main') && '-D warnings' || '' }}
-      CARGO_TARGET_AARCH64_APPLE_DARWIN_RUSTFLAGS: ${{ (github.ref == 'refs/heads/main' || github.base_ref == 'main') && '-D warnings' || '' }}
-      CARGO_TARGET_X86_64_APPLE_DARWIN_RUSTFLAGS: ${{ (github.ref == 'refs/heads/main' || github.base_ref == 'main') && '-D warnings' || '' }}
-      CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUSTFLAGS: ${{ (github.ref == 'refs/heads/main' || github.base_ref == 'main') && '-D warnings' || '' }}
     strategy:
       matrix:
         include:
@@ -78,6 +73,20 @@ jobs:
           - os: ubuntu-24.04-arm
           - os: ubuntu-latest
     steps:
+      - name: Set environment
+        if: matrix.os != 'windows-latest'
+        # Setting `RUSTFLAGS` overrides any flags set on .cargo/config.toml, so we need to
+        # set the target flags instead which are cumulative.
+        # Track https://github.com/rust-lang/cargo/issues/5376
+        run: |
+          target=$(rustc -vV | awk '/^host/ { print $2 }' | tr '[:lower:]' '[:upper:]' | tr '-' '_')
+          echo "CARGO_TARGET_${target}_RUSTFLAGS=$W_FLAGS" >> $GITHUB_ENV
+      - name: Set environment
+        if: matrix.os == "windows-latest"
+        run: |
+          $target = (rustc -vV | Select-String '^host') -replace '^host:\s+', '' | ForEach-Object { $_.ToUpper().Replace('-', '_') }
+          "CARGO_TARGET_${target}_RUSTFLAGS=$env:W_FLAGS" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+
       - name: Checkout repository
         uses: actions/checkout@v6
 
@@ -111,6 +120,54 @@ jobs:
         run: cargo test --doc --profile ci --features annex-b,intl_bundled,experimental
       - name: Test bytecode output
         run: cargo insta test -p insta-bytecode
+
+    cross-tests:
+      name: Test with Cross
+      runs-on: ubuntu-latest
+      timeout-minutes: 60
+      strategy:
+        matrix:
+          include:
+            - target: i686-unknown-linux-gnu
+      steps:
+        - name: Set environment
+          # Setting `RUSTFLAGS` overrides any flags set on .cargo/config.toml, so we need to
+          # set the target flags instead which are cumulative.
+          # Track https://github.com/rust-lang/cargo/issues/5376
+          run: |
+            target=$(echo ${{ matrix.target }} | tr [:lower:] [:upper:] | tr '-' '_')
+            echo "CARGO_TARGET_${target}_RUSTFLAGS=$W_FLAGS" >> $GITHUB_ENV
+
+        - name: Checkout repository
+          uses: actions/checkout@v6
+
+        - name: Install Rust toolchain
+          uses: dtolnay/rust-toolchain@stable
+          with:
+            toolchain: stable
+            target: ${{ matrix.target }}
+
+        - name: Install Cross
+          uses: baptiste0928/cargo-install@v3.4.0
+          with:
+            crate: cross
+            git: https://github.com/cross-rs/cross
+
+        - name: Cache cargo
+          uses: actions/cache@v5
+          with:
+            path: |
+              target
+              ~/.cargo/git
+              ~/.cargo/registry
+            key: ${{ matrix.target }}-${{ runner.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+        - name: Run tests
+          run: |
+            cross test --target ${{ matrix.target }} \
+              --profile ci \
+              --features annex-b,intl_bundled,experimental \
+              --exclude boa_macros,boa_macros_tests
 
   miri:
     name: Miri

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -121,53 +121,53 @@ jobs:
       - name: Test bytecode output
         run: cargo insta test -p insta-bytecode
 
-    cross-tests:
-      name: Test with Cross
-      runs-on: ubuntu-latest
-      timeout-minutes: 60
-      strategy:
-        matrix:
-          include:
-            - target: i686-unknown-linux-gnu
-      steps:
-        - name: Set environment
-          # Setting `RUSTFLAGS` overrides any flags set on .cargo/config.toml, so we need to
-          # set the target flags instead which are cumulative.
-          # Track https://github.com/rust-lang/cargo/issues/5376
-          run: |
-            target=$(echo ${{ matrix.target }} | tr [:lower:] [:upper:] | tr '-' '_')
-            echo "CARGO_TARGET_${target}_RUSTFLAGS=$W_FLAGS" >> $GITHUB_ENV
+  cross-tests:
+    name: Test with Cross
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      matrix:
+        include:
+          - target: i686-unknown-linux-gnu
+    steps:
+      - name: Set environment
+        # Setting `RUSTFLAGS` overrides any flags set on .cargo/config.toml, so we need to
+        # set the target flags instead which are cumulative.
+        # Track https://github.com/rust-lang/cargo/issues/5376
+        run: |
+          target=$(echo ${{ matrix.target }} | tr [:lower:] [:upper:] | tr '-' '_')
+          echo "CARGO_TARGET_${target}_RUSTFLAGS=$W_FLAGS" >> $GITHUB_ENV
 
-        - name: Checkout repository
-          uses: actions/checkout@v6
+      - name: Checkout repository
+        uses: actions/checkout@v6
 
-        - name: Install Rust toolchain
-          uses: dtolnay/rust-toolchain@stable
-          with:
-            toolchain: stable
-            target: ${{ matrix.target }}
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          target: ${{ matrix.target }}
 
-        - name: Install Cross
-          uses: baptiste0928/cargo-install@v3.4.0
-          with:
-            crate: cross
-            git: https://github.com/cross-rs/cross
+      - name: Install Cross
+        uses: baptiste0928/cargo-install@v3.4.0
+        with:
+          crate: cross
+          git: https://github.com/cross-rs/cross
 
-        - name: Cache cargo
-          uses: actions/cache@v5
-          with:
-            path: |
-              target
-              ~/.cargo/git
-              ~/.cargo/registry
-            key: ${{ matrix.target }}-${{ runner.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Cache cargo
+        uses: actions/cache@v5
+        with:
+          path: |
+            target
+            ~/.cargo/git
+            ~/.cargo/registry
+          key: ${{ matrix.target }}-${{ runner.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
-        - name: Run tests
-          run: |
-            cross test --target ${{ matrix.target }} \
-              --profile ci \
-              --features annex-b,intl_bundled,experimental \
-              --exclude boa_macros,boa_macros_tests
+      - name: Run tests
+        run: |
+          cross test --target ${{ matrix.target }} \
+            --profile ci \
+            --features annex-b,intl_bundled,experimental \
+            --exclude boa_macros,boa_macros_tests
 
   miri:
     name: Miri

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -122,7 +122,7 @@ jobs:
         run: cargo insta test -p insta-bytecode
 
   cross-tests:
-    name: Test with Cross
+    name: Test
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
@@ -164,7 +164,7 @@ jobs:
 
       - name: Run tests
         run: |
-          cross test --target ${{ matrix.target }} \
+          cross test --workspace --target ${{ matrix.target }} \
             --profile ci \
             --features annex-b,intl_bundled,experimental \
             --exclude boa_macros,boa_macros_tests

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,216 +20,6 @@ env:
   W_FLAGS: ${{ (github.ref == 'refs/heads/main' || github.base_ref == 'main') && '-D warnings' || '' }}
 
 jobs:
-  coverage:
-    name: Coverage
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    if: ${{ github.ref == 'refs/heads/main' || github.base_ref == 'main' }}
-    steps:
-      - name: Set environment
-        # Setting `RUSTFLAGS` overrides any flags set on .cargo/config.toml, so we need to
-        # set the target flags instead which are cumulative.
-        # Track https://github.com/rust-lang/cargo/issues/5376
-        run: |
-          target=$(rustc -vV | awk '/^host/ { print $2 }' | tr [:lower:] [:upper:] | tr '-' '_')
-          echo "CARGO_TARGET_${target}_RUSTFLAGS=$W_FLAGS" >> $GITHUB_ENV
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache cargo
-        uses: actions/cache@v5
-        with:
-          path: |
-            target
-            ~/.cargo/git
-            ~/.cargo/registry
-          key: ${{ runner.os }}-${{ runner.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: Install cargo-tarpaulin
-        uses: baptiste0928/cargo-install@v3.4.0
-        with:
-          crate: cargo-tarpaulin
-
-      - name: Run tarpaulin
-        run: cargo tarpaulin --workspace --features annex-b,intl_bundled,experimental --ignore-tests --engine llvm --out xml
-
-      - name: Upload to codecov.io
-        uses: codecov/codecov-action@v5
-
-  tests:
-    name: Test
-    runs-on: ${{ matrix.os }}
-    timeout-minutes: 60
-    env:
-      RUSTUP_WINDOWS_PATH_ADD_BIN: 1
-    strategy:
-      matrix:
-        include:
-          - os: macos-14
-          - os: windows-latest
-          - os: ubuntu-24.04-arm
-          - os: ubuntu-latest
-    steps:
-      - name: Set environment
-        if: ${{ matrix.os != 'windows-latest' }}
-        # Setting `RUSTFLAGS` overrides any flags set on .cargo/config.toml, so we need to
-        # set the target flags instead which are cumulative.
-        # Track https://github.com/rust-lang/cargo/issues/5376
-        run: |
-          target=$(rustc -vV | awk '/^host/ { print $2 }' | tr '[:lower:]' '[:upper:]' | tr '-' '_')
-          echo "CARGO_TARGET_${target}_RUSTFLAGS=$W_FLAGS" >> $GITHUB_ENV
-      - name: Set environment
-        if: ${{ matrix.os == 'windows-latest' }}
-        run: |
-          $target = (rustc -vV | Select-String '^host') -replace '^host:\s+', '' | ForEach-Object { $_.ToUpper().Replace('-', '_') }
-          "CARGO_TARGET_${target}_RUSTFLAGS=$env:W_FLAGS" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
-
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: stable
-
-      - name: Install Cargo insta
-        run: cargo install --locked cargo-insta
-
-      - name: Cache cargo
-        uses: actions/cache@v5
-        with:
-          path: |
-            target
-            ~/.cargo/git
-            ~/.cargo/registry
-          key: ${{ matrix.os }}-${{ runner.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: Build tests
-        run: cargo test --no-run --profile ci
-      # this order is faster according to rust-analyzer
-      - name: Build
-        run: cargo build --all-targets --quiet --profile ci --features annex-b,intl_bundled,experimental,embedded_lz4
-      - name: Install latest nextest
-        uses: taiki-e/install-action@nextest
-      - name: Test with nextest
-        run: cargo nextest run --profile ci --cargo-profile ci --features annex-b,intl_bundled,experimental,embedded_lz4
-      - name: Test docs
-        run: cargo test --doc --profile ci --features annex-b,intl_bundled,experimental
-      - name: Test bytecode output
-        run: cargo insta test -p insta-bytecode
-
-  cross-tests:
-    name: Test
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    strategy:
-      matrix:
-        include:
-          - target: i686-unknown-linux-gnu
-    steps:
-      - name: Set environment
-        # Setting `RUSTFLAGS` overrides any flags set on .cargo/config.toml, so we need to
-        # set the target flags instead which are cumulative.
-        # Track https://github.com/rust-lang/cargo/issues/5376
-        run: |
-          target=$(echo ${{ matrix.target }} | tr [:lower:] [:upper:] | tr '-' '_')
-          echo "CARGO_TARGET_${target}_RUSTFLAGS=$W_FLAGS" >> $GITHUB_ENV
-
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: stable
-          target: ${{ matrix.target }}
-
-      - name: Install Cross
-        uses: baptiste0928/cargo-install@v3.4.0
-        with:
-          crate: cross
-          git: https://github.com/cross-rs/cross
-
-      - name: Cache cargo
-        uses: actions/cache@v5
-        with:
-          path: |
-            target
-            ~/.cargo/git
-            ~/.cargo/registry
-          key: ${{ matrix.target }}-${{ runner.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: Run tests
-        run: |
-          cross test --workspace --target ${{ matrix.target }} \
-            --profile ci \
-            --features annex-b,intl_bundled,experimental \
-            --exclude boa_macros \
-            --exclude boa_macros_tests
-
-  miri:
-    name: Miri
-    runs-on: ubuntu-latest
-    timeout-minutes: 120
-    steps:
-      - name: Set environment
-        # Setting `RUSTFLAGS` overrides any flags set on .cargo/config.toml, so we need to
-        # set the target flags instead which are cumulative.
-        # Track https://github.com/rust-lang/cargo/issues/5376
-        run: |
-          target=$(rustc -vV | awk '/^host/ { print $2 }' | tr [:lower:] [:upper:] | tr '-' '_')
-          echo "CARGO_TARGET_${target}_RUSTFLAGS=$W_FLAGS" >> $GITHUB_ENV
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - name: Install Rust nightly with miri
-        uses: dtolnay/rust-toolchain@nightly
-        with:
-          components: miri
-
-      - name: Cache cargo
-        uses: actions/cache@v5
-        with:
-          path: |
-            target
-            ~/.cargo/git
-            ~/.cargo/registry
-          key: ${{ runner.os }}-${{ runner.arch }}-cargo-miri-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: Setup miri
-        run: cargo miri setup
-
-      - name: Run miri tests
-        run: cargo miri test --workspace --exclude boa_cli --exclude boa_examples miri
-
-  msrv:
-    name: MSRV
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    steps:
-      - name: Set environment
-        run: |
-          target=$(rustc -vV | awk '/^host/ { print $2 }' | tr [:lower:] [:upper:] | tr '-' '_')
-          echo "CARGO_TARGET_${target}_RUSTFLAGS=$W_FLAGS" >> $GITHUB_ENV
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      # Get the rust_version from the Cargo.toml
-      - name: Get rust_version
-        id: rust_version
-        run: echo "rust_version=$(grep '^rust-version' Cargo.toml | cut -d' ' -f3 | tr -d '"')" >> $GITHUB_OUTPUT
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: ${{ steps.rust_version.outputs.rust_version }}
-
-      - name: Check compilation
-        run: cargo check --all-features --all-targets
-
   fmt:
     name: Formatting
     runs-on: ubuntu-latest
@@ -334,10 +124,250 @@ jobs:
       - name: Generate documentation
         run: cargo doc -v --document-private-items --all-features
 
+  msrv:
+    name: MSRV
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Set environment
+        run: |
+          target=$(rustc -vV | awk '/^host/ { print $2 }' | tr [:lower:] [:upper:] | tr '-' '_')
+          echo "CARGO_TARGET_${target}_RUSTFLAGS=$W_FLAGS" >> $GITHUB_ENV
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      # Get the rust_version from the Cargo.toml
+      - name: Get rust_version
+        id: rust_version
+        run: echo "rust_version=$(grep '^rust-version' Cargo.toml | cut -d' ' -f3 | tr -d '"')" >> $GITHUB_OUTPUT
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ steps.rust_version.outputs.rust_version }}
+
+      - name: Check compilation
+        run: cargo check --all-features --all-targets
+
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    if: ${{ github.ref == 'refs/heads/main' || github.base_ref == 'main' }}
+    needs:
+      - fmt
+      - typos
+      - clippy
+      - docs
+      - msrv
+    steps:
+      - name: Set environment
+        # Setting `RUSTFLAGS` overrides any flags set on .cargo/config.toml, so we need to
+        # set the target flags instead which are cumulative.
+        # Track https://github.com/rust-lang/cargo/issues/5376
+        run: |
+          target=$(rustc -vV | awk '/^host/ { print $2 }' | tr [:lower:] [:upper:] | tr '-' '_')
+          echo "CARGO_TARGET_${target}_RUSTFLAGS=$W_FLAGS" >> $GITHUB_ENV
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: actions/cache@v5
+        with:
+          path: |
+            target
+            ~/.cargo/git
+            ~/.cargo/registry
+          key: ${{ runner.os }}-${{ runner.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Install cargo-tarpaulin
+        uses: baptiste0928/cargo-install@v3.4.0
+        with:
+          crate: cargo-tarpaulin
+
+      - name: Run tarpaulin
+        run: cargo tarpaulin --workspace --features annex-b,intl_bundled,experimental --ignore-tests --engine llvm --out xml
+
+      - name: Upload to codecov.io
+        uses: codecov/codecov-action@v5
+
+  tests:
+    name: Test
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    needs:
+      - fmt
+      - typos
+      - clippy
+      - docs
+      - msrv
+    env:
+      RUSTUP_WINDOWS_PATH_ADD_BIN: 1
+    strategy:
+      matrix:
+        include:
+          - os: macos-14
+          - os: windows-latest
+          - os: ubuntu-24.04-arm
+          - os: ubuntu-latest
+    steps:
+      - name: Set environment
+        if: ${{ matrix.os != 'windows-latest' }}
+        # Setting `RUSTFLAGS` overrides any flags set on .cargo/config.toml, so we need to
+        # set the target flags instead which are cumulative.
+        # Track https://github.com/rust-lang/cargo/issues/5376
+        run: |
+          target=$(rustc -vV | awk '/^host/ { print $2 }' | tr '[:lower:]' '[:upper:]' | tr '-' '_')
+          echo "CARGO_TARGET_${target}_RUSTFLAGS=$W_FLAGS" >> $GITHUB_ENV
+      - name: Set environment
+        if: ${{ matrix.os == 'windows-latest' }}
+        run: |
+          $target = (rustc -vV | Select-String '^host') -replace '^host:\s+', '' | ForEach-Object { $_.ToUpper().Replace('-', '_') }
+          "CARGO_TARGET_${target}_RUSTFLAGS=$env:W_FLAGS" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+
+      - name: Install Cargo insta
+        run: cargo install --locked cargo-insta
+
+      - name: Cache cargo
+        uses: actions/cache@v5
+        with:
+          path: |
+            target
+            ~/.cargo/git
+            ~/.cargo/registry
+          key: ${{ matrix.os }}-${{ runner.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Build tests
+        run: cargo test --no-run --profile ci
+      # this order is faster according to rust-analyzer
+      - name: Build
+        run: cargo build --all-targets --quiet --profile ci --features annex-b,intl_bundled,experimental,embedded_lz4
+      - name: Install latest nextest
+        uses: taiki-e/install-action@nextest
+      - name: Test with nextest
+        run: cargo nextest run --profile ci --cargo-profile ci --features annex-b,intl_bundled,experimental,embedded_lz4
+      - name: Test docs
+        run: cargo test --doc --profile ci --features annex-b,intl_bundled,experimental
+      - name: Test bytecode output
+        run: cargo insta test -p insta-bytecode
+
+  cross-tests:
+    name: Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    needs:
+      - fmt
+      - typos
+      - clippy
+      - docs
+      - msrv
+    strategy:
+      matrix:
+        include:
+          - target: i686-unknown-linux-gnu
+    steps:
+      - name: Set environment
+        # Setting `RUSTFLAGS` overrides any flags set on .cargo/config.toml, so we need to
+        # set the target flags instead which are cumulative.
+        # Track https://github.com/rust-lang/cargo/issues/5376
+        run: |
+          target=$(echo ${{ matrix.target }} | tr [:lower:] [:upper:] | tr '-' '_')
+          echo "CARGO_TARGET_${target}_RUSTFLAGS=$W_FLAGS" >> $GITHUB_ENV
+
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          target: ${{ matrix.target }}
+
+      - name: Install Cross
+        uses: baptiste0928/cargo-install@v3.4.0
+        with:
+          crate: cross
+          git: https://github.com/cross-rs/cross
+
+      - name: Cache cargo
+        uses: actions/cache@v5
+        with:
+          path: |
+            target
+            ~/.cargo/git
+            ~/.cargo/registry
+          key: ${{ matrix.target }}-${{ runner.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Run tests
+        run: |
+          cross test --workspace --target ${{ matrix.target }} \
+            --profile ci \
+            --features annex-b,intl_bundled,experimental \
+            --exclude boa_macros \
+            --exclude boa_macros_tests
+
+  miri:
+    name: Miri
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    needs:
+      - fmt
+      - typos
+      - clippy
+      - docs
+      - msrv
+    steps:
+      - name: Set environment
+        # Setting `RUSTFLAGS` overrides any flags set on .cargo/config.toml, so we need to
+        # set the target flags instead which are cumulative.
+        # Track https://github.com/rust-lang/cargo/issues/5376
+        run: |
+          target=$(rustc -vV | awk '/^host/ { print $2 }' | tr [:lower:] [:upper:] | tr '-' '_')
+          echo "CARGO_TARGET_${target}_RUSTFLAGS=$W_FLAGS" >> $GITHUB_ENV
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Install Rust nightly with miri
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: miri
+
+      - name: Cache cargo
+        uses: actions/cache@v5
+        with:
+          path: |
+            target
+            ~/.cargo/git
+            ~/.cargo/registry
+          key: ${{ runner.os }}-${{ runner.arch }}-cargo-miri-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Setup miri
+        run: cargo miri setup
+
+      - name: Run miri tests
+        run: cargo miri test --workspace --exclude boa_cli --exclude boa_examples miri
+
   build-fuzz:
     name: Fuzzing
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    needs:
+      - fmt
+      - typos
+      - clippy
+      - docs
+      - msrv
     steps:
       - name: Set environment
         run: |
@@ -370,6 +400,12 @@ jobs:
     name: Build & run examples
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    needs:
+      - fmt
+      - typos
+      - clippy
+      - docs
+      - msrv
     steps:
       - name: Set environment
         run: |
@@ -411,6 +447,12 @@ jobs:
     name: Check SemVer compatibility
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    needs:
+      - fmt
+      - typos
+      - clippy
+      - docs
+      - msrv
     steps:
       - name: Set environment
         run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -122,7 +122,7 @@ jobs:
         run: cargo insta test -p insta-bytecode
 
   cross-tests:
-    name: Test with Cross
+    name: Test
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -122,7 +122,7 @@ jobs:
         run: cargo insta test -p insta-bytecode
 
   cross-tests:
-    name: Test
+    name: Test with Cross
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
@@ -167,7 +167,8 @@ jobs:
           cross test --workspace --target ${{ matrix.target }} \
             --profile ci \
             --features annex-b,intl_bundled,experimental \
-            --exclude boa_macros,boa_macros_tests
+            --exclude boa_macros \
+            --exclude boa_macros_tests
 
   miri:
     name: Miri

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -82,7 +82,7 @@ jobs:
           target=$(rustc -vV | awk '/^host/ { print $2 }' | tr '[:lower:]' '[:upper:]' | tr '-' '_')
           echo "CARGO_TARGET_${target}_RUSTFLAGS=$W_FLAGS" >> $GITHUB_ENV
       - name: Set environment
-        if: ${{ matrix.os == "windows-latest" }}
+        if: ${{ matrix.os == 'windows-latest' }}
         run: |
           $target = (rustc -vV | Select-String '^host') -replace '^host:\s+', '' | ForEach-Object { $_.ToUpper().Replace('-', '_') }
           "CARGO_TARGET_${target}_RUSTFLAGS=$env:W_FLAGS" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8

--- a/core/gc/src/test/mod.rs
+++ b/core/gc/src/test/mod.rs
@@ -12,36 +12,42 @@ struct Harness;
 impl Harness {
     #[track_caller]
     fn assert_collections(o: usize) {
-        BOA_GC.with(|current| {
+        let collections = BOA_GC.with(|current| {
             let gc = current.borrow();
-            assert_eq!(gc.runtime.collections, o);
+            gc.runtime.collections
         });
+
+        assert_eq!(collections, o);
     }
 
     #[track_caller]
     fn assert_empty_gc() {
-        BOA_GC.with(|current| {
+        let (is_empty, bytes_allocated) = BOA_GC.with(|current| {
             let gc = current.borrow();
-
-            assert!(gc.strongs.is_empty());
-            assert!(gc.runtime.bytes_allocated == 0);
+            (gc.strongs.is_empty(), gc.runtime.bytes_allocated)
         });
+
+        assert!(is_empty);
+        assert_eq!(bytes_allocated, 0);
     }
 
     #[track_caller]
     fn assert_bytes_allocated() {
-        BOA_GC.with(|current| {
+        let bytes_allocated = BOA_GC.with(|current| {
             let gc = current.borrow();
-            assert!(gc.runtime.bytes_allocated > 0);
+            gc.runtime.bytes_allocated
         });
+
+        assert!(bytes_allocated > 0);
     }
 
     #[track_caller]
     fn assert_exact_bytes_allocated(bytes: usize) {
-        BOA_GC.with(|current| {
+        let bytes_allocated = BOA_GC.with(|current| {
             let gc = current.borrow();
-            assert_eq!(gc.runtime.bytes_allocated, bytes);
+            gc.runtime.bytes_allocated
         });
+        assert_eq!(bytes_allocated, bytes);
     }
 }
 

--- a/core/gc/src/test/weak.rs
+++ b/core/gc/src/test/weak.rs
@@ -161,12 +161,13 @@ mod miri {
             Harness::assert_exact_bytes_allocated(root_size);
 
             {
+                let eph_size = size_of::<EphemeronBox<InnerCell, TestCell>>();
                 // Generate a self-referential ephemeron
                 let eph = Ephemeron::new(&root.inner, root.clone());
                 *root.inner.inner.borrow_mut() = Some(eph.clone());
 
                 assert!(eph.value().is_some());
-                Harness::assert_exact_bytes_allocated(56);
+                Harness::assert_exact_bytes_allocated(root_size + eph_size);
             }
 
             *root.inner.inner.borrow_mut() = None;
@@ -190,8 +191,10 @@ mod miri {
             Harness::assert_exact_bytes_allocated(root_size);
 
             let watched = Gc::new(0);
+            let watched_size = size_of::<GcBox<u8>>();
 
             {
+                let eph_size = size_of::<EphemeronBox<u8, TestCell>>();
                 // Generate a self-referential loop of weak and non-weak pointers
                 let chain1 = TestCell {
                     inner: Gc::new(GcRefCell::new(None)),
@@ -212,7 +215,7 @@ mod miri {
 
                 assert!(eph_start.value().is_some());
                 assert!(eph_chain2.value().is_some());
-                Harness::assert_exact_bytes_allocated(168);
+                Harness::assert_exact_bytes_allocated(watched_size + 3 * root_size + 2 * eph_size);
             }
 
             *root.borrow_mut() = None;


### PR DESCRIPTION
This PR:
- Adds a new job that tests against `i686-unknown-linux-gnu` to check that any assumptions we do are also valid for 32-bit targets.
- Cleans up our PR action file to avoid running any build/test jobs if the lint/fmt/typos/docs checks failed. 
