### PR TITLE
test: add edge case coverage for Array.prototype.forEach

### DIFF
--- a/core/engine/src/object/tests.rs
+++ b/core/engine/src/object/tests.rs
@@ -38,3 +38,36 @@ fn object_properties_return_order() {
         ),
     ]);
 }
+
+#[test]
+fn array_prototype_for_each_edge_cases() {
+    run_test_actions([
+        TestAction::run_harness(),
+        // Empty array — callback never called
+        TestAction::assert(indoc! {r#"
+            var called = 0;
+            [].forEach(() => { called++; });
+            called === 0
+        "#}),
+        // Return value is always undefined
+        TestAction::assert(indoc! {r#"
+            var result = [1, 2, 3].forEach(x => x * 2);
+            result === undefined
+        "#}),
+        // Sparse array — holes are skipped
+        TestAction::assert(indoc! {r#"
+            var count = 0;
+            let arr = [1, , 3];
+            arr.forEach(() => { count++; });
+            count === 2
+        "#}),
+        // this binding via second argument
+        TestAction::assert(indoc! {r#"
+            var obj = { multiplier: 2, result: 0 };
+            [1, 2, 3].forEach(function(x) {
+                this.result += x * this.multiplier;
+            }, obj);
+            obj.result === 12
+        "#}),
+    ]);
+}


### PR DESCRIPTION
I added test cases for Array.prototype.forEach covering some edge 
cases that weren't tested before:

- Empty array  callback should never be called
- Return value should always be undefined
- Sparse array holes should be skipped by the callback
- this binding should work correctly via second argument

I made sure not to touch or remove any of the existing tests, 
only added the new ones.
Hope this looks good, let me know if any changes are needed!