### PR TITLE
fix(engine): replace str::replace with cow_replace in module loader

### DIFF
--- a/core/engine/src/module/loader/mod.rs
+++ b/core/engine/src/module/loader/mod.rs
@@ -3,8 +3,6 @@ use std::cell::RefCell;
 use std::path::{Component, Path, PathBuf};
 use std::rc::Rc;
 
-use cow_utils::CowUtils;
-
 use dynify::dynify;
 use rustc_hash::FxHashMap;
 
@@ -64,9 +62,9 @@ pub fn resolve_module_specifier(
 
     // On Windows, also replace `/` with `\`. JavaScript imports use `/` as path separator.
     #[cfg(target_family = "windows")]
-    let specifier = specifier.cow_replace('/', "\\").into_owned();
+    let specifier = cow_utils::CowUtils::cow_replace(&*specifier, '/', "\\");
 
-    let short_path = Path::new(&specifier);
+    let short_path = Path::new(&*specifier);
 
     // In ECMAScript, a path is considered relative if it starts with
     // `./` or `../`. In Rust it's any path that start with `/`.
@@ -81,7 +79,7 @@ pub fn resolve_module_specifier(
             ));
         }
     } else {
-        base_path.join(&specifier)
+        base_path.join(&*specifier)
     };
 
     if long_path.is_relative() && base.is_some() {

--- a/core/engine/src/module/loader/mod.rs
+++ b/core/engine/src/module/loader/mod.rs
@@ -3,6 +3,8 @@ use std::cell::RefCell;
 use std::path::{Component, Path, PathBuf};
 use std::rc::Rc;
 
+use cow_utils::CowUtils;
+
 use dynify::dynify;
 use rustc_hash::FxHashMap;
 
@@ -62,7 +64,7 @@ pub fn resolve_module_specifier(
 
     // On Windows, also replace `/` with `\`. JavaScript imports use `/` as path separator.
     #[cfg(target_family = "windows")]
-    let specifier = specifier.replace('/', "\\");
+    let specifier = specifier.cow_replace('/', "\\").into_owned();
 
     let short_path = Path::new(&specifier);
 


### PR DESCRIPTION
Closes #5140

Replaces `str::replace` with `cow_utils::CowUtils::cow_replace` in the module loader to satisfy `clippy::disallowed_methods` and avoid unnecessary allocation.

Follows the pattern introduced in #4123.