### PR TITLE
feat(vm): emit `Opcode::Debugger` for `debugger;` statements

### DIFF
--- a/core/engine/src/bytecompiler/statement/mod.rs
+++ b/core/engine/src/bytecompiler/statement/mod.rs
@@ -98,7 +98,10 @@ impl ByteCompiler<'_> {
                 }
             }
             Statement::With(with) => self.compile_with(with, use_expr),
-            Statement::Empty | Statement::Debugger => {}
+            Statement::Empty => {}
+            Statement::Debugger => {
+                self.bytecode.emit_debugger();
+            }
         }
     }
 

--- a/core/engine/src/vm/code_block.rs
+++ b/core/engine/src/vm/code_block.rs
@@ -858,7 +858,8 @@ impl CodeBlock {
             | Instruction::SuperCallSpread
             | Instruction::PopPrivateEnvironment
             | Instruction::Generator
-            | Instruction::AsyncGenerator => String::new(),
+            | Instruction::AsyncGenerator
+            | Instruction::Debugger => String::new(),
             Instruction::Reserved1
             | Instruction::Reserved2
             | Instruction::Reserved3
@@ -917,8 +918,7 @@ impl CodeBlock {
             | Instruction::Reserved56
             | Instruction::Reserved57
             | Instruction::Reserved58
-            | Instruction::Reserved59
-            | Instruction::Reserved60 => unreachable!("Reserved opcodes are unreachable"),
+            | Instruction::Reserved59 => unreachable!("Reserved opcodes are unreachable"),
         }
     }
 }

--- a/core/engine/src/vm/flowgraph/mod.rs
+++ b/core/engine/src/vm/flowgraph/mod.rs
@@ -432,8 +432,11 @@ impl CodeBlock {
                 | Instruction::Reserved56
                 | Instruction::Reserved57
                 | Instruction::Reserved58
-                | Instruction::Reserved59
-                | Instruction::Reserved60 => unreachable!("Reserved opcodes are unreachable"),
+                | Instruction::Reserved59 => unreachable!("Reserved opcodes are unreachable"),
+                Instruction::Debugger => {
+                    graph.add_node(previous_pc, NodeShape::None, label.into(), Color::None);
+                    graph.add_edge(previous_pc, pc, None, Color::None, EdgeStyle::Line);
+                }
             }
         }
 

--- a/core/engine/src/vm/opcode/debugger/mod.rs
+++ b/core/engine/src/vm/opcode/debugger/mod.rs
@@ -1,0 +1,20 @@
+use crate::{Context, vm::opcode::Operation};
+
+/// `Debugger` implements the Opcode Operation for `Opcode::Debugger`
+///
+/// Operation:
+///  - No-op for now. Emitted for `debugger;` statements so they are
+///    represented in bytecode and visible during tracing.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct Debugger;
+
+impl Debugger {
+    #[inline(always)]
+    pub(super) fn operation((): (), _: &mut Context) {}
+}
+
+impl Operation for Debugger {
+    const NAME: &'static str = "Debugger";
+    const INSTRUCTION: &'static str = "INST - Debugger";
+    const COST: u8 = 1;
+}

--- a/core/engine/src/vm/opcode/mod.rs
+++ b/core/engine/src/vm/opcode/mod.rs
@@ -18,6 +18,7 @@ mod call;
 mod concat;
 mod control_flow;
 mod copy;
+mod debugger;
 mod define;
 mod delete;
 mod environment;
@@ -54,6 +55,8 @@ pub(crate) use concat::*;
 pub(crate) use control_flow::*;
 #[doc(inline)]
 pub(crate) use copy::*;
+#[doc(inline)]
+pub(crate) use debugger::*;
 #[doc(inline)]
 pub(crate) use define::*;
 #[doc(inline)]
@@ -2141,6 +2144,18 @@ generate_opcodes! {
     ///   - Output: dst
     CreateUnmappedArgumentsObject { dst: RegisterOperand },
 
+    /// The `debugger` statement.
+    ///
+    /// Currently a no-op. This opcode is emitted for `debugger;` statements
+    /// so they are represented in the bytecode, enabling future debugger
+    /// integration to intercept them.
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-debugger-statement
+    Debugger,
+
     /// Reserved [`Opcode`].
     Reserved1 => Reserved,
     /// Reserved [`Opcode`].
@@ -2259,6 +2274,4 @@ generate_opcodes! {
     Reserved58 => Reserved,
     /// Reserved [`Opcode`].
     Reserved59 => Reserved,
-    /// Reserved [`Opcode`].
-    Reserved60 => Reserved,
 }


### PR DESCRIPTION
## Summary

Adds a dedicated `Opcode::Debugger` that the bytecompiler emits for `debugger;` statements. Previously these were silently ignored (empty match arm in the bytecompiler); now they are represented in bytecode and visible during tracing.

Currently a no-op — this lays groundwork for future debugger integration to intercept these points.

**Before:** `debugger;` produced no bytecode at all

**After:**
```
Location     Opcode        Operands
  000000     Debugger
  000001     PushOne       dst:r02
  ...
```

## Changes

- **`vm/opcode/mod.rs`** — new `Debugger` variant in `generate_opcodes!`, module declaration and re-export
- **`vm/opcode/debugger/mod.rs`** — new file, no-op operation implementation
- **`bytecompiler/statement/mod.rs`** — emit `Debugger` opcode instead of ignoring the statement
- **`vm/flowgraph/mod.rs`** — handle `Instruction::Debugger` in flowgraph generation
- **`vm/code_block.rs`** — handle `Instruction::Debugger` in operand display

## Test plan

- `cargo check` and `cargo check --features trace` pass
- `cargo test -p boa_engine` — all 183 tests pass, zero regressions
- `cargo test -p insta-bytecode` — bytecode snapshot tests pass
- Verified `debugger;` appears in trace output via `boa -t -e 'debugger; 1+1;'`
