### PR TITLE
fix(repl): Dot commands not working.

### DIFF
--- a/cli/src/helper.rs
+++ b/cli/src/helper.rs
@@ -60,6 +60,11 @@ impl Validator for RLHelper {
         &self,
         context: &mut ValidationContext<'_>,
     ) -> Result<ValidationResult, ReadlineError> {
+        // Dot commands are handled by the REPL loop, not the JS parser.
+        if context.input().trim_start().starts_with('.') {
+            return Ok(ValidationResult::Valid(None));
+        }
+
         let mut parser = boa_parser::Parser::new(Source::from_bytes(context.input()));
         if self.strict {
             parser.set_strict();


### PR DESCRIPTION
This Pull Request fixes/closes #5219.

This commit fixes the parsing error that shows when using `dot` commands in the REPL.
It fixes this by preventing the passing of the `dot` commands to the JS parser.



It changes the following:
- [cli/helper.rs](https://github.com/boa-dev/boa/blob/main/cli/src/helper.rs): Prevents passing of dot commands to JS parser.