### PR TITLE
test: add coverage for JsTypedArray toReversed, toSorted, toLocaleString

### DIFF
--- a/core/engine/src/object/builtins/jstypedarray.rs
+++ b/core/engine/src/object/builtins/jstypedarray.rs
@@ -1,14 +1,14 @@
 //! Rust API wrappers for the `TypedArray` Builtin ECMAScript Objects
 use crate::{
-    Context, JsExpect, JsResult, JsString, JsValue,
     builtins::{
-        BuiltInConstructor,
         array_buffer::AlignedVec,
         typed_array::{BuiltinTypedArray, TypedArray, TypedArrayKind},
+        BuiltInConstructor,
     },
     error::JsNativeError,
     object::{JsArrayBuffer, JsFunction, JsObject, JsSharedArrayBuffer},
     value::{IntoOrUndefined, TryFromJs},
+    Context, JsExpect, JsResult, JsString, JsValue,
 };
 use boa_gc::{Finalize, Trace};
 use std::ops::Deref;
@@ -1513,40 +1513,53 @@ fn typed_array_values() {
 }
 
 #[test]
-fn typed_array_iterator() {
+fn typed_array_to_reversed() {
     let context = &mut Context::default();
-    let vec = vec![1u8, 2];
-    let array = JsUint8Array::from_iter(vec, context).unwrap();
-    let values = array.iterator(context).unwrap();
-    let mut values_vec = Vec::new();
-    let next_str = crate::js_string!("next");
-    loop {
-        let next_fn = values
-            .as_object()
-            .unwrap()
-            .get(next_str.clone(), context)
-            .unwrap();
-        let result = next_fn
-            .as_object()
-            .unwrap()
-            .call(&values, &[], context)
-            .unwrap();
-        if result
-            .as_object()
-            .unwrap()
-            .get(crate::js_string!("done"), context)
-            .unwrap()
-            .to_boolean()
-        {
-            break;
-        }
-        values_vec.push(
-            result
-                .as_object()
-                .unwrap()
-                .get(crate::js_string!("value"), context)
-                .unwrap(),
-        );
-    }
-    assert_eq!(values_vec, vec![JsValue::new(1), JsValue::new(2)]);
+    let array = JsUint8Array::from_iter(vec![3u8, 1, 2], context).unwrap();
+
+    let reversed = array.to_reversed(context).unwrap();
+
+    // New array has reversed order
+    assert_eq!(reversed.at(0i64, context).unwrap(), JsValue::new(2));
+    assert_eq!(reversed.at(1i64, context).unwrap(), JsValue::new(1));
+    assert_eq!(reversed.at(2i64, context).unwrap(), JsValue::new(3));
+
+    // Original is unchanged
+    assert_eq!(array.at(0i64, context).unwrap(), JsValue::new(3));
+    assert_eq!(array.at(1i64, context).unwrap(), JsValue::new(1));
+    assert_eq!(array.at(2i64, context).unwrap(), JsValue::new(2));
+}
+
+#[test]
+fn typed_array_to_sorted() {
+    let context = &mut Context::default();
+    let array = JsUint8Array::from_iter(vec![3u8, 1, 2], context).unwrap();
+
+    let sorted = array.to_sorted(None, context).unwrap();
+
+    // New array is sorted
+    assert_eq!(sorted.at(0i64, context).unwrap(), JsValue::new(1));
+    assert_eq!(sorted.at(1i64, context).unwrap(), JsValue::new(2));
+    assert_eq!(sorted.at(2i64, context).unwrap(), JsValue::new(3));
+
+    // Original is unchanged
+    assert_eq!(array.at(0i64, context).unwrap(), JsValue::new(3));
+    assert_eq!(array.at(1i64, context).unwrap(), JsValue::new(1));
+    assert_eq!(array.at(2i64, context).unwrap(), JsValue::new(2));
+}
+
+#[test]
+fn typed_array_to_locale_string() {
+    let context = &mut Context::default();
+    let array = JsUint8Array::from_iter(vec![1u8, 2, 3], context).unwrap();
+
+    let result = array.to_locale_string(None, None, context).unwrap();
+
+    let result_str = result
+        .as_string()
+        .expect("toLocaleString should return a string");
+    assert!(
+        result_str.to_std_string_escaped().contains('1'),
+        "result should contain element values"
+    );
 }

--- a/core/engine/src/object/builtins/jstypedarray.rs
+++ b/core/engine/src/object/builtins/jstypedarray.rs
@@ -1,14 +1,14 @@
 //! Rust API wrappers for the `TypedArray` Builtin ECMAScript Objects
 use crate::{
+    Context, JsExpect, JsResult, JsString, JsValue,
     builtins::{
+        BuiltInConstructor,
         array_buffer::AlignedVec,
         typed_array::{BuiltinTypedArray, TypedArray, TypedArrayKind},
-        BuiltInConstructor,
     },
     error::JsNativeError,
     object::{JsArrayBuffer, JsFunction, JsObject, JsSharedArrayBuffer},
     value::{IntoOrUndefined, TryFromJs},
-    Context, JsExpect, JsResult, JsString, JsValue,
 };
 use boa_gc::{Finalize, Trace};
 use std::ops::Deref;

--- a/core/engine/src/object/builtins/jstypedarray.rs
+++ b/core/engine/src/object/builtins/jstypedarray.rs
@@ -1513,6 +1513,44 @@ fn typed_array_values() {
 }
 
 #[test]
+fn typed_array_iterator() {
+    let context = &mut Context::default();
+    let array = JsUint8Array::from_iter(vec![1u8, 2], context).unwrap();
+    let values = array.iterator(context).unwrap();
+    let mut values_vec = Vec::new();
+    let next_str = crate::js_string!("next");
+    loop {
+        let next_fn = values
+            .as_object()
+            .unwrap()
+            .get(next_str.clone(), context)
+            .unwrap();
+        let result = next_fn
+            .as_object()
+            .unwrap()
+            .call(&values, &[], context)
+            .unwrap();
+        if result
+            .as_object()
+            .unwrap()
+            .get(crate::js_string!("done"), context)
+            .unwrap()
+            .to_boolean()
+        {
+            break;
+        }
+        values_vec.push(
+            result
+                .as_object()
+                .unwrap()
+                .get(crate::js_string!("value"), context)
+                .unwrap(),
+        );
+    }
+    assert_eq!(values_vec, vec![JsValue::new(1), JsValue::new(2)]);
+}
+
+#[test]
 fn typed_array_to_reversed() {
     let context = &mut Context::default();
     let array = JsUint8Array::from_iter(vec![3u8, 1, 2], context).unwrap();


### PR DESCRIPTION
## Context

These three `JsTypedArray` wrapper methods are fully implemented but had no test coverage. This PR adds unit tests for each.

Ref #3252 -- the tracking issue checkboxes for `toLocaleString`, `toReversed`, and `toSorted` can be checked off, since the implementations already exist in both the builtins layer and the Rust wrapper.

## Tests added

- **`typed_array_to_reversed`** -- verifies `toReversed()` returns a new reversed array and leaves the original unchanged
- **`typed_array_to_sorted`** -- verifies `toSorted()` returns a new sorted array and leaves the original unchanged
- **`typed_array_to_locale_string`** -- verifies `toLocaleString()` returns a string containing the element values

All three tests pass locally: `cargo test --package boa_engine typed_array_to_`