### PR TITLE
Fix trace output

### DIFF
--- a/core/engine/src/builtins/array/mod.rs
+++ b/core/engine/src/builtins/array/mod.rs
@@ -1294,7 +1294,11 @@ impl Array {
 
             // Small optimization for arrays using dense properties.
             // Mirrors the fast-path in `shift`.
-            if o.is_array() {
+            // Guard: only take the fast path when len > 0, because for empty
+            // arrays (len == 0) there are no own indexed properties and `Set`
+            // must traverse the prototype chain (which may have setters that
+            // freeze the array or make `length` non-writable mid-operation).
+            if o.is_array() && len > 0 {
                 let mut o_borrow = o.borrow_mut();
                 let props = &mut o_borrow.properties_mut().indexed_properties;
 

--- a/core/engine/src/builtins/array/mod.rs
+++ b/core/engine/src/builtins/array/mod.rs
@@ -1291,6 +1291,49 @@ impl Array {
                     .with_message("length + number of arguments exceeds the max safe integer limit")
                     .into());
             }
+
+            // Small optimization for arrays using dense properties.
+            // Mirrors the fast-path in `shift`.
+            if o.is_array() {
+                let mut o_borrow = o.borrow_mut();
+                let props = &mut o_borrow.properties_mut().indexed_properties;
+
+                let fast_path_done = match props {
+                    IndexedProperties::DenseI32(dense) if len <= dense.len() as u64 => {
+                        // Only take the fast path if ALL new items are i32.
+                        let all_i32: Option<Vec<i32>> = args.iter().map(JsValue::as_i32).collect();
+                        if let Some(items) = all_i32 {
+                            dense.splice(0..0, items);
+                            true
+                        } else {
+                            false
+                        }
+                    }
+                    IndexedProperties::DenseF64(dense) if len <= dense.len() as u64 => {
+                        let all_f64: Option<Vec<f64>> =
+                            args.iter().map(JsValue::as_number).collect();
+                        if let Some(items) = all_f64 {
+                            dense.splice(0..0, items);
+                            true
+                        } else {
+                            false
+                        }
+                    }
+                    IndexedProperties::DenseElement(dense) if len <= dense.len() as u64 => {
+                        dense.splice(0..0, args.iter().cloned());
+                        true
+                    }
+                    _ => false,
+                };
+
+                drop(o_borrow);
+
+                if fast_path_done {
+                    Self::set_length(&o, len + arg_count, context)?;
+                    return Ok((len + arg_count).into());
+                }
+            }
+
             // b. Let k be len.
             let mut k = len;
             // c. Repeat, while k > 0,

--- a/core/engine/src/builtins/array/mod.rs
+++ b/core/engine/src/builtins/array/mod.rs
@@ -1292,52 +1292,6 @@ impl Array {
                     .into());
             }
 
-            // Small optimization for arrays using dense properties.
-            // Mirrors the fast-path in `shift`.
-            // Guard: only take the fast path when len > 0, because for empty
-            // arrays (len == 0) there are no own indexed properties and `Set`
-            // must traverse the prototype chain (which may have setters that
-            // freeze the array or make `length` non-writable mid-operation).
-            if o.is_array() && len > 0 {
-                let mut o_borrow = o.borrow_mut();
-                let props = &mut o_borrow.properties_mut().indexed_properties;
-
-                let fast_path_done = match props {
-                    IndexedProperties::DenseI32(dense) if len <= dense.len() as u64 => {
-                        // Only take the fast path if ALL new items are i32.
-                        let all_i32: Option<Vec<i32>> = args.iter().map(JsValue::as_i32).collect();
-                        if let Some(items) = all_i32 {
-                            dense.splice(0..0, items);
-                            true
-                        } else {
-                            false
-                        }
-                    }
-                    IndexedProperties::DenseF64(dense) if len <= dense.len() as u64 => {
-                        let all_f64: Option<Vec<f64>> =
-                            args.iter().map(JsValue::as_number).collect();
-                        if let Some(items) = all_f64 {
-                            dense.splice(0..0, items);
-                            true
-                        } else {
-                            false
-                        }
-                    }
-                    IndexedProperties::DenseElement(dense) if len <= dense.len() as u64 => {
-                        dense.splice(0..0, args.iter().cloned());
-                        true
-                    }
-                    _ => false,
-                };
-
-                drop(o_borrow);
-
-                if fast_path_done {
-                    Self::set_length(&o, len + arg_count, context)?;
-                    return Ok((len + arg_count).into());
-                }
-            }
-
             // b. Let k be len.
             let mut k = len;
             // c. Repeat, while k > 0,

--- a/core/engine/src/builtins/array/tests.rs
+++ b/core/engine/src/builtins/array/tests.rs
@@ -249,6 +249,24 @@ fn unshift() {
         TestAction::assert_eq("arr.unshift(1, 2)", 4),
         TestAction::assert("arrayEquals(arr, [1, 2, 3, 4])"),
     ]);
+
+    // Test case from PR 5076 ensuring unshift doesn't bypass setters
+    run_test_actions([
+        TestAction::run_harness(),
+        TestAction::run(indoc! {r#"
+            var array = [1];
+            Object.defineProperty(Array.prototype, "1", {
+                set(_val) {
+                    Object.freeze(array);
+                },
+            });
+        "#}),
+        TestAction::assert_native_error(
+            "array.unshift(0)",
+            JsNativeErrorKind::Type,
+            "cannot set non-writable property: 0",
+        ),
+    ]);
 }
 
 #[test]

--- a/core/engine/src/vm/mod.rs
+++ b/core/engine/src/vm/mod.rs
@@ -279,13 +279,21 @@ impl Stack {
     #[cfg(feature = "trace")]
     /// Display the stack trace of the current frame.
     fn display_trace(&self, frame: &CallFrame, frame_count: usize) -> String {
+        const MAX_VALUE_LENGTH: usize = 20;
+        const MAX_STACK_DISPLAY_WIDTH: usize = 60;
+
         let mut string = String::from("[ ");
         for (i, (j, value)) in self.stack.iter().enumerate().rev().enumerate() {
-            match value {
-                value if value.is_callable() => string.push_str("[function]"),
-                value if value.is_object() => string.push_str("[object]"),
-                value => string.push_str(&value.display().to_string()),
+            let mut value_str = match value {
+                value if value.is_callable() => "[function]".to_string(),
+                value if value.is_object() => "[object]".to_string(),
+                value => value.display().to_string(),
+            };
+            if value_str.len() > MAX_VALUE_LENGTH {
+                value_str.truncate(MAX_VALUE_LENGTH - 3);
+                value_str.push_str("...");
             }
+            string.push_str(&value_str);
 
             if frame.frame_pointer() == j {
                 let _ = write!(string, " |{frame_count}|");
@@ -294,6 +302,11 @@ impl Stack {
             }
 
             string.push(' ');
+        }
+
+        if string.len() > MAX_STACK_DISPLAY_WIDTH {
+            string.truncate(MAX_STACK_DISPLAY_WIDTH - 4);
+            string.push_str("... ");
         }
 
         string.push(']');
@@ -663,11 +676,16 @@ impl Context {
             .code_block
             .bytecode
             .next_instruction(frame.pc as usize);
-        let operands = self
+        let mut operands = self
             .vm
             .frame()
             .code_block()
             .instruction_operands(&instruction);
+
+        if operands.len() > Self::OPERAND_COLUMN_WIDTH {
+            operands.truncate(Self::OPERAND_COLUMN_WIDTH - 3);
+            operands.push_str("...");
+        }
 
         let instant = Instant::now();
         let result = self.execute_instruction(f, opcode);


### PR DESCRIPTION
This PR addresses the trace output formatting overflow in the CLI. 

It implements truncation for both the unbounded stack representation strings and the instruction operand strings to ensure they fit neatly within the terminal columns without wrapping or breaking the table alignment.
