### PR TITLE
CI: add timeout-minutes to prevent hung builds running for 6 hours

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -8,5 +8,6 @@ jobs:
       contents: read
       pull-requests: write
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
     - uses: actions/labeler@v6

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -25,6 +25,7 @@ jobs:
             os: windows-latest
             binary_extension: ".exe"
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/pr_management.yml
+++ b/.github/workflows/pr_management.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   manage_pr:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       pull-requests: write
       issues: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,6 +107,7 @@ jobs:
           target: x86_64-pc-windows-msvc
           binary_extension: ".exe"
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request fixes/closes #5138.

It changes the following:

- Appends a `timeout-minutes` configuration to all GitHub Actions jobs that were previously missing it.
- Prevents rogue scripts, network API stalls, or action outages from silently running continuously until GitHub forcefully kills them at the default 6-hour organizational limit.
- Adds `timeout-minutes: 60` to compilation-heavy jobs (like [nightly_build.yml](cci:7://file:///c:/Users/risha/Desktop/boa/.github/workflows/nightly_build.yml:0:0-0:0) and `release-binaries` inside [release.yml](cci:7://file:///c:/Users/risha/Desktop/boa/.github/release.yml:0:0-0:0)).
- Adds `timeout-minutes: 10` to lightweight/scripting API jobs (like [labeler.yml](cci:7://file:///c:/Users/risha/Desktop/boa/.github/labeler.yml:0:0-0:0) and [pr_management.yml](cci:7://file:///c:/Users/risha/Desktop/boa/.github/workflows/pr_management.yml:0:0-0:0)) to ensure they fail fast if GitHub's REST API is unreachable.
