### PR TITLE
ci: set fail-fast to false on tests matrix to prevent platform blind spots

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -207,6 +207,7 @@ jobs:
     env:
       RUSTUP_WINDOWS_PATH_ADD_BIN: 1
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: macos-14


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request fixes/closes #5152 .

It changes the following:

- Appends the explicit `fail-fast: false` property to the `tests` matrix strategy block within [.github/workflows/rust.yml](cci:7://file:///c:/Users/risha/Desktop/boa/.github/workflows/rust.yml:0:0-0:0).
- Enhances developer diagnostic visibility by guaranteeing that every OS environment (`macos`, `windows`, `ubuntu`, `ubuntu-arm`) successfully completes its full test suite execution, even if a sibling platform fails first.
- Prevents GitHub Actions' default behavior from instantly force-cancelling the entire pipeline, eliminating "platform blind spots" where developers are unaware of platform-specific regressions.
