### PR TITLE
CI: Add top-level permissions to workflows for least-privilege security

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -2,6 +2,9 @@ name: "Pull Request Labeler"
 on:
 - pull_request_target
 
+permissions:
+  contents: read
+
 jobs:
   labeler:
     permissions:

--- a/.github/workflows/pr_management.yml
+++ b/.github/workflows/pr_management.yml
@@ -4,6 +4,9 @@ on:
   pull_request_target:
     types: [opened, reopened, synchronize, closed]
 
+permissions:
+  contents: read
+
 jobs:
   manage_pr:
     runs-on: ubuntu-latest

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -6,6 +6,9 @@ on:
       - main
       - releases/**
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     name: Publish crates
@@ -88,6 +91,8 @@ jobs:
 
   release-binaries:
     name: Publish binaries
+    permissions:
+      contents: write
     needs: publish
     strategy:
       fail-fast: false

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,6 +12,9 @@ on:
   merge_group:
     types: [checks_requested]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/security_audit.yml
+++ b/.github/workflows/security_audit.yml
@@ -2,6 +2,9 @@ name: Security audit
 on:
   schedule:
     - cron: "0 0 * * *"
+
+permissions:
+  contents: read
 jobs:
   audit:
     runs-on: ubuntu-latest

--- a/.github/workflows/test262_pr.yml
+++ b/.github/workflows/test262_pr.yml
@@ -13,6 +13,9 @@ on:
       - main
       - releases/**
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
@@ -20,6 +23,9 @@ concurrency:
 jobs:
   run_test262:
     name: Run the test262 test suite
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:

--- a/.github/workflows/test262_release.yml
+++ b/.github/workflows/test262_release.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/webassembly.yml
+++ b/.github/workflows/webassembly.yml
@@ -12,6 +12,9 @@ on:
   merge_group:
     types: [checks_requested]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request fixes/closes #5124 .

It changes the following:

- Adds top-level `permissions: contents: read` to the `.github/workflows/` files.
- Enforces the GitHub-recommended principle of least privilege for the default `GITHUB_TOKEN`.
- Explicitly grants job-level write permissions (`contents: write`, `pull-requests: write`) only to the specific jobs that need to publish release binaries or post PR comments, ensuring CI pipelines do not break.
