### PR TITLE
fix(fetch): add status 205 to null body status check in Response

### DIFF
--- a/core/runtime/src/fetch/response.rs
+++ b/core/runtime/src/fetch/response.rs
@@ -96,11 +96,11 @@ impl TryIntoJs for ResponseType {
     }
 }
 
-/// A null body status is a status that is 101, 103, 204, or 304.
+/// A null body status is a status that is 101, 103, 204, 205, or 304.
 ///
 /// See <https://fetch.spec.whatwg.org/#null-body-status>
 fn is_null_body_status(status: u16) -> bool {
-    matches!(status, 101 | 103 | 204 | 304)
+    matches!(status, 101 | 103 | 204 | 205 | 304)
 }
 
 /// Validates that a string matches the `reason-phrase` token production.
@@ -239,7 +239,7 @@ fn initialize_response(
         // Step 6.1: If response's status is a null body status, throw a TypeError.
         if is_null_body_status(status) {
             return Err(
-                js_error!(TypeError: "Response body is not allowed for null body status codes (101, 103, 204, 304)."),
+                js_error!(TypeError: "Response body is not allowed for null body status codes (101, 103, 204, 205, 304)."),
             );
         }
 

--- a/core/runtime/src/fetch/tests/response.rs
+++ b/core/runtime/src/fetch/tests/response.rs
@@ -33,6 +33,28 @@ fn response_error() {
 }
 
 #[test]
+fn response_constructor_null_body_status_throws() {
+    run_test_actions([
+        TestAction::harness(),
+        TestAction::inspect_context(|ctx| register(&[], ctx)),
+        TestAction::run(
+            r#"
+                for (const status of [204, 205, 304]) {
+                    try {
+                        new Response("x", { status });
+                        throw Error("expected the call above to throw");
+                    } catch (e) {
+                        if (!(e instanceof TypeError)) {
+                            throw e;
+                        }
+                    }
+                }
+            "#,
+        ),
+    ]);
+}
+
+#[test]
 fn response_text() {
     run_test_actions([
         TestAction::harness(),


### PR DESCRIPTION
This Pull Request fixes/closes #5207.

It changes the following:
- Add `205` to the `is_null_body_status` check in `response.rs` so `new Response("x", { status: 205 })` throws a `TypeError`.
- Update the error message and doc comment to include `205`.
- Add a consolidated regression test covering `204`, `205`, and `304`.

Testing:
```bash
cargo test -p boa_runtime response -- --nocapture
```

Spec reference: https://fetch.spec.whatwg.org/#null-body-status