### PR TITLE
Refactor parser error context API by implementing `ErrorContext` for `Error`

### DIFF
--- a/core/parser/src/error/mod.rs
+++ b/core/parser/src/error/mod.rs
@@ -197,7 +197,6 @@ impl fmt::Display for Error {
                 span,
                 ..
             } => {
-                let context = self.context().expect("expected errors always have context");
                 write!(f, "expected ")?;
                 match &**expected {
                     [single] => write!(f, "token '{single}'")?,
@@ -215,12 +214,21 @@ impl fmt::Display for Error {
                         }
                     }
                 }
-                write!(
-                    f,
-                    ", got '{found}' in {context} at line {}, col {}",
-                    span.start().line_number(),
-                    span.start().column_number()
-                )
+                if let Some(context) = self.context() {
+                    write!(
+                        f,
+                        ", got '{found}' in {context} at line {}, col {}",
+                        span.start().line_number(),
+                        span.start().column_number()
+                    )
+                } else {
+                    write!(
+                        f,
+                        ", got '{found}' at line {}, col {}",
+                        span.start().line_number(),
+                        span.start().column_number()
+                    )
+                }
             }
             Self::Unexpected {
                 found,

--- a/core/parser/src/error/mod.rs
+++ b/core/parser/src/error/mod.rs
@@ -16,7 +16,6 @@ pub(crate) trait ErrorContext {
     fn set_context(self, context: &'static str) -> Self;
 
     /// Gets the context of the error, if any.
-    #[allow(dead_code)]
     fn context(&self) -> Option<&'static str>;
 }
 
@@ -26,7 +25,29 @@ impl<T> ErrorContext for ParseResult<T> {
     }
 
     fn context(&self) -> Option<&'static str> {
-        self.as_ref().err().and_then(Error::context)
+        self.as_ref().err().and_then(ErrorContext::context)
+    }
+}
+
+impl ErrorContext for Error {
+    fn set_context(self, new_context: &'static str) -> Self {
+        match self {
+            Self::Expected {
+                expected,
+                found,
+                span,
+                ..
+            } => Self::expected(expected, found, span, new_context),
+            e => e,
+        }
+    }
+
+    fn context(&self) -> Option<&'static str> {
+        if let Self::Expected { context, .. } = self {
+            Some(context)
+        } else {
+            None
+        }
     }
 }
 
@@ -93,29 +114,6 @@ pub enum Error {
 }
 
 impl Error {
-    /// Changes the context of the error, if any.
-    fn set_context(self, new_context: &'static str) -> Self {
-        match self {
-            Self::Expected {
-                expected,
-                found,
-                span,
-                ..
-            } => Self::expected(expected, found, span, new_context),
-            e => e,
-        }
-    }
-
-    /// Gets the context of the error, if any.
-    #[allow(unused)] // TODO: context method is unused, candidate for removal?
-    const fn context(&self) -> Option<&'static str> {
-        if let Self::Expected { context, .. } = self {
-            Some(context)
-        } else {
-            None
-        }
-    }
-
     /// Creates an `Expected` parsing error.
     pub(crate) fn expected<E, F>(expected: E, found: F, span: Span, context: &'static str) -> Self
     where
@@ -197,8 +195,9 @@ impl fmt::Display for Error {
                 expected,
                 found,
                 span,
-                context,
+                ..
             } => {
+                let context = self.context().expect("expected errors always have context");
                 write!(f, "expected ")?;
                 match &**expected {
                     [single] => write!(f, "token '{single}'")?,


### PR DESCRIPTION
 Summary

This PR refactors parser error context handling by making `Error` implement `ErrorContext` directly and removing duplicate inherent methods.

Closes #5094.

 What changed

- Implemented `ErrorContext` for `Error`.
- Kept `ParseResult<T>` using the same trait-based API.
- Removed redundant `Error::set_context` and `Error::context` inherent methods.
- Removed outdated dead-code/unused noise tied to the old duplicated methods.
- Kept behavior unchanged (refactor only).

 Why

`set_context` and `context` were not actually dead code, but the previous structure and comments suggested they might be.  
This makes the API consistent and clearer: both `Error` and `ParseResult<T>` use `ErrorContext`.

 Testing

- `cargo test -p boa_parser error::tests`
- `cargo test -p boa_parser`

Both passed.

