### PR TITLE
Enable oscars behind feature flags in boa_gc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -520,6 +520,7 @@ dependencies = [
  "either",
  "hashbrown 0.16.1",
  "icu_locale_core",
+ "oscars",
  "thin-vec",
 ]
 
@@ -3113,6 +3114,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "oscars"
+version = "0.1.0"
+source = "git+https://github.com/boa-dev/oscars.git?branch=main#a47bfba6fd06194eedffd58d37037ae8b34d8ff4"
+dependencies = [
+ "hashbrown 0.16.1",
+ "oscars_derive",
+ "rustc-hash 2.1.1",
+]
+
+[[package]]
+name = "oscars_derive"
+version = "0.1.0"
+source = "git+https://github.com/boa-dev/oscars.git?branch=main#a47bfba6fd06194eedffd58d37037ae8b34d8ff4"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3119,7 +3119,7 @@ dependencies = [
 [[package]]
 name = "oscars"
 version = "0.1.0"
-source = "git+https://github.com/boa-dev/oscars.git?branch=main#a47bfba6fd06194eedffd58d37037ae8b34d8ff4"
+source = "git+https://github.com/boa-dev/oscars.git?rev=d4864e7#d4864e7a6245139adc6eeac85a9f2b651d5937c3"
 dependencies = [
  "hashbrown 0.16.1",
  "oscars_derive",
@@ -3129,7 +3129,7 @@ dependencies = [
 [[package]]
 name = "oscars_derive"
 version = "0.1.0"
-source = "git+https://github.com/boa-dev/oscars.git?branch=main#a47bfba6fd06194eedffd58d37037ae8b34d8ff4"
+source = "git+https://github.com/boa-dev/oscars.git?rev=d4864e7#d4864e7a6245139adc6eeac85a9f2b651d5937c3"
 dependencies = [
  "cfg-if",
  "proc-macro2",

--- a/core/gc/Cargo.toml
+++ b/core/gc/Cargo.toml
@@ -22,9 +22,6 @@ either = ["dep:either"]
 # Enable default implementations of trace and finalize for the arrayvec crate
 arrayvec = ["dep:arrayvec"]
 
-experimental_mark_sweep = ["oscars", "oscars/mark_sweep"]
-experimental_mark_sweep2 = ["oscars", "oscars/mark_sweep2"]
-
 oscars = ["dep:oscars", "unstable"]
 
 # Unstable feature

--- a/core/gc/Cargo.toml
+++ b/core/gc/Cargo.toml
@@ -22,6 +22,14 @@ either = ["dep:either"]
 # Enable default implementations of trace and finalize for the arrayvec crate
 arrayvec = ["dep:arrayvec"]
 
+experimental_mark_sweep = ["oscars", "oscars/mark_sweep"]
+experimental_mark_sweep2 = ["oscars", "oscars/mark_sweep2"]
+
+oscars = ["dep:oscars", "unstable"]
+
+# Unstable feature
+unstable = []
+
 [dependencies]
 boa_macros.workspace = true
 hashbrown.workspace = true
@@ -31,6 +39,8 @@ either = { workspace = true, optional = true }
 thin-vec = { workspace = true, optional = true }
 icu_locale_core = { workspace = true, optional = true }
 arrayvec = { workspace = true, optional = true }
+oscars = { git = "https://github.com/boa-dev/oscars.git", rev = "d4864e7", optional = true }
+
 
 [lints]
 workspace = true

--- a/core/gc/src/lib.rs
+++ b/core/gc/src/lib.rs
@@ -17,6 +17,11 @@
 
 extern crate self as boa_gc;
 
+#[cfg(feature = "oscars")]
+pub mod oscars {
+    use oscars::*;
+}
+
 mod cell;
 mod pointers;
 mod trace;

--- a/core/gc/src/lib.rs
+++ b/core/gc/src/lib.rs
@@ -18,9 +18,7 @@
 extern crate self as boa_gc;
 
 #[cfg(feature = "oscars")]
-pub mod oscars {
-    use oscars::*;
-}
+pub use oscars;
 
 mod cell;
 mod pointers;


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This PR adds an `unstable` and `oscars` feature flag and re-exports the oscars repo from `boa_gc`.