### PR TITLE
fix(vm/opcode/define,set,call): convert panics to EngineError::Panic using js_expect

### DIFF
--- a/core/engine/src/vm/opcode/call/mod.rs
+++ b/core/engine/src/vm/opcode/call/mod.rs
@@ -5,7 +5,7 @@ use dynify::Dynify;
 
 use super::{IndexOperand, RegisterOperand};
 use crate::{
-    Context, JsError, JsObject, JsResult, JsValue, NativeFunction,
+    Context, JsError, JsExpect, JsObject, JsResult, JsValue, NativeFunction,
     builtins::{Promise, promise::PromiseCapability},
     error::JsNativeError,
     job::NativeAsyncJob,
@@ -107,12 +107,12 @@ impl CallEvalSpread {
         let arguments_array = context.vm.stack.pop();
         let arguments_array_object = arguments_array
             .as_object()
-            .expect("arguments array in call spread function must be an object");
+            .js_expect("arguments array in call spread function must be an object")?;
         let arguments = arguments_array_object
             .borrow()
             .properties()
             .to_dense_indexed_properties()
-            .expect("arguments array in call spread function must be dense");
+            .js_expect("arguments array in call spread function must be dense")?;
 
         let func = context.vm.stack.calling_convention_get_function(0);
 
@@ -223,12 +223,12 @@ impl CallSpread {
         let arguments_array = context.vm.stack.pop();
         let arguments_array_object = arguments_array
             .as_object()
-            .expect("arguments array in call spread function must be an object");
+            .js_expect("arguments array in call spread function must be an object")?;
         let arguments = arguments_array_object
             .borrow()
             .properties()
             .to_dense_indexed_properties()
-            .expect("arguments array in call spread function must be dense");
+            .js_expect("arguments array in call spread function must be dense")?;
 
         let argument_count = arguments.len();
         context
@@ -303,13 +303,13 @@ fn parse_import_attributes(
             for entry in entries {
                 let entry = entry
                     .as_object()
-                    .expect("entry from EnumerableOwnProperties must be an object");
+                    .js_expect("entry from EnumerableOwnProperties must be an object")?;
 
                 // 1. Let key be entry.[[Key]].
                 let key = entry.get(0, context)?;
                 let key_str = key
                     .as_string()
-                    .expect("key from EnumerableOwnProperties must be a string")
+                    .js_expect("key from EnumerableOwnProperties must be a string")?
                     .clone();
 
                 // 2. Let value be entry.[[Value]].

--- a/core/engine/src/vm/opcode/define/class/getter.rs
+++ b/core/engine/src/vm/opcode/define/class/getter.rs
@@ -1,7 +1,7 @@
 use boa_macros::js_str;
 
 use crate::{
-    Context, JsResult,
+    Context, JsExpect, JsResult,
     builtins::function::{OrdinaryFunction, set_function_name},
     object::internal_methods::InternalMethodPropertyContext,
     property::PropertyDescriptor,
@@ -23,7 +23,7 @@ impl DefineClassStaticGetterByName {
     ) -> JsResult<()> {
         let function = context.vm.get_register(function.into()).clone();
         let class = context.vm.get_register(class.into()).clone();
-        let class = class.as_object().expect("class must be object");
+        let class = class.as_object().js_expect("class must be object")?;
         let key = context
             .vm
             .frame()
@@ -33,11 +33,11 @@ impl DefineClassStaticGetterByName {
         {
             let function_object = function
                 .as_object()
-                .expect("method must be function object");
+                .js_expect("method must be function object")?;
             set_function_name(&function_object, &key, Some(js_str!("get")), context)?;
             function_object
                 .downcast_mut::<OrdinaryFunction>()
-                .expect("method must be function object")
+                .js_expect("method must be function object")?
                 .set_home_object(class.clone());
         }
         let set = class
@@ -80,7 +80,7 @@ impl DefineClassGetterByName {
     ) -> JsResult<()> {
         let function = context.vm.get_register(function.into()).clone();
         let class_proto = context.vm.get_register(class_proto.into()).clone();
-        let class_proto = class_proto.as_object().expect("class must be object");
+        let class_proto = class_proto.as_object().js_expect("class must be object")?;
         let key = context
             .vm
             .frame()
@@ -90,11 +90,11 @@ impl DefineClassGetterByName {
         {
             let function_object = function
                 .as_object()
-                .expect("method must be function object");
+                .js_expect("method must be function object")?;
             set_function_name(&function_object, &key, Some(js_str!("get")), context)?;
             function_object
                 .downcast_mut::<OrdinaryFunction>()
-                .expect("method must be function object")
+                .js_expect("method must be function object")?
                 .set_home_object(class_proto.clone());
         }
         let set = class_proto
@@ -138,18 +138,16 @@ impl DefineClassStaticGetterByValue {
         let function = context.vm.get_register(function.into()).clone();
         let key = context.vm.get_register(key.into()).clone();
         let class = context.vm.get_register(class.into()).clone();
-        let class = class.as_object().expect("class must be object");
-        let key = key
-            .to_property_key(context)
-            .expect("property key must already be valid");
+        let class = class.as_object().js_expect("class must be object")?;
+        let key = key.to_property_key(context)?;
         {
             let function_object = function
                 .as_object()
-                .expect("method must be function object");
+                .js_expect("method must be function object")?;
             set_function_name(&function_object, &key, Some(js_str!("get")), context)?;
             function_object
                 .downcast_mut::<OrdinaryFunction>()
-                .expect("method must be function object")
+                .js_expect("method must be function object")?
                 .set_home_object(class.clone());
         }
 
@@ -194,18 +192,16 @@ impl DefineClassGetterByValue {
         let function = context.vm.get_register(function.into()).clone();
         let key = context.vm.get_register(key.into()).clone();
         let class_proto = context.vm.get_register(class_proto.into()).clone();
-        let class_proto = class_proto.as_object().expect("class must be object");
-        let key = key
-            .to_property_key(context)
-            .expect("property key must already be valid");
+        let class_proto = class_proto.as_object().js_expect("class must be object")?;
+        let key = key.to_property_key(context)?;
         {
             let function_object = function
                 .as_object()
-                .expect("method must be function object");
+                .js_expect("method must be function object")?;
             set_function_name(&function_object, &key, Some(js_str!("get")), context)?;
             function_object
                 .downcast_mut::<OrdinaryFunction>()
-                .expect("method must be function object")
+                .js_expect("method must be function object")?
                 .set_home_object(class_proto.clone());
         }
         let set = class_proto

--- a/core/engine/src/vm/opcode/define/class/method.rs
+++ b/core/engine/src/vm/opcode/define/class/method.rs
@@ -1,5 +1,5 @@
 use crate::{
-    Context, JsResult,
+    Context, JsExpect, JsResult,
     builtins::function::{OrdinaryFunction, set_function_name},
     object::internal_methods::InternalMethodPropertyContext,
     property::PropertyDescriptor,
@@ -21,7 +21,7 @@ impl DefineClassStaticMethodByName {
     ) -> JsResult<()> {
         let function = context.vm.get_register(function.into()).clone();
         let class = context.vm.get_register(class.into()).clone();
-        let class = class.as_object().expect("class must be object");
+        let class = class.as_object().js_expect("class must be object")?;
         let key = context
             .vm
             .frame()
@@ -31,11 +31,11 @@ impl DefineClassStaticMethodByName {
         {
             let function_object = function
                 .as_object()
-                .expect("method must be function object");
+                .js_expect("method must be function object")?;
             set_function_name(&function_object, &key, None, context)?;
             function_object
                 .downcast_mut::<OrdinaryFunction>()
-                .expect("method must be function object")
+                .js_expect("method must be function object")?
                 .set_home_object(class.clone());
         }
 
@@ -69,7 +69,7 @@ impl DefineClassMethodByName {
     ) -> JsResult<()> {
         let function = context.vm.get_register(function.into()).clone();
         let class_proto = context.vm.get_register(class_proto.into()).clone();
-        let class_proto = class_proto.as_object().expect("class must be object");
+        let class_proto = class_proto.as_object().js_expect("class must be object")?;
         let key = context
             .vm
             .frame()
@@ -79,11 +79,11 @@ impl DefineClassMethodByName {
         {
             let function_object = function
                 .as_object()
-                .expect("method must be function object");
+                .js_expect("method must be function object")?;
             set_function_name(&function_object, &key, None, context)?;
             function_object
                 .downcast_mut::<OrdinaryFunction>()
-                .expect("method must be function object")
+                .js_expect("method must be function object")?
                 .set_home_object(class_proto.clone());
         }
 
@@ -118,18 +118,16 @@ impl DefineClassStaticMethodByValue {
         let function = context.vm.get_register(function.into()).clone();
         let key = context.vm.get_register(key.into()).clone();
         let class = context.vm.get_register(class.into()).clone();
-        let class = class.as_object().expect("class must be object");
-        let key = key
-            .to_property_key(context)
-            .expect("property key must already be valid");
+        let class = class.as_object().js_expect("class must be object")?;
+        let key = key.to_property_key(context)?;
         {
             let function_object = function
                 .as_object()
-                .expect("method must be function object");
+                .js_expect("method must be function object")?;
             set_function_name(&function_object, &key, None, context)?;
             function_object
                 .downcast_mut::<OrdinaryFunction>()
-                .expect("method must be function object")
+                .js_expect("method must be function object")?
                 .set_home_object(class.clone());
         }
 
@@ -169,18 +167,16 @@ impl DefineClassMethodByValue {
         let function = context.vm.get_register(function.into()).clone();
         let key = context.vm.get_register(key.into()).clone();
         let class_proto = context.vm.get_register(class_proto.into()).clone();
-        let class_proto = class_proto.as_object().expect("class must be object");
-        let key = key
-            .to_property_key(context)
-            .expect("property key must already be valid");
+        let class_proto = class_proto.as_object().js_expect("class must be object")?;
+        let key = key.to_property_key(context)?;
         {
             let function_object = function
                 .as_object()
-                .expect("method must be function object");
+                .js_expect("method must be function object")?;
             set_function_name(&function_object, &key, None, context)?;
             function_object
                 .downcast_mut::<OrdinaryFunction>()
-                .expect("method must be function object")
+                .js_expect("method must be function object")?
                 .set_home_object(class_proto.clone());
         }
 

--- a/core/engine/src/vm/opcode/define/class/setter.rs
+++ b/core/engine/src/vm/opcode/define/class/setter.rs
@@ -1,7 +1,7 @@
 use boa_macros::js_str;
 
 use crate::{
-    Context, JsResult,
+    Context, JsExpect, JsResult,
     builtins::function::{OrdinaryFunction, set_function_name},
     object::internal_methods::InternalMethodPropertyContext,
     property::PropertyDescriptor,
@@ -23,7 +23,7 @@ impl DefineClassStaticSetterByName {
     ) -> JsResult<()> {
         let function = context.vm.get_register(function.into()).clone();
         let class = context.vm.get_register(class.into()).clone();
-        let class = class.as_object().expect("class must be object");
+        let class = class.as_object().js_expect("class must be object")?;
         let key = context
             .vm
             .frame()
@@ -33,11 +33,11 @@ impl DefineClassStaticSetterByName {
         {
             let function_object = function
                 .as_object()
-                .expect("method must be function object");
+                .js_expect("method must be function object")?;
             set_function_name(&function_object, &key, Some(js_str!("set")), context)?;
             function_object
                 .downcast_mut::<OrdinaryFunction>()
-                .expect("method must be function object")
+                .js_expect("method must be function object")?
                 .set_home_object(class.clone());
         }
         let get = class
@@ -81,7 +81,7 @@ impl DefineClassSetterByName {
     ) -> JsResult<()> {
         let function = context.vm.get_register(function.into()).clone();
         let class_proto = context.vm.get_register(class_proto.into()).clone();
-        let class_proto = class_proto.as_object().expect("class must be object");
+        let class_proto = class_proto.as_object().js_expect("class must be object")?;
         let key = context
             .vm
             .frame()
@@ -91,11 +91,11 @@ impl DefineClassSetterByName {
         {
             let function_object = function
                 .as_object()
-                .expect("method must be function object");
+                .js_expect("method must be function object")?;
             set_function_name(&function_object, &key, Some(js_str!("set")), context)?;
             function_object
                 .downcast_mut::<OrdinaryFunction>()
-                .expect("method must be function object")
+                .js_expect("method must be function object")?
                 .set_home_object(class_proto.clone());
         }
         let get = class_proto
@@ -141,18 +141,16 @@ impl DefineClassStaticSetterByValue {
         let function = context.vm.get_register(function.into()).clone();
         let key = context.vm.get_register(key.into()).clone();
         let class = context.vm.get_register(class.into()).clone();
-        let class = class.as_object().expect("class must be object");
-        let key = key
-            .to_property_key(context)
-            .expect("property key must already be valid");
+        let class = class.as_object().js_expect("class must be object")?;
+        let key = key.to_property_key(context)?;
         {
             let function_object = function
                 .as_object()
-                .expect("method must be function object");
+                .js_expect("method must be function object")?;
             set_function_name(&function_object, &key, Some(js_str!("set")), context)?;
             function_object
                 .downcast_mut::<OrdinaryFunction>()
-                .expect("method must be function object")
+                .js_expect("method must be function object")?
                 .set_home_object(class.clone());
         }
         let get = class
@@ -198,18 +196,16 @@ impl DefineClassSetterByValue {
         let function = context.vm.get_register(function.into()).clone();
         let key = context.vm.get_register(key.into()).clone();
         let class_proto = context.vm.get_register(class_proto.into()).clone();
-        let class_proto = class_proto.as_object().expect("class must be object");
-        let key = key
-            .to_property_key(context)
-            .expect("property key must already be valid");
+        let class_proto = class_proto.as_object().js_expect("class must be object")?;
+        let key = key.to_property_key(context)?;
         {
             let function_object = function
                 .as_object()
-                .expect("method must be function object");
+                .js_expect("method must be function object")?;
             set_function_name(&function_object, &key, Some(js_str!("set")), context)?;
             function_object
                 .downcast_mut::<OrdinaryFunction>()
-                .expect("method must be function object")
+                .js_expect("method must be function object")?
                 .set_home_object(class_proto.clone());
         }
         let get = class_proto

--- a/core/engine/src/vm/opcode/set/name.rs
+++ b/core/engine/src/vm/opcode/set/name.rs
@@ -1,7 +1,7 @@
 use boa_ast::scope::{BindingLocator, BindingLocatorScope};
 
 use crate::{
-    Context, JsError, JsNativeError, JsResult,
+    Context, JsError, JsExpect, JsNativeError, JsResult,
     environments::Environment,
     vm::opcode::{IndexOperand, Operation, RegisterOperand},
 };
@@ -86,7 +86,7 @@ impl SetNameByLocator {
         let binding_locator = frame
             .binding_stack
             .pop()
-            .expect("locator should have been popped before");
+            .js_expect("locator should have been popped before")?;
         let value = context.vm.get_register(value.into()).clone();
 
         verify_initialized(&binding_locator, context)?;

--- a/core/engine/src/vm/opcode/set/private.rs
+++ b/core/engine/src/vm/opcode/set/private.rs
@@ -1,5 +1,5 @@
 use crate::{
-    Context, JsResult, js_str, js_string,
+    Context, JsExpect, JsResult, js_str, js_string,
     object::PrivateElement,
     property::PropertyDescriptor,
     vm::opcode::{IndexOperand, Operation, RegisterOperand},
@@ -31,7 +31,7 @@ impl SetPrivateField {
             .frame()
             .environments
             .resolve_private_identifier(name)
-            .expect("private name must be in environment");
+            .js_expect("private name must be in environment")?;
 
         base_obj.private_set(&name, value.clone(), context)?;
         Ok(())
@@ -67,7 +67,7 @@ impl DefinePrivateField {
 
         let object = object
             .as_object()
-            .expect("class prototype must be an object");
+            .js_expect("class prototype must be an object")?;
 
         let name = object.private_name(name);
         object.private_field_add(&name, value, context)?;


### PR DESCRIPTION
Part of #3241.
Converts all convertible .expect() panics to .js_expect()? in:

- `opcode/define/class/getter.rs`(14)
- `opcode/define/class/method.rs` (14)
- `opcode/define/class/setter.rs `(14)
- `opcode/set/name.rs` (1)
- `opcode/set/private.rs `(2)
- `opcode/call/mod.rs` (6)

Skipped with rationale:

set/private.rs SetPrivateMethod/SetPrivateSetter/SetPrivateGetter — return () instead of JsResult<()>
call/mod.rs remaining .expect() calls  spec-guaranteed invariants (ECMAScript ! notation) maybee genuine unreachable invariants inside async context.