### PR TITLE
normalize header values in Headers

### DIFF
--- a/core/runtime/src/fetch/headers.rs
+++ b/core/runtime/src/fetch/headers.rs
@@ -29,25 +29,10 @@ fn to_header_name(key: impl AsRef<str>) -> JsResult<HeaderName> {
         .map_err(|_| js_error!("Cannot convert key to header string as it is not valid ASCII."))
 }
 
-/// Converts a JavaScript string to a valid header value (or error).
-///
-/// # Errors
-/// If the value is not valid ASCII, an error is returned.
+/// Trims leading and trailing HTTP whitespace from a header value.
 #[inline]
 fn normalize_header_value(value: &str) -> &str {
-    let bytes = value.as_bytes();
-
-    let mut start = 0;
-    while start < bytes.len() && matches!(bytes[start], b'\t' | b'\n' | b'\r' | b' ') {
-        start += 1;
-    }
-
-    let mut end = bytes.len();
-    while end > start && matches!(bytes[end - 1], b'\t' | b'\n' | b'\r' | b' ') {
-        end -= 1;
-    }
-
-    &value[start..end]
+    value.trim_matches(|ch| matches!(ch, '\t' | '\n' | '\r' | ' '))
 }
 
 /// Converts a JavaScript string to a valid header value (or error).

--- a/core/runtime/src/fetch/headers.rs
+++ b/core/runtime/src/fetch/headers.rs
@@ -32,7 +32,7 @@ fn to_header_name(key: impl AsRef<str>) -> JsResult<HeaderName> {
 /// Trims leading and trailing HTTP whitespace from a header value.
 #[inline]
 fn normalize_header_value(value: &str) -> &str {
-    value.trim_matches(|ch| matches!(ch, '\t' | '\n' | '\r' | ' '))
+    value.trim_matches(['\t', '\n', '\r', ' '])
 }
 
 /// Converts a JavaScript string to a valid header value (or error).

--- a/core/runtime/src/fetch/headers.rs
+++ b/core/runtime/src/fetch/headers.rs
@@ -34,9 +34,29 @@ fn to_header_name(key: impl AsRef<str>) -> JsResult<HeaderName> {
 /// # Errors
 /// If the value is not valid ASCII, an error is returned.
 #[inline]
+fn normalize_header_value(value: &str) -> &str {
+    let bytes = value.as_bytes();
+
+    let mut start = 0;
+    while start < bytes.len() && matches!(bytes[start], b'\t' | b'\n' | b'\r' | b' ') {
+        start += 1;
+    }
+
+    let mut end = bytes.len();
+    while end > start && matches!(bytes[end - 1], b'\t' | b'\n' | b'\r' | b' ') {
+        end -= 1;
+    }
+
+    &value[start..end]
+}
+
+/// Converts a JavaScript string to a valid header value (or error).
+///
+/// # Errors
+/// If the value is not valid ASCII, an error is returned.
+#[inline]
 fn to_header_value(value: impl AsRef<str>) -> JsResult<HeaderValue> {
-    value
-        .as_ref()
+    normalize_header_value(value.as_ref())
         .parse()
         .map_err(|_| js_error!("Cannot convert value to header string as it is not valid ASCII."))
 }

--- a/core/runtime/src/fetch/tests/headers.rs
+++ b/core/runtime/src/fetch/tests/headers.rs
@@ -24,3 +24,45 @@ fn headers_are_iterable() {
         ),
     ]);
 }
+
+#[test]
+fn headers_normalize_values() {
+    run_test_actions([
+        TestAction::harness(),
+        TestAction::inspect_context(register),
+        TestAction::run(
+            r#"
+                const expectations = {
+                    name1: [" space ", "space"],
+                    name2: ["\ttab\t", "tab"],
+                    name3: [" spaceAndTab\t", "spaceAndTab"],
+                    name4: ["\r\n newLine", "newLine"],
+                    name5: ["newLine\r\n ", "newLine"],
+                    name6: ["\r\n\tnewLine", "newLine"],
+                };
+
+                const fromObject = new Headers(
+                    Object.fromEntries(
+                        Object.entries(expectations).map(([name, [value]]) => [name, value]),
+                    ),
+                );
+
+                for (const [name, [, expected]] of Object.entries(expectations)) {
+                    assertEq(fromObject.get(name), expected, `constructor should normalize ${name}`);
+                }
+
+                const appended = new Headers();
+                for (const [name, [value, expected]] of Object.entries(expectations)) {
+                    appended.append(name, value);
+                    assertEq(appended.get(name), expected, `append should normalize ${name}`);
+                }
+
+                const setHeaders = new Headers();
+                for (const [name, [value, expected]] of Object.entries(expectations)) {
+                    setHeaders.set(name, value);
+                    assertEq(setHeaders.get(name), expected, `set should normalize ${name}`);
+                }
+            "#,
+        ),
+    ]);
+}


### PR DESCRIPTION
Fixes #5114.

This normalizes header values before storing them in `Headers`, so the constructor, `append()`, and `set()` all trim leading and trailing HTTP whitespace the same way.

Tests:
- `cargo test -p boa_runtime headers --lib`
- `cargo test -p boa_runtime --lib`
