### PR TITLE
fix Headers.get spacing

### DIFF
--- a/core/runtime/src/fetch/headers.rs
+++ b/core/runtime/src/fetch/headers.rs
@@ -208,13 +208,10 @@ impl JsHeaders {
             .get_all(name.clone())
             .into_iter()
             .map(|v| v.to_str().unwrap_or(""))
-            // Use an Option<String> to accumulate the values into a single string,
-            // if there are any. Otherwise, we return None.
-            // Cannot use `join(",")` as we need to return undefined if none is found.
             .fold(None, |mut acc, v| {
                 let str = acc.get_or_insert_with(String::new);
                 if !str.is_empty() {
-                    str.push(',');
+                    str.push_str(", ");
                 }
                 str.push_str(v);
                 acc

--- a/core/runtime/src/fetch/tests/headers.rs
+++ b/core/runtime/src/fetch/tests/headers.rs
@@ -26,6 +26,24 @@ fn headers_are_iterable() {
 }
 
 #[test]
+fn headers_get_combines_duplicate_values_with_comma_space() {
+    run_test_actions([
+        TestAction::harness(),
+        TestAction::inspect_context(register),
+        TestAction::run(
+            r#"
+                const headers = new Headers([
+                    ["x-test", "1"],
+                    ["x-test", "2"],
+                ]);
+
+                assertEq(headers.get("x-test"), "1, 2");
+            "#,
+        ),
+    ]);
+}
+
+#[test]
 fn headers_normalize_values() {
     run_test_actions([
         TestAction::harness(),

--- a/core/runtime/src/fetch/tests/response.rs
+++ b/core/runtime/src/fetch/tests/response.rs
@@ -155,3 +155,32 @@ fn response_getter() {
         }),
     ]);
 }
+
+#[test]
+fn response_headers_get_combines_duplicate_values_with_comma_space() {
+    run_test_actions([
+        TestAction::harness(),
+        TestAction::inspect_context(|ctx| {
+            let mut response = Response::new(b"Hello World".to_vec());
+            response
+                .headers_mut()
+                .append("x-test", "1".parse().unwrap());
+            response
+                .headers_mut()
+                .append("x-test", "2".parse().unwrap());
+            register(&[("http://unit.test", response)], ctx);
+        }),
+        TestAction::run(
+            r#"
+                globalThis.response = (async () => {
+                    const response = await fetch("http://unit.test");
+                    assertEq(response.headers.get("x-test"), "1, 2");
+                })();
+            "#,
+        ),
+        TestAction::inspect_context(|ctx| {
+            let response = ctx.global_object().get(js_str!("response"), ctx).unwrap();
+            response.as_promise().unwrap().await_blocking(ctx).unwrap();
+        }),
+    ]);
+}


### PR DESCRIPTION
Fixes #5113.

This makes `Headers.get()` join duplicate header values with `, ` instead of `,`.

It also adds runtime tests for both direct `Headers` instances and fetched response headers.