### PR TITLE
CI: Include Rust toolchain version in cargo cache keys to prevent cache poisoning

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -40,6 +40,10 @@ jobs:
           toolchain: stable
           targets: ${{ matrix.target }}
 
+      - name: Get rust_version
+        id: rust_version
+        run: echo "version=$(rustc -V)" >> $GITHUB_OUTPUT
+
       - name: Restore cache
         id: cache
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
@@ -48,7 +52,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ matrix.os }}-${{ runner.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ matrix.os }}-${{ runner.arch }}-cargo-${{ steps.rust_version.outputs.version }}-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Build
         run: cargo build --target ${{ matrix.target }} --release --locked --bin boa

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -31,6 +31,10 @@ jobs:
         with:
           toolchain: stable
 
+      - name: Get rust_version
+        id: rust_version
+        run: echo "version=$(rustc -V)" >> $GITHUB_OUTPUT
+
       - name: Cache cargo
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         with:
@@ -38,7 +42,7 @@ jobs:
             target
             ~/.cargo/git
             ~/.cargo/registry
-          key: ${{ runner.os }}-${{ runner.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-cargo-${{ steps.rust_version.outputs.version }}-${{ hashFiles('**/Cargo.lock') }}
       - uses: boa-dev/criterion-compare-action@adfd3a94634fe2041ce5613eb7df09d247555b87 # v3.2.4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,6 +123,10 @@ jobs:
           toolchain: stable
           targets: ${{ matrix.target }}
 
+      - name: Get rust_version
+        id: rust_version
+        run: echo "version=$(rustc -V)" >> $GITHUB_OUTPUT
+
       - name: Cache cargo
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         with:
@@ -130,7 +134,7 @@ jobs:
             target
             ~/.cargo/git
             ~/.cargo/registry
-          key: ${{ matrix.os }}-${{ runner.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ matrix.os }}-${{ runner.arch }}-cargo-${{ steps.rust_version.outputs.version }}-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Build
         run: cargo build --target ${{ matrix.target }} --verbose --release --locked --bin boa

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -80,6 +80,10 @@ jobs:
           toolchain: stable
           components: clippy
 
+      - name: Get rust_version
+        id: rust_version
+        run: echo "version=$(rustc -V)" >> $GITHUB_OUTPUT
+
       - name: Cache cargo
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         with:
@@ -87,7 +91,7 @@ jobs:
             target
             ~/.cargo/git
             ~/.cargo/registry
-          key: ${{ runner.os }}-${{ runner.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-cargo-${{ steps.rust_version.outputs.version }}-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install cargo-workspaces
         run: cargo install cargo-workspaces
@@ -124,6 +128,10 @@ jobs:
         with:
           toolchain: stable
 
+      - name: Get rust_version
+        id: rust_version
+        run: echo "version=$(rustc -V)" >> $GITHUB_OUTPUT
+
       - name: Cache cargo
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         with:
@@ -131,7 +139,7 @@ jobs:
             target
             ~/.cargo/git
             ~/.cargo/registry
-          key: ${{ runner.os }}-${{ runner.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-cargo-${{ steps.rust_version.outputs.version }}-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Generate documentation
         run: cargo doc -v --document-private-items --all-features
@@ -190,6 +198,10 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
 
+      - name: Get rust_version
+        id: rust_version
+        run: echo "version=$(rustc -V)" >> $GITHUB_OUTPUT
+
       - name: Cache cargo
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         with:
@@ -197,7 +209,7 @@ jobs:
             target
             ~/.cargo/git
             ~/.cargo/registry
-          key: ${{ runner.os }}-${{ runner.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-cargo-${{ steps.rust_version.outputs.version }}-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install cargo-tarpaulin
         uses: baptiste0928/cargo-install@f204293d9709061b7bc1756fec3ec4e2cd57dec0 # v3.4.0
@@ -258,6 +270,10 @@ jobs:
       - name: Install Cargo insta
         run: cargo install --locked cargo-insta
 
+      - name: Get rust_version
+        id: rust_version
+        run: echo "version=$(rustc -V)" >> $GITHUB_OUTPUT
+
       - name: Cache cargo
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         with:
@@ -265,7 +281,7 @@ jobs:
             target
             ~/.cargo/git
             ~/.cargo/registry
-          key: ${{ matrix.os }}-${{ runner.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ matrix.os }}-${{ runner.arch }}-cargo-${{ steps.rust_version.outputs.version }}-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Build tests
         run: cargo test --no-run --profile ci
@@ -321,6 +337,10 @@ jobs:
           crate: cross
           git: https://github.com/cross-rs/cross
 
+      - name: Get rust_version
+        id: rust_version
+        run: echo "version=$(rustc -V)" >> $GITHUB_OUTPUT
+
       - name: Cache cargo
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         with:
@@ -328,7 +348,7 @@ jobs:
             target
             ~/.cargo/git
             ~/.cargo/registry
-          key: ${{ matrix.target }}-${{ runner.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ matrix.target }}-${{ runner.arch }}-cargo-${{ steps.rust_version.outputs.version }}-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Run tests
         run: |
@@ -366,6 +386,10 @@ jobs:
         with:
           components: miri
 
+      - name: Get rust_version
+        id: rust_version
+        run: echo "version=$(rustc -V)" >> $GITHUB_OUTPUT
+
       - name: Cache cargo
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         with:
@@ -373,7 +397,7 @@ jobs:
             target
             ~/.cargo/git
             ~/.cargo/registry
-          key: ${{ runner.os }}-${{ runner.arch }}-cargo-miri-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-cargo-miri-${{ steps.rust_version.outputs.version }}-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Setup miri
         run: cargo miri setup
@@ -406,6 +430,10 @@ jobs:
         with:
           toolchain: stable
 
+      - name: Get rust_version
+        id: rust_version
+        run: echo "version=$(rustc -V)" >> $GITHUB_OUTPUT
+
       - name: Cache cargo
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         with:
@@ -413,7 +441,7 @@ jobs:
             target
             ~/.cargo/git
             ~/.cargo/registry
-          key: ${{ runner.os }}-${{ runner.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-cargo-${{ steps.rust_version.outputs.version }}-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install cargo-fuzz
         run: cargo install cargo-fuzz
@@ -446,6 +474,10 @@ jobs:
         with:
           toolchain: stable
 
+      - name: Get rust_version
+        id: rust_version
+        run: echo "version=$(rustc -V)" >> $GITHUB_OUTPUT
+
       - name: Cache cargo
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         with:
@@ -453,7 +485,7 @@ jobs:
             target
             ~/.cargo/git
             ~/.cargo/registry
-          key: ${{ runner.os }}-${{ runner.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-cargo-${{ steps.rust_version.outputs.version }}-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install cargo-workspaces
         run: cargo install cargo-workspaces
@@ -490,6 +522,10 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Get rust_version
+        id: rust_version
+        run: echo "version=$(rustc -V)" >> $GITHUB_OUTPUT
+
       - name: Cache cargo
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         with:
@@ -497,7 +533,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-${{ steps.rust_version.outputs.version }}-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Check Semver
         uses: obi1kenobi/cargo-semver-checks-action@5b298c9520f7096a4683c0bd981a7ac5a7e249ae # v2

--- a/.github/workflows/test262.yml
+++ b/.github/workflows/test262.yml
@@ -30,6 +30,10 @@ jobs:
         with:
           toolchain: stable
 
+      - name: Get rust_version
+        id: rust_version
+        run: echo "version=$(rustc -V)" >> $GITHUB_OUTPUT
+
       - name: Cache cargo
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         with:
@@ -37,7 +41,7 @@ jobs:
             boa/target
             ~/.cargo/git
             ~/.cargo/registry
-          key: ${{ runner.os }}-${{ runner.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-cargo-${{ steps.rust_version.outputs.version }}-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Checkout the data repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/test262_release.yml
+++ b/.github/workflows/test262_release.yml
@@ -34,6 +34,10 @@ jobs:
           toolchain: stable
 
       # Cache cargo dependencies
+      - name: Get rust_version
+        id: rust_version
+        run: echo "version=$(rustc -V)" >> $GITHUB_OUTPUT
+
       - name: Cache cargo
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         with:
@@ -41,7 +45,7 @@ jobs:
             target
             ~/.cargo/git
             ~/.cargo/registry
-          key: ${{ runner.os }}-${{ runner.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-cargo-${{ steps.rust_version.outputs.version }}-${{ hashFiles('**/Cargo.lock') }}
 
       # Checkout the `data` repository
       - name: Checkout the data repo

--- a/.github/workflows/webassembly.yml
+++ b/.github/workflows/webassembly.yml
@@ -57,6 +57,10 @@ jobs:
           toolchain: stable
 
 
+      - name: Get rust_version
+        id: rust_version
+        run: echo "version=$(rustc -V)" >> $GITHUB_OUTPUT
+
       - name: Cache cargo
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         with:
@@ -64,7 +68,7 @@ jobs:
             target
             ~/.cargo/git
             ~/.cargo/registry
-          key: ${{ runner.os }}-${{ runner.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-cargo-${{ steps.rust_version.outputs.version }}-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install wasm-pack
         uses: baptiste0928/cargo-install@f204293d9709061b7bc1756fec3ec4e2cd57dec0 # v3.4.0


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request fixes/closes #5181 .

It changes the following:

- Injected a `Get rust_version` step (`rustc -V`) in 6 workflow files ([rust.yml](cci:7://file:///c:/Users/risha/Desktop/boa/.github/workflows/rust.yml:0:0-0:0), [webassembly.yml](cci:7://file:///c:/Users/risha/Desktop/boa/.github/workflows/webassembly.yml:0:0-0:0), [test262.yml](cci:7://file:///c:/Users/risha/Desktop/boa/.github/workflows/test262.yml:0:0-0:0), [test262_release.yml](cci:7://file:///c:/Users/risha/Desktop/boa/.github/workflows/test262_release.yml:0:0-0:0), [nightly_build.yml](cci:7://file:///c:/Users/risha/Desktop/boa/.github/workflows/nightly_build.yml:0:0-0:0), and [pull_request.yml](cci:7://file:///c:/Users/risha/Desktop/boa/.github/workflows/pull_request.yml:0:0-0:0)) to capture the exact active Rust compiler version.
- Updated 15 `actions/cache` key strings to include `-${{ steps.rust_version.outputs.version }}-`, ensuring Cargo caches are strongly segregated by Rust compiler version, which prevents cross-version cache poisoning and silent linkage failures.
