### PR TITLE
fix(runtime): allow TextDecoder.decode() with omitted input

### DIFF
--- a/core/runtime/src/text/mod.rs
+++ b/core/runtime/src/text/mod.rs
@@ -134,6 +134,8 @@ impl TextDecoder {
     /// The [`TextDecoder.decode()`][mdn] method returns a string containing text decoded from the
     /// buffer passed as a parameter.
     ///
+    /// If `buffer` is omitted or `undefined`, this returns an empty string.
+    ///
     /// `buffer` can be an `ArrayBuffer`, a `TypedArray` or a `DataView`.
     ///
     /// # Errors

--- a/core/runtime/src/text/mod.rs
+++ b/core/runtime/src/text/mod.rs
@@ -141,6 +141,10 @@ impl TextDecoder {
     ///
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/API/TextDecoder/decode
     pub fn decode(&self, buffer: JsValue, context: &mut Context) -> JsResult<JsString> {
+        if buffer.is_undefined() {
+            return Ok(js_string!(""));
+        }
+
         let mut range = None;
         let array_buffer = if let Ok(array_buffer) = JsArrayBuffer::try_from_js(&buffer, context) {
             array_buffer

--- a/core/runtime/src/text/tests.rs
+++ b/core/runtime/src/text/tests.rs
@@ -95,6 +95,29 @@ fn decoder_js() {
 }
 
 #[test]
+fn decoder_js_without_input() {
+    let context = &mut Context::default();
+    text::register(None, context).unwrap();
+
+    run_test_actions_with(
+        [
+            TestAction::run(indoc! {r#"
+                const d = new TextDecoder();
+                decoded = d.decode();
+            "#}),
+            TestAction::inspect_context(|context| {
+                let decoded = context
+                    .global_object()
+                    .get(js_str!("decoded"), context)
+                    .unwrap();
+                assert_eq!(decoded.as_string(), Some(js_string!("")));
+            }),
+        ],
+        context,
+    );
+}
+
+#[test]
 fn decoder_js_invalid() {
     use crate::test::{TestAction, run_test_actions_with};
     use indoc::indoc;

--- a/core/runtime/src/text/tests.rs
+++ b/core/runtime/src/text/tests.rs
@@ -104,13 +104,19 @@ fn decoder_js_without_input() {
             TestAction::run(indoc! {r#"
                 const d = new TextDecoder();
                 decoded = d.decode();
+                decodedUndefined = d.decode(undefined);
             "#}),
             TestAction::inspect_context(|context| {
                 let decoded = context
                     .global_object()
                     .get(js_str!("decoded"), context)
                     .unwrap();
+                let decoded_undefined = context
+                    .global_object()
+                    .get(js_str!("decodedUndefined"), context)
+                    .unwrap();
                 assert_eq!(decoded.as_string(), Some(js_string!("")));
+                assert_eq!(decoded_undefined.as_string(), Some(js_string!("")));
             }),
         ],
         context,


### PR DESCRIPTION
This Pull Request fixes/closes #5173.

It changes the following:
- Return empty string in `TextDecoder.decode()` when input is omitted 
or `undefined`, matching the Encoding Standard which defines `input` as optional.
- Invalid non-buffer inputs (e.g. `null`) still correctly throw `TypeError` — existing behavior preserved.
- Add regression test `decoder_js_without_input` in `tests.rs` covering 
both `decode()` and `decode(undefined)`.

Testing:
cargo test -p boa_runtime text::tests -- --nocapture

Spec reference:
https://encoding.spec.whatwg.org/#dom-textdecoder-decode