### PR TITLE
make TextEncoder utf-8 only

### DIFF
--- a/core/runtime/src/text/encodings.rs
+++ b/core/runtime/src/text/encodings.rs
@@ -22,15 +22,7 @@ pub(crate) mod utf8 {
 }
 
 pub(crate) mod utf16le {
-    use boa_engine::string::JsStrVariant;
     use boa_engine::{JsString, js_string};
-
-    pub(crate) fn encode(input: &JsString) -> Vec<u8> {
-        match input.as_str().variant() {
-            JsStrVariant::Latin1(l) => l.iter().flat_map(|c| [*c, 0]).collect(),
-            JsStrVariant::Utf16(s) => bytemuck::cast_slice(s).to_vec(),
-        }
-    }
 
     pub(crate) fn decode(mut input: &[u8], strip_bom: bool) -> JsString {
         if strip_bom {
@@ -56,15 +48,7 @@ pub(crate) mod utf16le {
 }
 
 pub(crate) mod utf16be {
-    use boa_engine::string::JsStrVariant;
     use boa_engine::{JsString, js_string};
-
-    pub(crate) fn encode(input: &JsString) -> Vec<u8> {
-        match input.as_str().variant() {
-            JsStrVariant::Latin1(l) => l.iter().flat_map(|c| [0, *c]).collect(),
-            JsStrVariant::Utf16(s) => s.iter().flat_map(|b| b.to_be_bytes()).collect::<Vec<_>>(),
-        }
-    }
 
     pub(crate) fn decode(mut input: Vec<u8>, strip_bom: bool) -> JsString {
         if strip_bom && input.starts_with(&[0xFE, 0xFF]) {

--- a/core/runtime/src/text/mod.rs
+++ b/core/runtime/src/text/mod.rs
@@ -6,8 +6,8 @@ use boa_engine::object::builtins::{JsArrayBuffer, JsDataView, JsTypedArray, JsUi
 use boa_engine::realm::Realm;
 use boa_engine::value::TryFromJs;
 use boa_engine::{
-    Context, Finalize, JsData, JsObject, JsResult, JsString, JsValue, Trace, boa_class, boa_module,
-    js_error, js_string,
+    Context, Finalize, JsData, JsResult, JsString, JsValue, Trace, boa_class, boa_module, js_error,
+    js_string,
 };
 
 #[cfg(test)]
@@ -171,42 +171,21 @@ impl TextDecoder {
     }
 }
 
-/// The `TextEncoder`[mdn] class represents an encoder for a specific method, that is
-/// a specific character encoding, like `utf-8`.
+/// The `TextEncoder`[mdn] class represents a UTF-8 encoder.
 ///
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/API/TextEncoder
 #[derive(Debug, Default, Clone, JsData, Trace, Finalize)]
-pub enum TextEncoder {
-    /// Encode UTF-8 strings into buffers.
-    #[default]
-    Utf8,
-    /// Encode UTF-16 strings (little endian) into buffers.
-    Utf16Le,
-    /// Encode UTF-16 strings (big endian) into buffers.
-    Utf16Be,
-}
+pub struct TextEncoder;
 
 #[boa_class]
 impl TextEncoder {
     /// The [`TextEncoder()`][mdn] constructor returns a newly created `TextEncoder` object.
     ///
-    /// # Errors
-    /// This will return an error if the encoding or options are invalid or unsupported.
-    ///
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/API/TextEncoder/TextEncoder
     #[boa(constructor)]
-    pub fn constructor(encoding: Option<JsString>, _options: Option<JsObject>) -> JsResult<Self> {
-        let Some(encoding) = encoding else {
-            return Ok(Self::default());
-        };
-
-        match encoding.to_std_string_lossy().as_str() {
-            "utf-8" => Ok(Self::Utf8),
-            // Default encoding is Little Endian.
-            "utf-16" | "utf-16le" => Ok(Self::Utf16Le),
-            "utf-16be" => Ok(Self::Utf16Be),
-            e => Err(js_error!(RangeError: "The given encoding '{}' is not supported.", e)),
-        }
+    #[must_use]
+    pub fn constructor() -> Self {
+        Self
     }
 
     /// The [`TextEncoder.encoding`][mdn] read-only property returns a string containing
@@ -215,12 +194,8 @@ impl TextEncoder {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/API/TextEncoder/encoding
     #[boa(getter)]
     #[must_use]
-    fn encoding(&self) -> JsString {
-        match self {
-            Self::Utf8 => js_string!("utf-8"),
-            Self::Utf16Le => js_string!("utf-16le"),
-            Self::Utf16Be => js_string!("utf-16be"),
-        }
+    fn encoding() -> JsString {
+        js_string!("utf-8")
     }
 
     /// The [`TextEncoder.encode()`][mdn] method takes a string as input, and returns
@@ -236,12 +211,7 @@ impl TextEncoder {
             return JsUint8Array::from_iter([], context);
         };
 
-        let vec = match self {
-            Self::Utf8 => encodings::utf8::encode(&text),
-            Self::Utf16Le => encodings::utf16le::encode(&text),
-            Self::Utf16Be => encodings::utf16be::encode(&text),
-        };
-        JsUint8Array::from_iter(vec, context)
+        JsUint8Array::from_iter(encodings::utf8::encode(&text), context)
     }
 }
 

--- a/core/runtime/src/text/tests.rs
+++ b/core/runtime/src/text/tests.rs
@@ -125,11 +125,37 @@ fn decoder_js_invalid() {
     );
 }
 
+#[test]
+fn roundtrip_utf8() {
+    let context = &mut Context::default();
+    text::register(None, context).unwrap();
+
+    run_test_actions_with(
+        [
+            TestAction::run(indoc! {r#"
+                const encoder = new TextEncoder();
+                const decoder = new TextDecoder();
+                const text = "Hello, World!";
+                const encoded = encoder.encode(text);
+                decoded = decoder.decode(encoded);
+            "#}),
+            TestAction::inspect_context(|context| {
+                let decoded = context
+                    .global_object()
+                    .get(js_str!("decoded"), context)
+                    .unwrap();
+                assert_eq!(decoded.as_string(), Some(js_string!("Hello, World!")));
+            }),
+        ],
+        context,
+    );
+}
+
 #[test_case("utf-8")]
 #[test_case("utf-16")]
 #[test_case("utf-16le")]
 #[test_case("utf-16be")]
-fn roundtrip(encoding: &'static str) {
+fn encoder_ignores_non_utf_encoding_arguments(encoding: &'static str) {
     let context = &mut Context::default();
     text::register(None, context).unwrap();
 
@@ -138,18 +164,25 @@ fn roundtrip(encoding: &'static str) {
             TestAction::run(format!(
                 r#"
                 const encoder = new TextEncoder({encoding:?});
-                const decoder = new TextDecoder({encoding:?});
-                const text = "Hello, World!";
-                const encoded = encoder.encode(text);
-                decoded = decoder.decode(encoded);
+                actualEncoding = encoder.encoding;
+                encoded = encoder.encode("Hi");
             "#
             )),
             TestAction::inspect_context(|context| {
-                let decoded = context
+                let actual_encoding = context
                     .global_object()
-                    .get(js_str!("decoded"), context)
+                    .get(js_str!("actualEncoding"), context)
                     .unwrap();
-                assert_eq!(decoded.as_string(), Some(js_string!("Hello, World!")));
+                assert_eq!(actual_encoding.as_string(), Some(js_string!("utf-8")));
+
+                let encoded = context
+                    .global_object()
+                    .get(js_str!("encoded"), context)
+                    .unwrap();
+                let array =
+                    JsUint8Array::from_object(encoded.as_object().unwrap().clone()).unwrap();
+                let buffer = array.iter(context).collect::<Vec<_>>();
+                assert_eq!(buffer, b"Hi");
             }),
         ],
         context,

--- a/tests/wpt/src/lib.rs
+++ b/tests/wpt/src/lib.rs
@@ -398,6 +398,7 @@ fn console(
 fn encoding(
     #[base_dir = "${WPT_ROOT}"]
     #[files("encoding/api-*.any.js")]
+    #[files("encoding/textencoder-constructor-non-utf.any.js")]
     // TODO: re-enable those when better encoding and options are supported.
     // #[files("encoding/textdecoder-*.any.js")]
     // #[files("encoding/textencoder-*.any.js")]


### PR DESCRIPTION
Fixes #5120.

This makes `TextEncoder` UTF-8-only.

It now ignores passed encoding labels, always reports `utf-8`, and always encodes with UTF-8.

This also updates the local runtime tests and enables the `encoding/textencoder-constructor-non-utf.any.js` WPT file.