### PR TITLE
ci: replace bare cargo install with cached baptiste0928/cargo-install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,9 @@ jobs:
           toolchain: stable
 
       - name: Install cargo-workspaces
-        run: cargo install cargo-workspaces
+        uses: baptiste0928/cargo-install@f204293d9709061b7bc1756fec3ec4e2cd57dec0 # v3.4.0
+        with:
+          crate: cargo-workspaces
 
       - name: Release
         env:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -90,7 +90,9 @@ jobs:
           key: ${{ runner.os }}-${{ runner.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install cargo-workspaces
-        run: cargo install cargo-workspaces
+        uses: baptiste0928/cargo-install@f204293d9709061b7bc1756fec3ec4e2cd57dec0 # v3.4.0
+        with:
+          crate: cargo-workspaces
 
       - name: Clippy (All features)
         run: cargo workspaces exec cargo clippy --all-features --all-targets
@@ -256,7 +258,10 @@ jobs:
           toolchain: stable
 
       - name: Install Cargo insta
-        run: cargo install --locked cargo-insta
+        uses: baptiste0928/cargo-install@f204293d9709061b7bc1756fec3ec4e2cd57dec0 # v3.4.0
+        with:
+          crate: cargo-insta
+          locked: true
 
       - name: Cache cargo
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
@@ -416,7 +421,9 @@ jobs:
           key: ${{ runner.os }}-${{ runner.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install cargo-fuzz
-        run: cargo install cargo-fuzz
+        uses: baptiste0928/cargo-install@f204293d9709061b7bc1756fec3ec4e2cd57dec0 # v3.4.0
+        with:
+          crate: cargo-fuzz
 
       - name: Build fuzz
         run: cd tests/fuzz && cargo fuzz build -s none --dev
@@ -456,7 +463,9 @@ jobs:
           key: ${{ runner.os }}-${{ runner.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install cargo-workspaces
-        run: cargo install cargo-workspaces
+        uses: baptiste0928/cargo-install@f204293d9709061b7bc1756fec3ec4e2cd57dec0 # v3.4.0
+        with:
+          crate: cargo-workspaces
 
       - name: Build (All features)
         run: cargo workspaces exec cargo build --all-features --all-targets --profile ci


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request fixes/closes #5197 .

It changes the following:

- Migrates 5 instances of bare `cargo install <binary>` commands to use the `baptiste0928/cargo-install` action (which Boa already safely uses for `cross` and `cargo-tarpaulin`).
- Eliminates redundant compilation of `cargo-workspaces`, `cargo-insta`, and `cargo-fuzz` from source on every single matrix job run.
- Pinning the cache-aware GitHub action to exactly `# v3.4.0` to preserve identical and secure behavior while aggressively chopping off minutes of dead compile time across the CI pipeline.
