### PR TITLE
fix(intl): add @@toStringTag to Intl.DateTimeFormat.prototype

### DIFF
--- a/core/engine/src/builtins/intl/date_time_format/mod.rs
+++ b/core/engine/src/builtins/intl/date_time_format/mod.rs
@@ -101,6 +101,7 @@ impl Service for DateTimeFormat {
 
 impl IntrinsicObject for DateTimeFormat {
     fn init(realm: &Realm) {
+        use crate::JsSymbol;
         let get_format = BuiltInBuilder::callable(realm, Self::get_format)
             .name(js_string!("get format"))
             .build();
@@ -118,6 +119,11 @@ impl IntrinsicObject for DateTimeFormat {
                 Attribute::CONFIGURABLE,
             )
             .method(Self::resolved_options, js_string!("resolvedOptions"), 0)
+            .property(
+                JsSymbol::to_string_tag(),
+                js_string!("Intl.DateTimeFormat"),
+                Attribute::READONLY | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE,
+            )
             .build();
     }
 
@@ -132,7 +138,7 @@ impl BuiltInObject for DateTimeFormat {
 
 impl BuiltInConstructor for DateTimeFormat {
     const CONSTRUCTOR_ARGUMENTS: usize = 0;
-    const PROTOTYPE_STORAGE_SLOTS: usize = 3;
+    const PROTOTYPE_STORAGE_SLOTS: usize = 4;
     const CONSTRUCTOR_STORAGE_SLOTS: usize = 1;
 
     const STANDARD_CONSTRUCTOR: fn(&StandardConstructors) -> &StandardConstructor =


### PR DESCRIPTION
**Adds the missing `@@toStringTag` property to `Intl.DateTimeFormat.prototype`.**

According to ECMA-402 11.3.2, 
The initial value of the [@@toStringTag](https://tc39.es/ecma262/#sec-well-known-symbols) property is the String value "Intl.DateTimeFormat". This property has the attributes { [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: true }.

This was missing from the `IntrinsicObject::init` registration, causing
`Object.prototype.toString.call(new Intl.DateTimeFormat())` to return
<img width="1047" height="76" alt="image" src="https://github.com/user-attachments/assets/6c194070-00cc-496f-9a5d-da0618df5ab0" />