### PR TITLE
perf(store): use FxHashMap/FxHashSet for traversal seen maps

### DIFF
--- a/core/runtime/src/store/from.rs
+++ b/core/runtime/src/store/from.rs
@@ -9,12 +9,12 @@ use boa_engine::object::builtins::{
 };
 use boa_engine::property::PropertyKey;
 use boa_engine::{Context, JsError, JsObject, JsResult, JsString, JsValue, JsVariant, js_error};
-use std::collections::{HashMap, HashSet};
+use rustc_hash::{FxHashMap, FxHashSet};
 
 /// A Map of seen objects when walking through the value. We use the address
 /// of the inner object as it is unique per JavaScript value.
 #[derive(Default)]
-pub(super) struct SeenMap(HashMap<usize, JsValueStore>);
+pub(super) struct SeenMap(FxHashMap<usize, JsValueStore>);
 
 impl SeenMap {
     fn get(&self, object: &JsObject) -> Option<JsValueStore> {
@@ -37,7 +37,7 @@ pub(super) fn is_transferable(object: &JsObject) -> bool {
 /// The core logic of the [`JsValueStore::try_from_js`] function.
 fn try_from_js_object(
     value: &JsObject,
-    transfer: &HashSet<JsObject>,
+    transfer: &FxHashSet<JsObject>,
     seen: &mut SeenMap,
     context: &mut Context,
 ) -> JsResult<JsValueStore> {
@@ -79,7 +79,7 @@ fn try_from_js_object_transfer(
 
 fn try_from_array_clone(
     array: &JsArray,
-    transfer: &HashSet<JsObject>,
+    transfer: &FxHashSet<JsObject>,
     seen: &mut SeenMap,
     context: &mut Context,
 ) -> JsResult<JsValueStore> {
@@ -139,7 +139,7 @@ fn try_from_shared_array_buffer(
 fn clone_typed_array(
     original: &JsObject,
     buffer: &JsTypedArray,
-    transfer: &HashSet<JsObject>,
+    transfer: &FxHashSet<JsObject>,
     seen: &mut SeenMap,
     context: &mut Context,
 ) -> JsResult<JsValueStore> {
@@ -184,7 +184,7 @@ fn clone_regexp(
 fn try_from_map(
     original: &JsObject,
     map: &JsMap,
-    transfer: &HashSet<JsObject>,
+    transfer: &FxHashSet<JsObject>,
     seen: &mut SeenMap,
     context: &mut Context,
 ) -> JsResult<JsValueStore> {
@@ -211,7 +211,7 @@ fn try_from_map(
 fn try_from_set(
     original: &JsObject,
     set: &JsSet,
-    transfer: &HashSet<JsObject>,
+    transfer: &FxHashSet<JsObject>,
     seen: &mut SeenMap,
     context: &mut Context,
 ) -> JsResult<JsValueStore> {
@@ -236,7 +236,7 @@ fn try_from_set(
 
 fn try_from_js_object_clone(
     object: &JsObject,
-    transfer: &HashSet<JsObject>,
+    transfer: &FxHashSet<JsObject>,
     seen: &mut SeenMap,
     context: &mut Context,
 ) -> JsResult<JsValueStore> {
@@ -297,7 +297,7 @@ fn try_from_js_object_clone(
 
 pub(super) fn try_from_js_value(
     value: &JsValue,
-    transfer: &HashSet<JsObject>,
+    transfer: &FxHashSet<JsObject>,
     seen: &mut SeenMap,
     context: &mut Context,
 ) -> JsResult<JsValueStore> {

--- a/core/runtime/src/store/mod.rs
+++ b/core/runtime/src/store/mod.rs
@@ -5,7 +5,7 @@ use boa_engine::builtins::error::ErrorKind;
 use boa_engine::builtins::typed_array::TypedArrayKind;
 use boa_engine::value::TryIntoJs;
 use boa_engine::{Context, JsError, JsResult, JsString, JsValue, JsVariant, js_error};
-use std::collections::HashSet;
+use rustc_hash::FxHashSet;
 use std::sync::Arc;
 
 mod from;
@@ -211,7 +211,7 @@ impl JsValueStore {
                 JsVariant::Object(o) if from::is_transferable(&o) => Ok(o),
                 _ => Err(unsupported_transfer()),
             })
-            .collect::<Result<HashSet<_>, _>>()?;
+            .collect::<Result<FxHashSet<_>, _>>()?;
 
         let v = from::try_from_js_value(value, &transfer, &mut seen, context)?;
         Ok(v)

--- a/core/runtime/src/store/to.rs
+++ b/core/runtime/src/store/to.rs
@@ -7,10 +7,10 @@ use boa_engine::object::builtins::{
     js_typed_array_from_kind,
 };
 use boa_engine::{Context, JsBigInt, JsObject, JsResult, JsString, JsValue, js_error};
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 
 #[derive(Default)]
-pub(super) struct ReverseSeenMap(HashMap<usize, JsObject>);
+pub(super) struct ReverseSeenMap(FxHashMap<usize, JsObject>);
 
 impl ReverseSeenMap {
     fn get(&self, object: &JsValueStore) -> Option<JsObject> {


### PR DESCRIPTION
Closes #5213

This switches `HashMap` / `HashSet` to `FxHashMap` / `FxHashSet` in the structured clone/store path (`core/runtime/src/store/from.rs` and `to.rs`).

#### Problem
The store path uses standard collections for traversal bookkeeping (e.g. `SeenMap`, `ReverseSeenMap`).

These maps are keyed by internal identities (pointer-like values) and are hit a lot during deep or cyclic object traversal. Using the default hasher here is probably doing more work than needed.

#### Change
Replace those maps with `FxHashMap` / `FxHashSet`.

This only affects internal bookkeeping. There is no intended semantic change.

#### Benchmark
Ran a local benchmark using `boa_cli` with repeated `structuredClone()` on a deep cyclic object graph (10 rounds, release build).

| Metric | std (main) | FxHash (this PR) | Improvement |
|--------|------------|------------------|-------------|
| Median | 10,423 ms | 6,894 ms | ~33.8% faster |
| Min | 9,231 ms | 6,050 ms | ~34.4% faster |
| Max | 12,028 ms | 8,806 ms | ~26.7% faster |

#### Notes
- no intended semantic change
- only touches internal traversal bookkeeping
- FxHash is already used in other perf-sensitive parts of the engine

#### Test plan
- `cargo test -p boa_engine -p boa_runtime` passes
- manually tested structured cloning on deep / cyclic graphs
