### PR TITLE
CI: Add manual workflow trigger (workflow_dispatch) to rust.yml

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,6 +11,7 @@ on:
       - releases/**
   merge_group:
     types: [checks_requested]
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request fixes/closes #5122.

It changes the following:

- Adds the `workflow_dispatch` trigger to the `Continuous integration` workflow ([.github/workflows/rust.yml](cci:7://file:///c:/Users/risha/Desktop/boa/.github/workflows/rust.yml:0:0-0:0))
- Allows developers to manually run the CI workflow from the GitHub Actions UI on specific branches
- Improves the ability to debug CI issues and re-run flaky test failures without needing to push empty commits
