### PR TITLE
CI: add greeting workflow for first-time contributors

### DIFF
--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -1,0 +1,29 @@
+name: Greetings
+
+on:
+  issues:
+    types: [opened]
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  greeting:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/first-interaction@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          issue-message: |
+            Welcome to the Boa project! 🎉 Thanks for opening your first issue! 
+            
+            We are a volunteer-run project, so we will try to get back to you as soon as possible.
+            In the meantime, feel free to check out our [documentation](https://boajs.dev/boa/doc/boa_engine/) or browse existing issues to see if this has been discussed before.
+          pr-message: |
+            Welcome to the Boa project! 🎉 Thanks for submitting your first pull request!
+            
+            We are a volunteer-run project, and we really appreciate your contribution. One of our maintainers will review your PR as soon as they can.
+            Before your PR is reviewed, please ensure you have read our [Contributing Guidelines](https://github.com/boa-dev/boa/blob/main/CONTRIBUTING.md) and that all CI checks pass.


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request fixes/closes #5126 .

It changes the following:

- Adds [.github/workflows/greetings.yml](cci:7://file:///c:/Users/risha/Desktop/boa/.github/workflows/greetings.yml:0:0-0:0).
- Automates welcome messages for first-time issue reporters with helpful documentation links.
- Automates welcome messages for first-time PR authors with contribution guidelines and expectations.
- Utilizes the official `actions/first-interaction@v1` action with safe, explicitly defined write permissions.
