### PR TITLE
fix(math): correct Math.acosh for large finite inputs

### DIFF
--- a/core/engine/src/builtins/math/mod.rs
+++ b/core/engine/src/builtins/math/mod.rs
@@ -153,9 +153,11 @@ impl Math {
     /// [spec]: https://tc39.es/ecma262/#sec-math.acosh
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/acosh
     pub(crate) fn acosh(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+        const ACOSH_LARGE_INPUT_THRESHOLD: f64 = 1e154;
+
         // 1. Let n be ? ToNumber(x).
         let n = args.get_or_undefined(0).to_number(context)?;
-        if n.is_finite() && n > 1e154 {
+        if n.is_finite() && n > ACOSH_LARGE_INPUT_THRESHOLD {
             return Ok((n.ln() + std::f64::consts::LN_2).into());
         }
 

--- a/core/engine/src/builtins/math/mod.rs
+++ b/core/engine/src/builtins/math/mod.rs
@@ -153,16 +153,17 @@ impl Math {
     /// [spec]: https://tc39.es/ecma262/#sec-math.acosh
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/acosh
     pub(crate) fn acosh(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        Ok(args
-            .get_or_undefined(0)
-            // 1. Let n be ? ToNumber(x).
-            .to_number(context)?
-            // 4. If n < 1𝔽, return NaN.
-            // 2. If n is NaN or n is +∞𝔽, return n.
-            // 3. If n is 1𝔽, return +0𝔽.
-            // 5. Return an implementation-approximated value representing the result of the inverse hyperbolic cosine of ℝ(n).
-            .acosh()
-            .into())
+        // 1. Let n be ? ToNumber(x).
+        let n = args.get_or_undefined(0).to_number(context)?;
+        if n.is_finite() && n > 1e154 {
+            return Ok((n.ln() + std::f64::consts::LN_2).into());
+        }
+
+        // 4. If n < 1𝔽, return NaN.
+        // 2. If n is NaN or n is +∞𝔽, return n.
+        // 3. If n is 1𝔽, return +0𝔽.
+        // 5. Return an implementation-approximated value representing the result of the inverse hyperbolic cosine of ℝ(n).
+        Ok(n.acosh().into())
     }
 
     /// Get the arcsine of a number.

--- a/core/engine/src/builtins/math/mod.rs
+++ b/core/engine/src/builtins/math/mod.rs
@@ -153,7 +153,8 @@ impl Math {
     /// [spec]: https://tc39.es/ecma262/#sec-math.acosh
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/acosh
     pub(crate) fn acosh(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        const ACOSH_LARGE_INPUT_THRESHOLD: f64 = 1e154;
+        // 1/√f64::EPSILON, as established by the Boost math library.
+        const ACOSH_LARGE_INPUT_THRESHOLD: f64 = 67_108_864.0;
 
         // 1. Let n be ? ToNumber(x).
         let n = args.get_or_undefined(0).to_number(context)?;

--- a/core/engine/src/builtins/math/tests.rs
+++ b/core/engine/src/builtins/math/tests.rs
@@ -24,6 +24,8 @@ fn acosh() {
         TestAction::assert_eq("Math.acosh(2)", 1.316_957_896_924_816_6),
         TestAction::assert_eq("Math.acosh(-1)", f64::NAN),
         TestAction::assert_eq("Math.acosh(0.5)", f64::NAN),
+        TestAction::assert_eq("Math.acosh(1e308)", 709.889_355_822_726_f64),
+        TestAction::assert_eq("Math.acosh(Number.MAX_VALUE)", 710.475_860_073_943_9_f64),
     ]);
 }
 


### PR DESCRIPTION
This Pull Request fixes/closes #5229.

It changes the following:
- When the input is finite and greater than `1/√f64::EPSILON` (`67_108_864.0`), fall back to `n.ln() + LN_2` instead of calling `f64::acosh()` directly, avoiding an internal `x²` overflow that produces `Infinity`. Threshold follows the [Boost math library convention](https://www.boost.org/doc/libs/latest/libs/math/doc/html/math_toolkit/inv_hyper/acosh.html).
- Add regression tests for `Math.acosh(1e308)` and `Math.acosh(Number.MAX_VALUE)`.

Testing:
```bash
cargo test -p boa_engine math -- --nocapture
```

Spec reference: https://tc39.es/ecma262/#sec-math.acosh