### PR TITLE
CI: add workflow to cleanup PR caches on close

### DIFF
--- a/.github/workflows/cleanup-caches.yml
+++ b/.github/workflows/cleanup-caches.yml
@@ -1,0 +1,38 @@
+name: Cleanup PR Caches
+
+on:
+  pull_request:
+    types:
+      - closed
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+
+      - name: Cleanup
+        run: |
+          gh extension install actions/gh-actions-cache
+          
+          REPO=${{ github.repository }}
+          BRANCH="refs/pull/${{ github.event.pull_request.number }}/merge"
+
+          echo "Fetching list of cache key"
+          cacheKeysForPR=$(gh actions-cache list -R $REPO -B $BRANCH -L 100 | cut -f 1 )
+
+          ## Setting this to not fail the workflow while deleting cache keys. 
+          set +e
+          echo "Deleting caches..."
+          for cacheKey in $cacheKeysForPR
+          do
+              gh actions-cache delete $cacheKey -R $REPO -B $BRANCH --confirm
+          done
+          echo "Done"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request fixes/closes #5128 .

It changes the following:

- Adds [.github/workflows/cleanup-caches.yml](cci:7://file:///c:/Users/risha/Desktop/boa/.github/workflows/cleanup-caches.yml:0:0-0:0) workflow.
- Automatically deletes GitHub Actions caches scoped specifically to a pull request branch when that PR is closed or merged.
- Prevents orphaned PR caches from accumulating and exceeding the repository's 10 GB limit, reducing cache eviction churn.
- Uses the `gh actions-cache delete` CLI securely with `actions: write` scope.
