### PR TITLE
refactor: extract type-check boilerplate into a single `require_internal_slot!` macro

### DIFF
--- a/core/engine/src/builtins/array_buffer/mod.rs
+++ b/core/engine/src/builtins/array_buffer/mod.rs
@@ -496,12 +496,12 @@ impl ArrayBuffer {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[ArrayBufferData]]).
         // 3. If IsSharedArrayBuffer(O) is true, throw a TypeError exception.
-        require_internal_slot!(buf = this, Self, "ArrayBuffer");
+        let buf = require_internal_slot!(this, Self, "ArrayBuffer");
 
         // 4. If IsDetachedBuffer(O) is true, return +0𝔽.
         // 5. Let length be O.[[ArrayBufferByteLength]].
         // 6. Return 𝔽(length).
-        Ok(buf.len().into())
+        Ok(buf.borrow().data().len().into())
     }
 
     /// [`get ArrayBuffer.prototype.maxByteLength`][spec].
@@ -515,10 +515,12 @@ impl ArrayBuffer {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[ArrayBufferData]]).
         // 3. If IsSharedArrayBuffer(O) is true, throw a TypeError exception.
-        require_internal_slot!(buf = this, Self, "ArrayBuffer");
+        let buf = require_internal_slot!(this, Self, "ArrayBuffer");
 
         // 4. If IsDetachedBuffer(O) is true, return +0𝔽.
-        let Some(data) = buf.bytes() else {
+        let buf_data = buf.borrow();
+        let buf_data = buf_data.data();
+        let Some(data) = buf_data.bytes() else {
             return Ok(JsValue::from(0));
         };
 
@@ -527,7 +529,7 @@ impl ArrayBuffer {
         // 6. Else,
         //     a. Let length be O.[[ArrayBufferMaxByteLength]].
         // 7. Return 𝔽(length).
-        Ok(buf.max_byte_len.unwrap_or(data.len() as u64).into())
+        Ok(buf_data.max_byte_len.unwrap_or(data.len() as u64).into())
     }
 
     /// [`get ArrayBuffer.prototype.resizable`][spec].
@@ -541,10 +543,10 @@ impl ArrayBuffer {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[ArrayBufferData]]).
         // 3. If IsSharedArrayBuffer(O) is true, throw a TypeError exception.
-        require_internal_slot!(buf = this, Self, "ArrayBuffer");
+        let buf = require_internal_slot!(this, Self, "ArrayBuffer");
 
         // 4. If IsFixedLengthArrayBuffer(O) is false, return true; otherwise return false.
-        Ok(JsValue::from(!buf.is_fixed_len()))
+        Ok(JsValue::from(!buf.borrow().data().is_fixed_len()))
     }
 
     /// [`get ArrayBuffer.prototype.detached`][spec].
@@ -559,10 +561,10 @@ impl ArrayBuffer {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[ArrayBufferData]]).
         // 3. If IsSharedArrayBuffer(O) is true, throw a TypeError exception.
-        require_internal_slot!(buf = this, Self, "ArrayBuffer");
+        let buf = require_internal_slot!(this, Self, "ArrayBuffer");
 
         // 4. Return IsDetachedBuffer(O).
-        Ok(buf.is_detached().into())
+        Ok(buf.borrow().data().is_detached().into())
     }
 
     /// [`ArrayBuffer.prototype.resize ( newLength )`][spec].

--- a/core/engine/src/builtins/array_buffer/mod.rs
+++ b/core/engine/src/builtins/array_buffer/mod.rs
@@ -496,14 +496,7 @@ impl ArrayBuffer {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[ArrayBufferData]]).
         // 3. If IsSharedArrayBuffer(O) is true, throw a TypeError exception.
-        let object = this.as_object();
-        let buf = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ()
-                    .with_message("get ArrayBuffer.prototype.byteLength called with invalid `this`")
-            })?;
+        require_internal_slot!(buf = this, Self, "ArrayBuffer");
 
         // 4. If IsDetachedBuffer(O) is true, return +0𝔽.
         // 5. Let length be O.[[ArrayBufferByteLength]].
@@ -522,15 +515,7 @@ impl ArrayBuffer {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[ArrayBufferData]]).
         // 3. If IsSharedArrayBuffer(O) is true, throw a TypeError exception.
-        let object = this.as_object();
-        let buf = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message(
-                    "get ArrayBuffer.prototype.maxByteLength called with invalid `this`",
-                )
-            })?;
+        require_internal_slot!(buf = this, Self, "ArrayBuffer");
 
         // 4. If IsDetachedBuffer(O) is true, return +0𝔽.
         let Some(data) = buf.bytes() else {
@@ -556,14 +541,7 @@ impl ArrayBuffer {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[ArrayBufferData]]).
         // 3. If IsSharedArrayBuffer(O) is true, throw a TypeError exception.
-        let object = this.as_object();
-        let buf = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ()
-                    .with_message("get ArrayBuffer.prototype.resizable called with invalid `this`")
-            })?;
+        require_internal_slot!(buf = this, Self, "ArrayBuffer");
 
         // 4. If IsFixedLengthArrayBuffer(O) is false, return true; otherwise return false.
         Ok(JsValue::from(!buf.is_fixed_len()))
@@ -581,14 +559,7 @@ impl ArrayBuffer {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[ArrayBufferData]]).
         // 3. If IsSharedArrayBuffer(O) is true, throw a TypeError exception.
-        let object = this.as_object();
-        let buf = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ()
-                    .with_message("get ArrayBuffer.prototype.detached called with invalid `this`")
-            })?;
+        require_internal_slot!(buf = this, Self, "ArrayBuffer");
 
         // 4. Return IsDetachedBuffer(O).
         Ok(buf.is_detached().into())

--- a/core/engine/src/builtins/array_buffer/shared.rs
+++ b/core/engine/src/builtins/array_buffer/shared.rs
@@ -225,14 +225,7 @@ impl SharedArrayBuffer {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[ArrayBufferData]]).
         // 3. If IsSharedArrayBuffer(O) is true, throw a TypeError exception.
-        let object = this.as_object();
-        let buf = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ()
-                    .with_message("SharedArrayBuffer.byteLength called with invalid value")
-            })?;
+        require_internal_slot!(buf = this, Self, "SharedArrayBuffer");
 
         // 4. Let length be ArrayBufferByteLength(O, seq-cst).
         let len = buf.bytes(Ordering::SeqCst).len() as u64;
@@ -252,14 +245,7 @@ impl SharedArrayBuffer {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[ArrayBufferData]]).
         // 3. If IsSharedArrayBuffer(O) is false, throw a TypeError exception.
-        let object = this.as_object();
-        let buf = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ()
-                    .with_message("get SharedArrayBuffer.growable called with invalid `this`")
-            })?;
+        require_internal_slot!(buf = this, Self, "SharedArrayBuffer");
 
         // 4. If IsFixedLengthArrayBuffer(O) is false, return true; otherwise return false.
         Ok(JsValue::from(!buf.is_fixed_len()))
@@ -276,14 +262,7 @@ impl SharedArrayBuffer {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[ArrayBufferData]]).
         // 3. If IsSharedArrayBuffer(O) is false, throw a TypeError exception.
-        let object = this.as_object();
-        let buf = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ()
-                    .with_message("get SharedArrayBuffer.maxByteLength called with invalid value")
-            })?;
+        require_internal_slot!(buf = this, Self, "SharedArrayBuffer");
 
         // 4. If IsFixedLengthArrayBuffer(O) is true, then
         //     a. Let length be O.[[ArrayBufferByteLength]].

--- a/core/engine/src/builtins/array_buffer/shared.rs
+++ b/core/engine/src/builtins/array_buffer/shared.rs
@@ -225,10 +225,10 @@ impl SharedArrayBuffer {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[ArrayBufferData]]).
         // 3. If IsSharedArrayBuffer(O) is true, throw a TypeError exception.
-        require_internal_slot!(buf = this, Self, "SharedArrayBuffer");
+        let buf = require_internal_slot!(this, Self, "SharedArrayBuffer");
 
         // 4. Let length be ArrayBufferByteLength(O, seq-cst).
-        let len = buf.bytes(Ordering::SeqCst).len() as u64;
+        let len = buf.borrow().data().bytes(Ordering::SeqCst).len() as u64;
 
         // 5. Return 𝔽(length).
         Ok(len.into())
@@ -245,10 +245,10 @@ impl SharedArrayBuffer {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[ArrayBufferData]]).
         // 3. If IsSharedArrayBuffer(O) is false, throw a TypeError exception.
-        require_internal_slot!(buf = this, Self, "SharedArrayBuffer");
+        let buf = require_internal_slot!(this, Self, "SharedArrayBuffer");
 
         // 4. If IsFixedLengthArrayBuffer(O) is false, return true; otherwise return false.
-        Ok(JsValue::from(!buf.is_fixed_len()))
+        Ok(JsValue::from(!buf.borrow().data().is_fixed_len()))
     }
 
     /// [`get SharedArrayBuffer.prototype.maxByteLength`][spec].
@@ -262,14 +262,14 @@ impl SharedArrayBuffer {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[ArrayBufferData]]).
         // 3. If IsSharedArrayBuffer(O) is false, throw a TypeError exception.
-        require_internal_slot!(buf = this, Self, "SharedArrayBuffer");
+        let buf = require_internal_slot!(this, Self, "SharedArrayBuffer");
 
         // 4. If IsFixedLengthArrayBuffer(O) is true, then
         //     a. Let length be O.[[ArrayBufferByteLength]].
         // 5. Else,
         //     a. Let length be O.[[ArrayBufferMaxByteLength]].
         // 6. Return 𝔽(length).
-        Ok(buf.data.buffer.len().into())
+        Ok(buf.borrow().data().data.buffer.len().into())
     }
 
     /// [`SharedArrayBuffer.prototype.grow ( newLength )`][spec].

--- a/core/engine/src/builtins/dataview/mod.rs
+++ b/core/engine/src/builtins/dataview/mod.rs
@@ -331,10 +331,11 @@ impl DataView {
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[DataView]]).
-        require_internal_slot!(view = this, Self, "DataView");
+        let view = require_internal_slot!(this, Self, "DataView");
         // 3. Assert: O has a [[ViewedArrayBuffer]] internal slot.
         // 4. Let buffer be O.[[ViewedArrayBuffer]].
-        let buffer = view.viewed_array_buffer.clone();
+        let view_data = view.borrow();
+        let buffer = view_data.data().viewed_array_buffer.clone();
         // 5. Return buffer.
         Ok(buffer.into())
     }
@@ -357,14 +358,15 @@ impl DataView {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[DataView]]).
         // 3. Assert: O has a [[ViewedArrayBuffer]] internal slot.
-        require_internal_slot!(view = this, Self, "DataView");
+        let view = require_internal_slot!(this, Self, "DataView");
 
         // 4. Let viewRecord be MakeDataViewWithBufferWitnessRecord(O, seq-cst).
         // 5. If IsViewOutOfBounds(viewRecord) is true, throw a TypeError exception.
-        let buffer = view.viewed_array_buffer.as_buffer();
+        let view_data = view.borrow();
+        let buffer = view_data.data().viewed_array_buffer.as_buffer();
         let Some(slice) = buffer
             .bytes(Ordering::SeqCst)
-            .filter(|s| !view.is_out_of_bounds(s.len()))
+            .filter(|s| !view.borrow().data().is_out_of_bounds(s.len()))
         else {
             return Err(JsNativeError::typ()
                 .with_message("view out of bounds for its inner buffer")
@@ -372,7 +374,8 @@ impl DataView {
         };
 
         // 6. Let size be GetViewByteLength(viewRecord).
-        let size = view.byte_length(slice.len());
+        let view_data = view.borrow();
+        let size = view_data.data().byte_length(slice.len());
 
         // 7. Return 𝔽(size).
         Ok(size.into())
@@ -396,15 +399,16 @@ impl DataView {
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[DataView]]).
-        require_internal_slot!(view = this, Self, "DataView");
+        let view = require_internal_slot!(this, Self, "DataView");
 
         // 3. Assert: O has a [[ViewedArrayBuffer]] internal slot.
-        let buffer = view.viewed_array_buffer.as_buffer();
+        let view_data = view.borrow();
+        let buffer = view_data.data().viewed_array_buffer.as_buffer();
         // 4. Let viewRecord be MakeDataViewWithBufferWitnessRecord(O, seq-cst).
         // 5. If IsViewOutOfBounds(viewRecord) is true, throw a TypeError exception.
         if buffer
             .bytes(Ordering::SeqCst)
-            .filter(|b| !view.is_out_of_bounds(b.len()))
+            .filter(|b| !view.borrow().data().is_out_of_bounds(b.len()))
             .is_none()
         {
             return Err(JsNativeError::typ()
@@ -413,7 +417,8 @@ impl DataView {
         }
 
         // 6. Let offset be O.[[ByteOffset]].
-        let offset = view.byte_offset;
+        let view_data = view.borrow();
+        let offset = view_data.data().byte_offset;
         // 7. Return 𝔽(offset).
         Ok(offset.into())
     }
@@ -436,7 +441,7 @@ impl DataView {
     ) -> JsResult<JsValue> {
         // 1. Perform ? RequireInternalSlot(view, [[DataView]]).
         // 2. Assert: view has a [[ViewedArrayBuffer]] internal slot.
-        require_internal_slot!(view = view, Self, "DataView");
+        let view = require_internal_slot!(view, Self, "DataView");
 
         // 3. Let getIndex be ? ToIndex(requestIndex).
         let get_index = request_index.to_index(context)?;
@@ -447,10 +452,11 @@ impl DataView {
         // 6. Let viewRecord be MakeDataViewWithBufferWitnessRecord(view, unordered).
         // 7. NOTE: Bounds checking is not a synchronizing operation when view's backing buffer is a growable SharedArrayBuffer.
         // 8. If IsViewOutOfBounds(viewRecord) is true, throw a TypeError exception.
-        let buffer = view.viewed_array_buffer.as_buffer();
+        let view_data = view.borrow();
+        let buffer = view_data.data().viewed_array_buffer.as_buffer();
         let Some(data) = buffer
             .bytes(Ordering::Relaxed)
-            .filter(|buf| !view.is_out_of_bounds(buf.len()))
+            .filter(|buf| !view.borrow().data().is_out_of_bounds(buf.len()))
         else {
             return Err(JsNativeError::typ()
                 .with_message("view out of bounds for its inner buffer")
@@ -458,10 +464,12 @@ impl DataView {
         };
 
         // 5. Let viewOffset be view.[[ByteOffset]].
-        let view_offset = view.byte_offset;
+        let view_data = view.borrow();
+        let view_offset = view_data.data().byte_offset;
 
         // 9. Let viewSize be GetViewByteLength(viewRecord).
-        let view_size = view.byte_length(data.len());
+        let view_data = view.borrow();
+        let view_size = view_data.data().byte_length(data.len());
 
         // 10. Let elementSize be the Element Size value specified in Table 71 for Element Type type.
         let element_size = size_of::<T>() as u64;
@@ -774,7 +782,7 @@ impl DataView {
     ) -> JsResult<JsValue> {
         // 1. Perform ? RequireInternalSlot(view, [[DataView]]).
         // 2. Assert: view has a [[ViewedArrayBuffer]] internal slot.
-        require_internal_slot!(view = view, Self, "DataView");
+        let view = require_internal_slot!(view, Self, "DataView");
 
         // 3. Let getIndex be ? ToIndex(requestIndex).
         let get_index = request_index.to_index(context)?;
@@ -789,11 +797,15 @@ impl DataView {
         // 8. Let viewRecord be MakeDataViewWithBufferWitnessRecord(view, unordered).
         // 9. NOTE: Bounds checking is not a synchronizing operation when view's backing buffer is a growable SharedArrayBuffer.
         // 10. If IsViewOutOfBounds(viewRecord) is true, throw a TypeError exception.
-        let mut buffer = view.viewed_array_buffer.as_buffer_mut();
+        let viewed_buffer = {
+            let view_data = view.borrow();
+            view_data.data().viewed_array_buffer.clone()
+        };
+        let mut buffer = viewed_buffer.as_buffer_mut();
 
         let Some(mut data) = buffer
             .bytes(Ordering::Relaxed)
-            .filter(|buf| !view.is_out_of_bounds(buf.len()))
+            .filter(|buf| !view.borrow().data().is_out_of_bounds(buf.len()))
         else {
             return Err(JsNativeError::typ()
                 .with_message("view out of bounds for its inner buffer")
@@ -801,10 +813,12 @@ impl DataView {
         };
 
         // 11. Let viewSize be GetViewByteLength(viewRecord).
-        let view_size = view.byte_length(data.len());
+        let view_data = view.borrow();
+        let view_size = view_data.data().byte_length(data.len());
 
         // 7. Let viewOffset be view.[[ByteOffset]].
-        let view_offset = view.byte_offset;
+        let view_data = view.borrow();
+        let view_offset = view_data.data().byte_offset;
 
         // 12. Let elementSize be the Element Size value specified in Table 71 for Element Type type.
         let elem_size = size_of::<T>();

--- a/core/engine/src/builtins/dataview/mod.rs
+++ b/core/engine/src/builtins/dataview/mod.rs
@@ -331,11 +331,7 @@ impl DataView {
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[DataView]]).
-        let object = this.as_object();
-        let view = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| JsNativeError::typ().with_message("`this` is not a DataView"))?;
+        require_internal_slot!(view = this, Self, "DataView");
         // 3. Assert: O has a [[ViewedArrayBuffer]] internal slot.
         // 4. Let buffer be O.[[ViewedArrayBuffer]].
         let buffer = view.viewed_array_buffer.clone();
@@ -361,11 +357,7 @@ impl DataView {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[DataView]]).
         // 3. Assert: O has a [[ViewedArrayBuffer]] internal slot.
-        let object = this.as_object();
-        let view = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| JsNativeError::typ().with_message("`this` is not a DataView"))?;
+        require_internal_slot!(view = this, Self, "DataView");
 
         // 4. Let viewRecord be MakeDataViewWithBufferWitnessRecord(O, seq-cst).
         // 5. If IsViewOutOfBounds(viewRecord) is true, throw a TypeError exception.
@@ -404,11 +396,7 @@ impl DataView {
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[DataView]]).
-        let object = this.as_object();
-        let view = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| JsNativeError::typ().with_message("`this` is not a DataView"))?;
+        require_internal_slot!(view = this, Self, "DataView");
 
         // 3. Assert: O has a [[ViewedArrayBuffer]] internal slot.
         let buffer = view.viewed_array_buffer.as_buffer();
@@ -448,11 +436,7 @@ impl DataView {
     ) -> JsResult<JsValue> {
         // 1. Perform ? RequireInternalSlot(view, [[DataView]]).
         // 2. Assert: view has a [[ViewedArrayBuffer]] internal slot.
-        let object = view.as_object();
-        let view = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| JsNativeError::typ().with_message("`this` is not a DataView"))?;
+        require_internal_slot!(view = view, Self, "DataView");
 
         // 3. Let getIndex be ? ToIndex(requestIndex).
         let get_index = request_index.to_index(context)?;
@@ -790,11 +774,7 @@ impl DataView {
     ) -> JsResult<JsValue> {
         // 1. Perform ? RequireInternalSlot(view, [[DataView]]).
         // 2. Assert: view has a [[ViewedArrayBuffer]] internal slot.
-        let object = view.as_object();
-        let view = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| JsNativeError::typ().with_message("`this` is not a DataView"))?;
+        require_internal_slot!(view = view, Self, "DataView");
 
         // 3. Let getIndex be ? ToIndex(requestIndex).
         let get_index = request_index.to_index(context)?;

--- a/core/engine/src/builtins/date/mod.rs
+++ b/core/engine/src/builtins/date/mod.rs
@@ -446,11 +446,8 @@ impl Date {
         // 1. Let dateObject be the this value.
         // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
         // 3. Let t be dateObject.[[DateValue]].
-        let t = this
-            .as_object()
-            .and_then(|obj| obj.downcast_ref::<Date>().as_deref().copied())
-            .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?
-            .0;
+        require_internal_slot!(date = this, Date, "Date");
+        let t = date.0;
 
         // 4. If t is NaN, return NaN.
         if t.is_nan() {
@@ -485,11 +482,8 @@ impl Date {
         // 1. Let dateObject be the this value.
         // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
         // 3. Let t be dateObject.[[DateValue]].
-        let t = this
-            .as_object()
-            .and_then(|obj| obj.downcast_ref::<Date>().as_deref().copied())
-            .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?
-            .0;
+        require_internal_slot!(date = this, Date, "Date");
+        let t = date.0;
 
         // 4. If t is NaN, return NaN.
         if t.is_nan() {
@@ -527,11 +521,8 @@ impl Date {
         // 1. Let dateObject be the this value.
         // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
         // 3. Let t be dateObject.[[DateValue]].
-        let t = this
-            .as_object()
-            .and_then(|obj| obj.downcast_ref::<Date>().as_deref().copied())
-            .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?
-            .0;
+        require_internal_slot!(date = this, Date, "Date");
+        let t = date.0;
 
         // 4. If t is NaN, return NaN.
         if t.is_nan() {
@@ -559,11 +550,8 @@ impl Date {
         // 1. Let dateObject be the this value.
         // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
         // 3. Let t be dateObject.[[DateValue]].
-        let t = this
-            .as_object()
-            .and_then(|obj| obj.downcast_ref::<Date>().as_deref().copied())
-            .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?
-            .0;
+        require_internal_slot!(date = this, Date, "Date");
+        let t = date.0;
 
         // 4. If t is NaN, return NaN.
         if t.is_nan() {
@@ -597,11 +585,8 @@ impl Date {
         // 1. Let dateObject be the this value.
         // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
         // 3. Let t be dateObject.[[DateValue]].
-        let t = this
-            .as_object()
-            .and_then(|obj| obj.downcast_ref::<Date>().as_deref().copied())
-            .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?
-            .0;
+        require_internal_slot!(date = this, Date, "Date");
+        let t = date.0;
 
         // 4. If t is NaN, return NaN.
         if t.is_nan() {
@@ -635,11 +620,8 @@ impl Date {
         // 1. Let dateObject be the this value.
         // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
         // 3. Let t be dateObject.[[DateValue]].
-        let t = this
-            .as_object()
-            .and_then(|obj| obj.downcast_ref::<Date>().as_deref().copied())
-            .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?
-            .0;
+        require_internal_slot!(date = this, Date, "Date");
+        let t = date.0;
 
         // 4. If t is NaN, return NaN.
         if t.is_nan() {
@@ -673,11 +655,8 @@ impl Date {
         // 1. Let dateObject be the this value.
         // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
         // 3. Let t be dateObject.[[DateValue]].
-        let t = this
-            .as_object()
-            .and_then(|obj| obj.downcast_ref::<Date>().as_deref().copied())
-            .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?
-            .0;
+        require_internal_slot!(date = this, Date, "Date");
+        let t = date.0;
 
         // 4. If t is NaN, return NaN.
         if t.is_nan() {
@@ -712,11 +691,8 @@ impl Date {
         // 1. Let dateObject be the this value.
         // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
         // 3. Let t be dateObject.[[DateValue]].
-        let t = this
-            .as_object()
-            .and_then(|obj| obj.downcast_ref::<Date>().as_deref().copied())
-            .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?
-            .0;
+        require_internal_slot!(date = this, Date, "Date");
+        let t = date.0;
 
         // 4. If t is NaN, return NaN.
         if t.is_nan() {
@@ -750,11 +726,8 @@ impl Date {
         // 1. Let dateObject be the this value.
         // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
         // 3. Let t be dateObject.[[DateValue]].
-        let t = this
-            .as_object()
-            .and_then(|obj| obj.downcast_ref::<Date>().as_deref().copied())
-            .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?
-            .0;
+        require_internal_slot!(date = this, Date, "Date");
+        let t = date.0;
 
         // 4. If t is NaN, return NaN.
         if t.is_nan() {
@@ -791,12 +764,8 @@ impl Date {
         // 1. Let dateObject be the this value.
         // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
         // 3. Return dateObject.[[DateValue]].
-        Ok(this
-            .as_object()
-            .and_then(|obj| obj.downcast_ref::<Date>().as_deref().copied())
-            .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?
-            .0
-            .into())
+        require_internal_slot!(date = this, Date, "Date");
+        Ok(date.0.into())
     }
 
     /// `Date.prototype.getTimeZoneOffset()`.
@@ -818,11 +787,8 @@ impl Date {
         // 1. Let dateObject be the this value.
         // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
         // 3. Let t be dateObject.[[DateValue]].
-        let t = this
-            .as_object()
-            .and_then(|obj| obj.downcast_ref::<Date>().as_deref().copied())
-            .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?
-            .0;
+        require_internal_slot!(date = this, Date, "Date");
+        let t = date.0;
 
         // 4. If t is NaN, return NaN.
         if t.is_nan() {
@@ -850,11 +816,7 @@ impl Date {
     ) -> JsResult<JsValue> {
         // 1. Let dateObject be the this value.
         // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
-        let object = this.as_object();
-        let date = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Date>)
-            .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?;
+        require_internal_slot!(date = this, Date, "Date");
 
         // 3. Let t be dateObject.[[DateValue]].
         let mut t = date.0;
@@ -896,7 +858,9 @@ impl Date {
         let mut date_mut = object
             .as_ref()
             .and_then(JsObject::downcast_mut::<Date>)
-            .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?;
+            .ok_or_else(|| {
+                JsNativeError::typ().with_message("the this object must be a Date object.")
+            })?;
 
         // 9. Set dateObject.[[DateValue]] to u.
         date_mut.0 = u;
@@ -920,11 +884,7 @@ impl Date {
     ) -> JsResult<JsValue> {
         // 1. Let dateObject be the this value.
         // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
-        let object = this.as_object();
-        let date = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Date>)
-            .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?;
+        require_internal_slot!(date = this, Date, "Date");
 
         // 3. Let t be dateObject.[[DateValue]].
         let t = date.0;
@@ -979,7 +939,9 @@ impl Date {
         let mut date_mut = object
             .as_ref()
             .and_then(JsObject::downcast_mut::<Date>)
-            .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?;
+            .ok_or_else(|| {
+                JsNativeError::typ().with_message("the this object must be a Date object.")
+            })?;
 
         // 10. Set dateObject.[[DateValue]] to u.
         date_mut.0 = u;
@@ -1005,11 +967,7 @@ impl Date {
     ) -> JsResult<JsValue> {
         // 1. Let dateObject be the this value.
         // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
-        let object = this.as_object();
-        let date = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Date>)
-            .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?;
+        require_internal_slot!(date = this, Date, "Date");
 
         // 3. Let t be dateObject.[[DateValue]].
         let mut t = date.0;
@@ -1066,7 +1024,9 @@ impl Date {
         let mut date_mut = object
             .as_ref()
             .and_then(JsObject::downcast_mut::<Date>)
-            .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?;
+            .ok_or_else(|| {
+                JsNativeError::typ().with_message("the this object must be a Date object.")
+            })?;
 
         // 15. Set dateObject.[[DateValue]] to u.
         date_mut.0 = u;
@@ -1089,11 +1049,7 @@ impl Date {
     ) -> JsResult<JsValue> {
         // 1. Let dateObject be the this value.
         // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
-        let object = this.as_object();
-        let date = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Date>)
-            .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?;
+        require_internal_slot!(date = this, Date, "Date");
 
         // 3. Let t be dateObject.[[DateValue]].
         let mut t = date.0;
@@ -1140,7 +1096,9 @@ impl Date {
         let mut date_mut = object
             .as_ref()
             .and_then(JsObject::downcast_mut::<Date>)
-            .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?;
+            .ok_or_else(|| {
+                JsNativeError::typ().with_message("the this object must be a Date object.")
+            })?;
 
         // 9. Set dateObject.[[DateValue]] to u.
         date_mut.0 = u;
@@ -1163,11 +1121,7 @@ impl Date {
     ) -> JsResult<JsValue> {
         // 1. Let dateObject be the this value.
         // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
-        let object = this.as_object();
-        let date = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Date>)
-            .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?;
+        require_internal_slot!(date = this, Date, "Date");
 
         // 3. Let t be dateObject.[[DateValue]].
         let mut t = date.0;
@@ -1218,7 +1172,9 @@ impl Date {
         let mut date_mut = object
             .as_ref()
             .and_then(JsObject::downcast_mut::<Date>)
-            .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?;
+            .ok_or_else(|| {
+                JsNativeError::typ().with_message("the this object must be a Date object.")
+            })?;
 
         // 13. Set dateObject.[[DateValue]] to u.
         date_mut.0 = u;
@@ -1242,11 +1198,7 @@ impl Date {
     ) -> JsResult<JsValue> {
         // 1. Let dateObject be the this value.
         // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
-        let object = this.as_object();
-        let date = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Date>)
-            .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?;
+        require_internal_slot!(date = this, Date, "Date");
 
         // 3. Let t be dateObject.[[DateValue]].
         let mut t = date.0;
@@ -1294,7 +1246,9 @@ impl Date {
         let mut date_mut = object
             .as_ref()
             .and_then(JsObject::downcast_mut::<Date>)
-            .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?;
+            .ok_or_else(|| {
+                JsNativeError::typ().with_message("the this object must be a Date object.")
+            })?;
 
         // 11. Set dateObject.[[DateValue]] to u.
         date_mut.0 = u;
@@ -1317,11 +1271,7 @@ impl Date {
     ) -> JsResult<JsValue> {
         // 1. Let dateObject be the this value.
         // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
-        let object = this.as_object();
-        let date = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Date>)
-            .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?;
+        require_internal_slot!(date = this, Date, "Date");
 
         // 3. Let t be dateObject.[[DateValue]].
         let mut t = date.0;
@@ -1369,7 +1319,9 @@ impl Date {
         let mut date_mut = object
             .as_ref()
             .and_then(JsObject::downcast_mut::<Date>)
-            .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?;
+            .ok_or_else(|| {
+                JsNativeError::typ().with_message("the this object must be a Date object.")
+            })?;
 
         // 11. Set dateObject.[[DateValue]] to u.
         date_mut.0 = u;
@@ -1399,11 +1351,7 @@ impl Date {
     ) -> JsResult<JsValue> {
         // 1. Let dateObject be the this value.
         // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
-        let object = this.as_object();
-        let date = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Date>)
-            .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?;
+        require_internal_slot!(date = this, Date, "Date");
 
         // 3. Let t be dateObject.[[DateValue]].
         let t = date.0;
@@ -1440,7 +1388,9 @@ impl Date {
         let mut date_mut = object
             .as_ref()
             .and_then(JsObject::downcast_mut::<Date>)
-            .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?;
+            .ok_or_else(|| {
+                JsNativeError::typ().with_message("the this object must be a Date object.")
+            })?;
 
         // 10. Set dateObject.[[DateValue]] to u.
         date_mut.0 = u;
@@ -1466,11 +1416,7 @@ impl Date {
     ) -> JsResult<JsValue> {
         // 1. Let dateObject be the this value.
         // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
-        let object = this.as_object();
-        let date = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Date>)
-            .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?;
+        require_internal_slot!(date = this, Date, "Date");
 
         // 3. Let t be ? ToNumber(time).
         let t = args.get_or_undefined(0).to_number(context)?;
@@ -1488,7 +1434,9 @@ impl Date {
         let mut date_mut = object
             .as_ref()
             .and_then(JsObject::downcast_mut::<Date>)
-            .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?;
+            .ok_or_else(|| {
+                JsNativeError::typ().with_message("the this object must be a Date object.")
+            })?;
 
         // 5. Set dateObject.[[DateValue]] to v.
         date_mut.0 = v;
@@ -1514,11 +1462,8 @@ impl Date {
         // 1. Let dateObject be the this value.
         // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
         // 3. Let tv be dateObject.[[DateValue]].
-        let tv = this
-            .as_object()
-            .and_then(|obj| obj.downcast_ref::<Date>().as_deref().copied())
-            .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?
-            .0;
+        require_internal_slot!(date = this, Date, "Date");
+        let tv = date.0;
 
         // 4. If tv is NaN, return "Invalid Date".
         if tv.is_nan() {
@@ -1551,11 +1496,8 @@ impl Date {
         // 1. Let dateObject be the this value.
         // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
         // 3. Let tv be dateObject.[[DateValue]].
-        let tv = this
-            .as_object()
-            .and_then(|obj| obj.downcast_ref::<Date>().as_deref().copied())
-            .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?
-            .0;
+        require_internal_slot!(date = this, Date, "Date");
+        let tv = date.0;
 
         // 4. If tv is not finite, throw a RangeError exception.
         if !tv.is_finite() {
@@ -1663,11 +1605,8 @@ impl Date {
             // 1. Let dateObject be the this value.
             // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
             // 3. Let x be dateObject.[[DateValue]].
-            let t = this
-                .as_object()
-                .and_then(|obj| obj.downcast_ref::<Date>().as_deref().copied())
-                .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?
-                .0;
+            require_internal_slot!(date = this, Date, "Date");
+            let t = date.0;
             // 4. If x is NaN, return "Invalid Date".
             if t.is_nan() {
                 return Ok(JsValue::new(js_string!("Invalid Date")));
@@ -1717,11 +1656,8 @@ impl Date {
             // 1. Let dateObject be the this value.
             // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
             // 3. Let x be dateObject.[[DateValue]].
-            let t = this
-                .as_object()
-                .and_then(|obj| obj.downcast_ref::<Date>().as_deref().copied())
-                .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?
-                .0;
+            require_internal_slot!(date = this, Date, "Date");
+            let t = date.0;
             // 4. If x is NaN, return "Invalid Date".
             if t.is_nan() {
                 return Ok(JsValue::new(js_string!("Invalid Date")));
@@ -1772,11 +1708,8 @@ impl Date {
             // 1. Let dateObject be the this value.
             // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
             // 3. Let x be dateObject.[[DateValue]].
-            let t = this
-                .as_object()
-                .and_then(|obj| obj.downcast_ref::<Date>().as_deref().copied())
-                .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?
-                .0;
+            require_internal_slot!(date = this, Date, "Date");
+            let t = date.0;
             // 4. If x is NaN, return "Invalid Date".
             if t.is_nan() {
                 return Ok(JsValue::new(js_string!("Invalid Date")));
@@ -1817,11 +1750,8 @@ impl Date {
         // 1. Let dateObject be the this value.
         // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
         // 3. Let tv be dateObject.[[DateValue]].
-        let tv = this
-            .as_object()
-            .and_then(|obj| obj.downcast_ref::<Date>().as_deref().copied())
-            .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?
-            .0;
+        require_internal_slot!(date = this, Date, "Date");
+        let tv = date.0;
 
         // 4. Return ToDateString(tv).
         Ok(JsValue::from(to_date_string_t(
@@ -1848,11 +1778,8 @@ impl Date {
         // 1. Let dateObject be the this value.
         // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
         // 3. Let tv be dateObject.[[DateValue]].
-        let tv = this
-            .as_object()
-            .and_then(|obj| obj.downcast_ref::<Date>().as_deref().copied())
-            .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?
-            .0;
+        require_internal_slot!(date = this, Date, "Date");
+        let tv = date.0;
 
         // 4. If tv is NaN, return "Invalid Date".
         if tv.is_nan() {
@@ -1886,11 +1813,8 @@ impl Date {
         // 1. Let dateObject be the this value.
         // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
         // 3. Let tv be dateObject.[[DateValue]].
-        let tv = this
-            .as_object()
-            .and_then(|obj| obj.downcast_ref::<Date>().as_deref().copied())
-            .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?
-            .0;
+        require_internal_slot!(date = this, Date, "Date");
+        let tv = date.0;
 
         // 4. If tv is NaN, return "Invalid Date".
         if tv.is_nan() {
@@ -1990,12 +1914,8 @@ impl Date {
         // 1. Let dateObject be the this value.
         // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
         // 3. Return dateObject.[[DateValue]].
-        Ok(this
-            .as_object()
-            .and_then(|obj| obj.downcast_ref::<Date>().as_deref().copied())
-            .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?
-            .0
-            .into())
+        require_internal_slot!(date = this, Date, "Date");
+        Ok(date.0.into())
     }
 
     /// [`Date.prototype [ @@toPrimitive ] ( hint )`][spec].
@@ -2063,11 +1983,8 @@ impl Date {
         // 1. Let dateObject be the this value.
         // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
         // 3. Let t be dateObject.[[DateValue]].
-        let t = this
-            .as_object()
-            .and_then(|obj| obj.downcast_ref::<Date>().as_deref().copied())
-            .ok_or_else(|| js_error!(TypeError: "'this' is not a Date"))?
-            .0;
+        require_internal_slot!(date = this, Date, "Date");
+        let t = date.0;
 
         // 4. Let ns be ? NumberToBigInt(t) × ℤ(10**6).
         let ns = i128::from_f64(t)

--- a/core/engine/src/builtins/date/mod.rs
+++ b/core/engine/src/builtins/date/mod.rs
@@ -446,8 +446,8 @@ impl Date {
         // 1. Let dateObject be the this value.
         // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
         // 3. Let t be dateObject.[[DateValue]].
-        require_internal_slot!(date = this, Date, "Date");
-        let t = date.0;
+        let date = require_internal_slot!(this, Date, "Date");
+        let t = date.borrow().data().0;
 
         // 4. If t is NaN, return NaN.
         if t.is_nan() {
@@ -482,8 +482,8 @@ impl Date {
         // 1. Let dateObject be the this value.
         // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
         // 3. Let t be dateObject.[[DateValue]].
-        require_internal_slot!(date = this, Date, "Date");
-        let t = date.0;
+        let date = require_internal_slot!(this, Date, "Date");
+        let t = date.borrow().data().0;
 
         // 4. If t is NaN, return NaN.
         if t.is_nan() {
@@ -521,8 +521,8 @@ impl Date {
         // 1. Let dateObject be the this value.
         // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
         // 3. Let t be dateObject.[[DateValue]].
-        require_internal_slot!(date = this, Date, "Date");
-        let t = date.0;
+        let date = require_internal_slot!(this, Date, "Date");
+        let t = date.borrow().data().0;
 
         // 4. If t is NaN, return NaN.
         if t.is_nan() {
@@ -550,8 +550,8 @@ impl Date {
         // 1. Let dateObject be the this value.
         // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
         // 3. Let t be dateObject.[[DateValue]].
-        require_internal_slot!(date = this, Date, "Date");
-        let t = date.0;
+        let date = require_internal_slot!(this, Date, "Date");
+        let t = date.borrow().data().0;
 
         // 4. If t is NaN, return NaN.
         if t.is_nan() {
@@ -585,8 +585,8 @@ impl Date {
         // 1. Let dateObject be the this value.
         // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
         // 3. Let t be dateObject.[[DateValue]].
-        require_internal_slot!(date = this, Date, "Date");
-        let t = date.0;
+        let date = require_internal_slot!(this, Date, "Date");
+        let t = date.borrow().data().0;
 
         // 4. If t is NaN, return NaN.
         if t.is_nan() {
@@ -620,8 +620,8 @@ impl Date {
         // 1. Let dateObject be the this value.
         // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
         // 3. Let t be dateObject.[[DateValue]].
-        require_internal_slot!(date = this, Date, "Date");
-        let t = date.0;
+        let date = require_internal_slot!(this, Date, "Date");
+        let t = date.borrow().data().0;
 
         // 4. If t is NaN, return NaN.
         if t.is_nan() {
@@ -655,8 +655,8 @@ impl Date {
         // 1. Let dateObject be the this value.
         // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
         // 3. Let t be dateObject.[[DateValue]].
-        require_internal_slot!(date = this, Date, "Date");
-        let t = date.0;
+        let date = require_internal_slot!(this, Date, "Date");
+        let t = date.borrow().data().0;
 
         // 4. If t is NaN, return NaN.
         if t.is_nan() {
@@ -691,8 +691,8 @@ impl Date {
         // 1. Let dateObject be the this value.
         // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
         // 3. Let t be dateObject.[[DateValue]].
-        require_internal_slot!(date = this, Date, "Date");
-        let t = date.0;
+        let date = require_internal_slot!(this, Date, "Date");
+        let t = date.borrow().data().0;
 
         // 4. If t is NaN, return NaN.
         if t.is_nan() {
@@ -726,8 +726,8 @@ impl Date {
         // 1. Let dateObject be the this value.
         // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
         // 3. Let t be dateObject.[[DateValue]].
-        require_internal_slot!(date = this, Date, "Date");
-        let t = date.0;
+        let date = require_internal_slot!(this, Date, "Date");
+        let t = date.borrow().data().0;
 
         // 4. If t is NaN, return NaN.
         if t.is_nan() {
@@ -764,8 +764,8 @@ impl Date {
         // 1. Let dateObject be the this value.
         // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
         // 3. Return dateObject.[[DateValue]].
-        require_internal_slot!(date = this, Date, "Date");
-        Ok(date.0.into())
+        let date = require_internal_slot!(this, Date, "Date");
+        Ok(date.borrow().data().0.into())
     }
 
     /// `Date.prototype.getTimeZoneOffset()`.
@@ -787,8 +787,8 @@ impl Date {
         // 1. Let dateObject be the this value.
         // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
         // 3. Let t be dateObject.[[DateValue]].
-        require_internal_slot!(date = this, Date, "Date");
-        let t = date.0;
+        let date = require_internal_slot!(this, Date, "Date");
+        let t = date.borrow().data().0;
 
         // 4. If t is NaN, return NaN.
         if t.is_nan() {
@@ -816,16 +816,10 @@ impl Date {
     ) -> JsResult<JsValue> {
         // 1. Let dateObject be the this value.
         // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
-        require_internal_slot!(date = this, Date, "Date");
+        let date_obj = require_internal_slot!(this, Date, "Date");
 
         // 3. Let t be dateObject.[[DateValue]].
-        let mut t = date.0;
-
-        // NOTE (nekevss): `downcast_ref` is used and then dropped for a short lived borrow.
-        // ToNumber() may call userland code which can modify the underlying date
-        // which will cause a panic. In order to avoid this, we drop the borrow,
-        // here and only `downcast_mut` when date will be modified.
-        drop(date);
+        let mut t = date_obj.borrow().data().0;
 
         // 4. Let dt be ? ToNumber(date).
         let dt = args.get_or_undefined(0).to_number(context)?;
@@ -854,16 +848,8 @@ impl Date {
             time_clip(new_date)
         };
 
-        let object = this.as_object();
-        let mut date_mut = object
-            .as_ref()
-            .and_then(JsObject::downcast_mut::<Date>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a Date object.")
-            })?;
-
         // 9. Set dateObject.[[DateValue]] to u.
-        date_mut.0 = u;
+        date_obj.borrow_mut().data_mut().0 = u;
 
         // 10. Return u.
         Ok(JsValue::from(u))
@@ -884,16 +870,10 @@ impl Date {
     ) -> JsResult<JsValue> {
         // 1. Let dateObject be the this value.
         // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
-        require_internal_slot!(date = this, Date, "Date");
+        let date_obj = require_internal_slot!(this, Date, "Date");
 
         // 3. Let t be dateObject.[[DateValue]].
-        let t = date.0;
-
-        // NOTE (nekevss): `downcast_ref` is used and then dropped for a short lived borrow.
-        // ToNumber() may call userland code which can modify the underlying date
-        // which will cause a panic. In order to avoid this, we drop the borrow,
-        // here and only `downcast_mut` when date will be modified.
-        drop(date);
+        let t = date_obj.borrow().data().0;
 
         let t = if LOCAL {
             // 5. If t is NaN, set t to +0𝔽; otherwise, set t to LocalTime(t).
@@ -935,16 +915,8 @@ impl Date {
             time_clip(new_date)
         };
 
-        let object = this.as_object();
-        let mut date_mut = object
-            .as_ref()
-            .and_then(JsObject::downcast_mut::<Date>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a Date object.")
-            })?;
-
         // 10. Set dateObject.[[DateValue]] to u.
-        date_mut.0 = u;
+        date_obj.borrow_mut().data_mut().0 = u;
 
         // 11. Return u.
         Ok(JsValue::from(u))
@@ -967,16 +939,10 @@ impl Date {
     ) -> JsResult<JsValue> {
         // 1. Let dateObject be the this value.
         // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
-        require_internal_slot!(date = this, Date, "Date");
+        let date_obj = require_internal_slot!(this, Date, "Date");
 
         // 3. Let t be dateObject.[[DateValue]].
-        let mut t = date.0;
-
-        // NOTE (nekevss): `downcast_ref` is used and then dropped for a short lived borrow.
-        // ToNumber() may call userland code which can modify the underlying date
-        // which will cause a panic. In order to avoid this, we drop the borrow,
-        // here and only `downcast_mut` when date will be modified.
-        drop(date);
+        let mut t = date_obj.borrow().data().0;
 
         // 4. Let h be ? ToNumber(hour).
         let h = args.get_or_undefined(0).to_number(context)?;
@@ -1020,16 +986,8 @@ impl Date {
             time_clip(date)
         };
 
-        let object = this.as_object();
-        let mut date_mut = object
-            .as_ref()
-            .and_then(JsObject::downcast_mut::<Date>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a Date object.")
-            })?;
-
         // 15. Set dateObject.[[DateValue]] to u.
-        date_mut.0 = u;
+        date_obj.borrow_mut().data_mut().0 = u;
 
         // 16. Return u.
         Ok(JsValue::from(u))
@@ -1049,16 +1007,10 @@ impl Date {
     ) -> JsResult<JsValue> {
         // 1. Let dateObject be the this value.
         // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
-        require_internal_slot!(date = this, Date, "Date");
+        let date_obj = require_internal_slot!(this, Date, "Date");
 
         // 3. Let t be dateObject.[[DateValue]].
-        let mut t = date.0;
-
-        // NOTE (nekevss): `downcast_ref` is used and then dropped for a short lived borrow.
-        // ToNumber() may call userland code which can modify the underlying date
-        // which will cause a panic. In order to avoid this, we drop the borrow,
-        // here and only `downcast_mut` when date will be modified.
-        drop(date);
+        let mut t = date_obj.borrow().data().0;
 
         // 4. Set ms to ? ToNumber(ms).
         let ms = args.get_or_undefined(0).to_number(context)?;
@@ -1092,16 +1044,8 @@ impl Date {
             time_clip(make_date(day(t), time))
         };
 
-        let object = this.as_object();
-        let mut date_mut = object
-            .as_ref()
-            .and_then(JsObject::downcast_mut::<Date>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a Date object.")
-            })?;
-
         // 9. Set dateObject.[[DateValue]] to u.
-        date_mut.0 = u;
+        date_obj.borrow_mut().data_mut().0 = u;
 
         // 10. Return u.
         Ok(JsValue::from(u))
@@ -1121,16 +1065,10 @@ impl Date {
     ) -> JsResult<JsValue> {
         // 1. Let dateObject be the this value.
         // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
-        require_internal_slot!(date = this, Date, "Date");
+        let date_obj = require_internal_slot!(this, Date, "Date");
 
         // 3. Let t be dateObject.[[DateValue]].
-        let mut t = date.0;
-
-        // NOTE (nekevss): `downcast_ref` is used and then dropped for a short lived borrow.
-        // ToNumber() may call userland code which can modify the underlying date
-        // which will cause a panic. In order to avoid this, we drop the borrow,
-        // here and only `downcast_mut` when date will be modified.
-        drop(date);
+        let mut t = date_obj.borrow().data().0;
 
         // 4. Let m be ? ToNumber(min).
         let m = args.get_or_undefined(0).to_number(context)?;
@@ -1168,16 +1106,8 @@ impl Date {
             time_clip(date)
         };
 
-        let object = this.as_object();
-        let mut date_mut = object
-            .as_ref()
-            .and_then(JsObject::downcast_mut::<Date>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a Date object.")
-            })?;
-
         // 13. Set dateObject.[[DateValue]] to u.
-        date_mut.0 = u;
+        date_obj.borrow_mut().data_mut().0 = u;
 
         // 14. Return u.
         Ok(JsValue::from(u))
@@ -1198,16 +1128,10 @@ impl Date {
     ) -> JsResult<JsValue> {
         // 1. Let dateObject be the this value.
         // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
-        require_internal_slot!(date = this, Date, "Date");
+        let date_obj = require_internal_slot!(this, Date, "Date");
 
         // 3. Let t be dateObject.[[DateValue]].
-        let mut t = date.0;
-
-        // NOTE (nekevss): `downcast_ref` is used and then dropped for a short lived borrow.
-        // ToNumber() may call userland code which can modify the underlying date
-        // which will cause a panic. In order to avoid this, we drop the borrow,
-        // here and only `downcast_mut` when date will be modified.
-        drop(date);
+        let mut t = date_obj.borrow().data().0;
 
         // 4. Let m be ? ToNumber(month).
         let m = args.get_or_undefined(0).to_number(context)?;
@@ -1242,16 +1166,8 @@ impl Date {
             time_clip(new_date)
         };
 
-        let object = this.as_object();
-        let mut date_mut = object
-            .as_ref()
-            .and_then(JsObject::downcast_mut::<Date>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a Date object.")
-            })?;
-
         // 11. Set dateObject.[[DateValue]] to u.
-        date_mut.0 = u;
+        date_obj.borrow_mut().data_mut().0 = u;
 
         // 12. Return u.
         Ok(JsValue::from(u))
@@ -1271,16 +1187,10 @@ impl Date {
     ) -> JsResult<JsValue> {
         // 1. Let dateObject be the this value.
         // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
-        require_internal_slot!(date = this, Date, "Date");
+        let date_obj = require_internal_slot!(this, Date, "Date");
 
         // 3. Let t be dateObject.[[DateValue]].
-        let mut t = date.0;
-
-        // NOTE (nekevss): `downcast_ref` is used and then dropped for a short lived borrow.
-        // ToNumber() may call userland code which can modify the underlying date
-        // which will cause a panic. In order to avoid this, we drop the borrow,
-        // here and only `downcast_mut` when date will be modified.
-        drop(date);
+        let mut t = date_obj.borrow().data().0;
 
         // 4. Let s be ? ToNumber(sec).
         let s = args.get_or_undefined(0).to_number(context)?;
@@ -1315,16 +1225,8 @@ impl Date {
             time_clip(date)
         };
 
-        let object = this.as_object();
-        let mut date_mut = object
-            .as_ref()
-            .and_then(JsObject::downcast_mut::<Date>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a Date object.")
-            })?;
-
         // 11. Set dateObject.[[DateValue]] to u.
-        date_mut.0 = u;
+        date_obj.borrow_mut().data_mut().0 = u;
 
         // 12. Return u.
         Ok(JsValue::from(u))
@@ -1351,16 +1253,10 @@ impl Date {
     ) -> JsResult<JsValue> {
         // 1. Let dateObject be the this value.
         // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
-        require_internal_slot!(date = this, Date, "Date");
+        let date_obj = require_internal_slot!(this, Date, "Date");
 
         // 3. Let t be dateObject.[[DateValue]].
-        let t = date.0;
-
-        // NOTE (nekevss): `downcast_ref` is used and then dropped for a short lived borrow.
-        // ToNumber() may call userland code which can modify the underlying date
-        // which will cause a panic. In order to avoid this, we drop the borrow,
-        // here and only `downcast_mut` when date will be modified.
-        drop(date);
+        let t = date_obj.borrow().data().0;
 
         // 4. Let y be ? ToNumber(year).
         let y = args.get_or_undefined(0).to_number(context)?;
@@ -1384,16 +1280,8 @@ impl Date {
         // 9. Let u be TimeClip(UTC(date)).
         let u = time_clip(utc_t(date, context.host_hooks().as_ref()));
 
-        let object = this.as_object();
-        let mut date_mut = object
-            .as_ref()
-            .and_then(JsObject::downcast_mut::<Date>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a Date object.")
-            })?;
-
         // 10. Set dateObject.[[DateValue]] to u.
-        date_mut.0 = u;
+        date_obj.borrow_mut().data_mut().0 = u;
 
         // 11. Return u.
         Ok(JsValue::from(u))
@@ -1416,30 +1304,16 @@ impl Date {
     ) -> JsResult<JsValue> {
         // 1. Let dateObject be the this value.
         // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
-        require_internal_slot!(date = this, Date, "Date");
+        let date_obj = require_internal_slot!(this, Date, "Date");
 
         // 3. Let t be ? ToNumber(time).
         let t = args.get_or_undefined(0).to_number(context)?;
 
-        // NOTE (nekevss): `downcast_ref` is used and then dropped for a short lived borrow.
-        // ToNumber() may call userland code which can modify the underlying date
-        // which will cause a panic. In order to avoid this, we drop the borrow,
-        // here and only `downcast_mut` when date will be modified.
-        drop(date);
-
         // 4. Let v be TimeClip(t).
         let v = time_clip(t);
 
-        let object = this.as_object();
-        let mut date_mut = object
-            .as_ref()
-            .and_then(JsObject::downcast_mut::<Date>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a Date object.")
-            })?;
-
         // 5. Set dateObject.[[DateValue]] to v.
-        date_mut.0 = v;
+        date_obj.borrow_mut().data_mut().0 = v;
 
         // 6. Return v.
         Ok(JsValue::from(v))
@@ -1462,8 +1336,8 @@ impl Date {
         // 1. Let dateObject be the this value.
         // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
         // 3. Let tv be dateObject.[[DateValue]].
-        require_internal_slot!(date = this, Date, "Date");
-        let tv = date.0;
+        let date = require_internal_slot!(this, Date, "Date");
+        let tv = date.borrow().data().0;
 
         // 4. If tv is NaN, return "Invalid Date".
         if tv.is_nan() {
@@ -1496,8 +1370,8 @@ impl Date {
         // 1. Let dateObject be the this value.
         // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
         // 3. Let tv be dateObject.[[DateValue]].
-        require_internal_slot!(date = this, Date, "Date");
-        let tv = date.0;
+        let date = require_internal_slot!(this, Date, "Date");
+        let tv = date.borrow().data().0;
 
         // 4. If tv is not finite, throw a RangeError exception.
         if !tv.is_finite() {
@@ -1605,8 +1479,8 @@ impl Date {
             // 1. Let dateObject be the this value.
             // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
             // 3. Let x be dateObject.[[DateValue]].
-            require_internal_slot!(date = this, Date, "Date");
-            let t = date.0;
+            let date = require_internal_slot!(this, Date, "Date");
+            let t = date.borrow().data().0;
             // 4. If x is NaN, return "Invalid Date".
             if t.is_nan() {
                 return Ok(JsValue::new(js_string!("Invalid Date")));
@@ -1656,8 +1530,8 @@ impl Date {
             // 1. Let dateObject be the this value.
             // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
             // 3. Let x be dateObject.[[DateValue]].
-            require_internal_slot!(date = this, Date, "Date");
-            let t = date.0;
+            let date = require_internal_slot!(this, Date, "Date");
+            let t = date.borrow().data().0;
             // 4. If x is NaN, return "Invalid Date".
             if t.is_nan() {
                 return Ok(JsValue::new(js_string!("Invalid Date")));
@@ -1708,8 +1582,8 @@ impl Date {
             // 1. Let dateObject be the this value.
             // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
             // 3. Let x be dateObject.[[DateValue]].
-            require_internal_slot!(date = this, Date, "Date");
-            let t = date.0;
+            let date = require_internal_slot!(this, Date, "Date");
+            let t = date.borrow().data().0;
             // 4. If x is NaN, return "Invalid Date".
             if t.is_nan() {
                 return Ok(JsValue::new(js_string!("Invalid Date")));
@@ -1750,8 +1624,8 @@ impl Date {
         // 1. Let dateObject be the this value.
         // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
         // 3. Let tv be dateObject.[[DateValue]].
-        require_internal_slot!(date = this, Date, "Date");
-        let tv = date.0;
+        let date = require_internal_slot!(this, Date, "Date");
+        let tv = date.borrow().data().0;
 
         // 4. Return ToDateString(tv).
         Ok(JsValue::from(to_date_string_t(
@@ -1778,8 +1652,8 @@ impl Date {
         // 1. Let dateObject be the this value.
         // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
         // 3. Let tv be dateObject.[[DateValue]].
-        require_internal_slot!(date = this, Date, "Date");
-        let tv = date.0;
+        let date = require_internal_slot!(this, Date, "Date");
+        let tv = date.borrow().data().0;
 
         // 4. If tv is NaN, return "Invalid Date".
         if tv.is_nan() {
@@ -1813,8 +1687,8 @@ impl Date {
         // 1. Let dateObject be the this value.
         // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
         // 3. Let tv be dateObject.[[DateValue]].
-        require_internal_slot!(date = this, Date, "Date");
-        let tv = date.0;
+        let date = require_internal_slot!(this, Date, "Date");
+        let tv = date.borrow().data().0;
 
         // 4. If tv is NaN, return "Invalid Date".
         if tv.is_nan() {
@@ -1914,8 +1788,8 @@ impl Date {
         // 1. Let dateObject be the this value.
         // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
         // 3. Return dateObject.[[DateValue]].
-        require_internal_slot!(date = this, Date, "Date");
-        Ok(date.0.into())
+        let date = require_internal_slot!(this, Date, "Date");
+        Ok(date.borrow().data().0.into())
     }
 
     /// [`Date.prototype [ @@toPrimitive ] ( hint )`][spec].
@@ -1983,8 +1857,8 @@ impl Date {
         // 1. Let dateObject be the this value.
         // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
         // 3. Let t be dateObject.[[DateValue]].
-        require_internal_slot!(date = this, Date, "Date");
-        let t = date.0;
+        let date = require_internal_slot!(this, Date, "Date");
+        let t = date.borrow().data().0;
 
         // 4. Let ns be ? NumberToBigInt(t) × ℤ(10**6).
         let ns = i128::from_f64(t)

--- a/core/engine/src/builtins/date/tests.rs
+++ b/core/engine/src/builtins/date/tests.rs
@@ -103,7 +103,7 @@ fn date_this_time_value() {
     run_test_actions([TestAction::assert_native_error(
         "({toString: Date.prototype.toString}).toString()",
         JsNativeErrorKind::Type,
-        "'this' is not a Date",
+        "the this object must be a Date object.",
     )]);
 }
 
@@ -952,17 +952,17 @@ fn date_proto_to_locale_string_intl() {
         TestAction::assert_native_error(
             "Date.prototype.toLocaleString.call({})",
             JsNativeErrorKind::Type,
-            "'this' is not a Date",
+            "the this object must be a Date object.",
         ),
         TestAction::assert_native_error(
             "Date.prototype.toLocaleDateString.call({})",
             JsNativeErrorKind::Type,
-            "'this' is not a Date",
+            "the this object must be a Date object.",
         ),
         TestAction::assert_native_error(
             "Date.prototype.toLocaleTimeString.call({})",
             JsNativeErrorKind::Type,
-            "'this' is not a Date",
+            "the this object must be a Date object.",
         ),
         TestAction::assert_eq("new Date(NaN).toLocaleString()", js_str!("Invalid Date")),
         TestAction::assert("typeof new Date(2020, 6, 8).toLocaleString() === 'string'"),

--- a/core/engine/src/builtins/intl/collator/mod.rs
+++ b/core/engine/src/builtins/intl/collator/mod.rs
@@ -413,7 +413,7 @@ impl Collator {
     fn resolved_options(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let collator be the this value.
         // 2. Perform ? RequireInternalSlot(collator, [[InitializedCollator]]).
-        require_internal_slot!(collator = this, Self, "Collator");
+        let collator = require_internal_slot!(this, Self, "Collator");
 
         // 3. Let options be OrdinaryObjectCreate(%Object.prototype%).
         let options = context
@@ -435,14 +435,14 @@ impl Collator {
         options
             .create_data_property_or_throw(
                 js_string!("locale"),
-                js_string!(collator.locale.to_string()),
+                js_string!(collator.borrow().data().locale.to_string()),
                 context,
             )
             .js_expect("operation must not fail per the spec")?;
         options
             .create_data_property_or_throw(
                 js_string!("usage"),
-                match collator.usage {
+                match collator.borrow().data().usage {
                     Usage::Search => js_string!("search"),
                     Usage::Sort => js_string!("sort"),
                 },
@@ -452,7 +452,7 @@ impl Collator {
         options
             .create_data_property_or_throw(
                 js_string!("sensitivity"),
-                match collator.sensitivity {
+                match collator.borrow().data().sensitivity {
                     Sensitivity::Base => js_string!("base"),
                     Sensitivity::Accent => js_string!("accent"),
                     Sensitivity::Case => js_string!("case"),
@@ -464,24 +464,28 @@ impl Collator {
         options
             .create_data_property_or_throw(
                 js_string!("ignorePunctuation"),
-                collator.ignore_punctuation,
+                collator.borrow().data().ignore_punctuation,
                 context,
             )
             .js_expect("operation must not fail per the spec")?;
         options
             .create_data_property_or_throw(
                 js_string!("collation"),
-                collator
+                collator.borrow().data()
                     .collation
-                    .map(|co| js_string!(co.as_str()))
+                    .map(|co: CollationType| js_string!(co.as_str()))
                     .unwrap_or(js_string!("default")),
                 context,
             )
             .js_expect("operation must not fail per the spec")?;
         options
-            .create_data_property_or_throw(js_string!("numeric"), collator.numeric, context)
+            .create_data_property_or_throw(
+                js_string!("numeric"),
+                collator.borrow().data().numeric,
+                context,
+            )
             .js_expect("operation must not fail per the spec")?;
-        if let Some(kf) = collator.case_first {
+        if let Some(kf) = collator.borrow().data().case_first {
             options
                 .create_data_property_or_throw(
                     js_string!("caseFirst"),

--- a/core/engine/src/builtins/intl/collator/mod.rs
+++ b/core/engine/src/builtins/intl/collator/mod.rs
@@ -413,14 +413,7 @@ impl Collator {
     fn resolved_options(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let collator be the this value.
         // 2. Perform ? RequireInternalSlot(collator, [[InitializedCollator]]).
-        let object = this.as_object();
-        let collator = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ()
-                    .with_message("`resolvedOptions` can only be called on a `Collator` object")
-            })?;
+        require_internal_slot!(collator = this, Self, "Collator");
 
         // 3. Let options be OrdinaryObjectCreate(%Object.prototype%).
         let options = context

--- a/core/engine/src/builtins/intl/collator/mod.rs
+++ b/core/engine/src/builtins/intl/collator/mod.rs
@@ -471,7 +471,9 @@ impl Collator {
         options
             .create_data_property_or_throw(
                 js_string!("collation"),
-                collator.borrow().data()
+                collator
+                    .borrow()
+                    .data()
                     .collation
                     .map(|co: CollationType| js_string!(co.as_str()))
                     .unwrap_or(js_string!("default")),

--- a/core/engine/src/builtins/intl/segmenter/mod.rs
+++ b/core/engine/src/builtins/intl/segmenter/mod.rs
@@ -262,7 +262,7 @@ impl Segmenter {
     fn resolved_options(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let segmenter be the this value.
         // 2. Perform ? RequireInternalSlot(segmenter, [[InitializedSegmenter]]).
-        require_internal_slot!(segmenter = this, Self, "Segmenter");
+        let segmenter = require_internal_slot!(this, Self, "Segmenter");
 
         // 3. Let options be OrdinaryObjectCreate(%Object.prototype%).
         // 4. For each row of Table 19, except the header row, in table order, do
@@ -273,12 +273,12 @@ impl Segmenter {
         let options = ObjectInitializer::new(context)
             .property(
                 js_string!("locale"),
-                js_string!(segmenter.locale.to_string()),
+                js_string!(segmenter.borrow().data().locale.to_string()),
                 Attribute::all(),
             )
             .property(
                 js_string!("granularity"),
-                js_string!(segmenter.native.granularity().to_string()),
+                js_string!(segmenter.borrow().data().native.granularity().to_string()),
                 Attribute::all(),
             )
             .build();

--- a/core/engine/src/builtins/intl/segmenter/mod.rs
+++ b/core/engine/src/builtins/intl/segmenter/mod.rs
@@ -262,15 +262,7 @@ impl Segmenter {
     fn resolved_options(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let segmenter be the this value.
         // 2. Perform ? RequireInternalSlot(segmenter, [[InitializedSegmenter]]).
-        let object = this.as_object();
-        let segmenter = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message(
-                    "`resolved_options` can only be called on an `Intl.Segmenter` object",
-                )
-            })?;
+        require_internal_slot!(segmenter = this, Self, "Segmenter");
 
         // 3. Let options be OrdinaryObjectCreate(%Object.prototype%).
         // 4. For each row of Table 19, except the header row, in table order, do

--- a/core/engine/src/builtins/intl/segmenter/segments.rs
+++ b/core/engine/src/builtins/intl/segmenter/segments.rs
@@ -55,14 +55,7 @@ impl Segments {
     fn containing(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let segments be the this value.
         // 2. Perform ? RequireInternalSlot(segments, [[SegmentsSegmenter]]).
-        let object = this.as_object();
-        let segments = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ()
-                    .with_message("`containing` can only be called on a `Segments` object")
-            })?;
+        require_internal_slot!(segments = this, Self, "Segments");
 
         // 3. Let segmenter be segments.[[SegmentsSegmenter]].
         let segmenter = segments

--- a/core/engine/src/builtins/intl/segmenter/segments.rs
+++ b/core/engine/src/builtins/intl/segmenter/segments.rs
@@ -55,17 +55,22 @@ impl Segments {
     fn containing(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let segments be the this value.
         // 2. Perform ? RequireInternalSlot(segments, [[SegmentsSegmenter]]).
-        require_internal_slot!(segments = this, Self, "Segments");
+        let segments = require_internal_slot!(this, Self, "Segments");
 
         // 3. Let segmenter be segments.[[SegmentsSegmenter]].
-        let segmenter = segments
-            .segmenter
+        // 4. Let string be segments.[[SegmentsString]].
+        let (segmenter_obj, string) = {
+            let seg_data = segments.borrow();
+            let seg_data = seg_data.data();
+            (seg_data.segmenter.clone(), seg_data.string.clone())
+        };
+
+        let segmenter = segmenter_obj
             .downcast_ref::<Segmenter>()
             .js_expect("segments object should contain a segmenter")?;
 
-        // 4. Let string be segments.[[SegmentsString]].
         // 5. Let len be the length of string.
-        let len = segments.string.len() as i64;
+        let len = string.len() as i64;
 
         // 6. Let n be ? ToIntegerOrInfinity(index).
         let Some(n) = args
@@ -82,8 +87,10 @@ impl Segments {
         // 8. Let startIndex be ! FindBoundary(segmenter, string, n, before).
         // 9. Let endIndex be ! FindBoundary(segmenter, string, n, after).
         let (range, is_word_like) = {
-            let mut segments = segmenter.native.segment(segments.string.variant());
-            std::iter::from_fn(|| segments.next().map(|i| (i, segments.is_word_like())))
+            let mut seg_iter = segmenter
+                .native
+                .segment(string.variant());
+            std::iter::from_fn(|| seg_iter.next().map(|i| (i, seg_iter.is_word_like())))
                 .tuple_windows()
                 .find(|((i, _), (j, _))| (*i..*j).contains(&n))
                 .map(|((i, _), (j, word))| ((i..j), word))
@@ -91,10 +98,13 @@ impl Segments {
         };
 
         // 10. Return ! CreateSegmentDataObject(segmenter, string, startIndex, endIndex).
-        Ok(
-            create_segment_data_object(segments.string.clone(), range, is_word_like, context)
-                .into(),
+        Ok(create_segment_data_object(
+            string,
+            range,
+            is_word_like,
+            context,
         )
+        .into())
     }
 
     /// [`%SegmentsPrototype% [ @@iterator ] ( )`][spec]

--- a/core/engine/src/builtins/intl/segmenter/segments.rs
+++ b/core/engine/src/builtins/intl/segmenter/segments.rs
@@ -87,9 +87,7 @@ impl Segments {
         // 8. Let startIndex be ! FindBoundary(segmenter, string, n, before).
         // 9. Let endIndex be ! FindBoundary(segmenter, string, n, after).
         let (range, is_word_like) = {
-            let mut seg_iter = segmenter
-                .native
-                .segment(string.variant());
+            let mut seg_iter = segmenter.native.segment(string.variant());
             std::iter::from_fn(|| seg_iter.next().map(|i| (i, seg_iter.is_word_like())))
                 .tuple_windows()
                 .find(|((i, _), (j, _))| (*i..*j).contains(&n))
@@ -98,13 +96,7 @@ impl Segments {
         };
 
         // 10. Return ! CreateSegmentDataObject(segmenter, string, startIndex, endIndex).
-        Ok(create_segment_data_object(
-            string,
-            range,
-            is_word_like,
-            context,
-        )
-        .into())
+        Ok(create_segment_data_object(string, range, is_word_like, context).into())
     }
 
     /// [`%SegmentsPrototype% [ @@iterator ] ( )`][spec]

--- a/core/engine/src/builtins/mod.rs
+++ b/core/engine/src/builtins/mod.rs
@@ -1,5 +1,26 @@
 //! Boa's ECMAScript built-in object implementations, e.g. Object, String, Math, Array, etc.
 
+/// Downcasts `$this` (a `&JsValue`) to a `Ref<$type>`, returning a `TypeError` if the
+/// cast fails. The error message uses `$name` as the type name.
+///
+/// This centralizes the repeated this-type-check boilerplate found across
+/// all builtin methods. The macro introduces a hidden binding for the
+/// owned `JsObject` to ensure it outlives the returned `Ref`, and binds the
+/// result to `$var`.
+///
+/// Usage: `require_internal_slot!(dt = this, Self, "PlainDateTime");`
+macro_rules! require_internal_slot {
+    ($var:ident = $this:expr, $type:ty, $name:expr) => {
+        let __temporal_obj = $crate::JsValue::as_object($this);
+        let $var = __temporal_obj
+            .as_ref()
+            .and_then($crate::JsObject::downcast_ref::<$type>)
+            .ok_or_else(|| {
+                $crate::js_error!(TypeError: "the this object must be a {} object.", $name)
+            })?;
+    };
+}
+
 pub mod array;
 pub mod array_buffer;
 pub mod async_function;

--- a/core/engine/src/builtins/mod.rs
+++ b/core/engine/src/builtins/mod.rs
@@ -1,23 +1,24 @@
 //! Boa's ECMAScript built-in object implementations, e.g. Object, String, Math, Array, etc.
 
-/// Downcasts `$this` (a `&JsValue`) to a `Ref<$type>`, returning a `TypeError` if the
-/// cast fails. The error message uses `$name` as the type name.
+/// Downcasts `$this` (a `&JsValue`) to a `JsObject<$type>`, returning a
+/// `TypeError` if the cast fails. The error message uses `$name` as the
+/// type name.
 ///
 /// This centralizes the repeated this-type-check boilerplate found across
-/// all builtin methods. The macro introduces a hidden binding for the
-/// owned `JsObject` to ensure it outlives the returned `Ref`, and binds the
-/// result to `$var`.
+/// all builtin methods. Unlike `downcast_ref`, the returned `JsObject<T>`
+/// does **not** hold an active borrow, so callers can `.borrow()` /
+/// `.borrow_mut()` only when needed, avoiding panics from long-lived
+/// `GcRefCell` borrows.
 ///
-/// Usage: `require_internal_slot!(dt = this, Self, "PlainDateTime");`
+/// Usage: `let dt = require_internal_slot!(this, Self, "PlainDateTime");`
 macro_rules! require_internal_slot {
-    ($var:ident = $this:expr, $type:ty, $name:expr) => {
-        let __temporal_obj = $crate::JsValue::as_object($this);
-        let $var = __temporal_obj
-            .as_ref()
-            .and_then($crate::JsObject::downcast_ref::<$type>)
+    ($this:expr, $type:ty, $name:expr) => {
+        $crate::JsValue::as_object($this)
+            .map(|o| o.clone())
+            .and_then(|o| $crate::JsObject::downcast::<$type>(o).ok())
             .ok_or_else(|| {
                 $crate::js_error!(TypeError: "the this object must be a {} object.", $name)
-            })?;
+            })?
     };
 }
 

--- a/core/engine/src/builtins/temporal/duration/mod.rs
+++ b/core/engine/src/builtins/temporal/duration/mod.rs
@@ -331,9 +331,10 @@ impl BuiltInConstructor for Duration {
 impl Duration {
     // Internal utility function for getting `Duration` field values.
     fn get_internal_field(this: &JsValue, field: &DateTimeValues) -> JsResult<JsValue> {
-        require_internal_slot!(duration = this, Self, "Duration");
+        let duration = require_internal_slot!(this, Self, "Duration");
 
-        let inner = &duration.inner;
+        let duration_data = duration.borrow();
+        let inner = &duration_data.data().inner;
 
         match field {
             DateTimeValues::Year => Ok(JsValue::new(inner.years())),
@@ -516,12 +517,12 @@ impl Duration {
     fn get_sign(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Let duration be the this value.
         // 2. Perform ? RequireInternalSlot(duration, [[InitializedTemporalDuration]]).
-        require_internal_slot!(duration = this, Self, "Duration");
+        let duration = require_internal_slot!(this, Self, "Duration");
 
         // 3. Return 𝔽(! DurationSign(duration.[[Years]], duration.[[Months]], duration.[[Weeks]],
         // duration.[[Days]], duration.[[Hours]], duration.[[Minutes]], duration.[[Seconds]],
         // duration.[[Milliseconds]], duration.[[Microseconds]], duration.[[Nanoseconds]])).
-        Ok((duration.inner.sign() as i8).into())
+        Ok((duration.borrow().data().inner.sign() as i8).into())
     }
 
     /// 7.3.14 get `Temporal.Duration.prototype.blank`
@@ -538,14 +539,14 @@ impl Duration {
     fn get_blank(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Let duration be the this value.
         // 2. Perform ? RequireInternalSlot(duration, [[InitializedTemporalDuration]]).
-        require_internal_slot!(duration = this, Self, "Duration");
+        let duration = require_internal_slot!(this, Self, "Duration");
 
         // 3. Let sign be ! DurationSign(duration.[[Years]], duration.[[Months]], duration.[[Weeks]],
         // duration.[[Days]], duration.[[Hours]], duration.[[Minutes]], duration.[[Seconds]],
         // duration.[[Milliseconds]], duration.[[Microseconds]], duration.[[Nanoseconds]]).
         // 4. If sign = 0, return true.
         // 5. Return false.
-        Ok(duration.inner.is_zero().into())
+        Ok(duration.borrow().data().inner.is_zero().into())
     }
 }
 
@@ -624,7 +625,7 @@ impl Duration {
     ) -> JsResult<JsValue> {
         // 1. Let duration be the this value.
         // 2. Perform ? RequireInternalSlot(duration, [[InitializedTemporalDuration]]).
-        require_internal_slot!(duration = this, Self, "Duration");
+        let duration = require_internal_slot!(this, Self, "Duration");
 
         // 3. Let temporalDurationLike be ? ToTemporalPartialDurationRecord(temporalDurationLike).
         let temporal_duration_like =
@@ -636,7 +637,7 @@ impl Duration {
         // a. Let years be duration.[[Years]].
         let years = temporal_duration_like
             .years
-            .unwrap_or(duration.inner.years());
+            .unwrap_or(duration.borrow().data().inner.years());
 
         // 6. If temporalDurationLike.[[Months]] is not undefined, then
         // a. Let months be temporalDurationLike.[[Months]].
@@ -644,7 +645,7 @@ impl Duration {
         // a. Let months be duration.[[Months]].
         let months = temporal_duration_like
             .months
-            .unwrap_or(duration.inner.months());
+            .unwrap_or(duration.borrow().data().inner.months());
 
         // 8. If temporalDurationLike.[[Weeks]] is not undefined, then
         // a. Let weeks be temporalDurationLike.[[Weeks]].
@@ -652,13 +653,15 @@ impl Duration {
         // a. Let weeks be duration.[[Weeks]].
         let weeks = temporal_duration_like
             .weeks
-            .unwrap_or(duration.inner.weeks());
+            .unwrap_or(duration.borrow().data().inner.weeks());
 
         // 10. If temporalDurationLike.[[Days]] is not undefined, then
         // a. Let days be temporalDurationLike.[[Days]].
         // 11. Else,
         // a. Let days be duration.[[Days]].
-        let days = temporal_duration_like.days.unwrap_or(duration.inner.days());
+        let days = temporal_duration_like
+            .days
+            .unwrap_or(duration.borrow().data().inner.days());
 
         // 12. If temporalDurationLike.[[Hours]] is not undefined, then
         // a. Let hours be temporalDurationLike.[[Hours]].
@@ -666,7 +669,7 @@ impl Duration {
         // a. Let hours be duration.[[Hours]].
         let hours = temporal_duration_like
             .hours
-            .unwrap_or(duration.inner.hours());
+            .unwrap_or(duration.borrow().data().inner.hours());
 
         // 14. If temporalDurationLike.[[Minutes]] is not undefined, then
         // a. Let minutes be temporalDurationLike.[[Minutes]].
@@ -674,7 +677,7 @@ impl Duration {
         // a. Let minutes be duration.[[Minutes]].
         let minutes = temporal_duration_like
             .minutes
-            .unwrap_or(duration.inner.minutes());
+            .unwrap_or(duration.borrow().data().inner.minutes());
 
         // 16. If temporalDurationLike.[[Seconds]] is not undefined, then
         // a. Let seconds be temporalDurationLike.[[Seconds]].
@@ -682,7 +685,7 @@ impl Duration {
         // a. Let seconds be duration.[[Seconds]].
         let seconds = temporal_duration_like
             .seconds
-            .unwrap_or(duration.inner.seconds());
+            .unwrap_or(duration.borrow().data().inner.seconds());
 
         // 18. If temporalDurationLike.[[Milliseconds]] is not undefined, then
         // a. Let milliseconds be temporalDurationLike.[[Milliseconds]].
@@ -690,7 +693,7 @@ impl Duration {
         // a. Let milliseconds be duration.[[Milliseconds]].
         let milliseconds = temporal_duration_like
             .milliseconds
-            .unwrap_or(duration.inner.milliseconds());
+            .unwrap_or(duration.borrow().data().inner.milliseconds());
 
         // 20. If temporalDurationLike.[[Microseconds]] is not undefined, then
         // a. Let microseconds be temporalDurationLike.[[Microseconds]].
@@ -698,7 +701,7 @@ impl Duration {
         // a. Let microseconds be duration.[[Microseconds]].
         let microseconds = temporal_duration_like
             .microseconds
-            .unwrap_or(duration.inner.microseconds());
+            .unwrap_or(duration.borrow().data().inner.microseconds());
 
         // 22. If temporalDurationLike.[[Nanoseconds]] is not undefined, then
         // a. Let nanoseconds be temporalDurationLike.[[Nanoseconds]].
@@ -706,7 +709,7 @@ impl Duration {
         // a. Let nanoseconds be duration.[[Nanoseconds]].
         let nanoseconds = temporal_duration_like
             .nanoseconds
-            .unwrap_or(duration.inner.nanoseconds());
+            .unwrap_or(duration.borrow().data().inner.nanoseconds());
 
         // 24. Return ? CreateTemporalDuration(years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds).
         let new_duration = InnerDuration::new(
@@ -743,9 +746,10 @@ impl Duration {
         // 1. Let duration be the this value.
         // 2. Perform ? RequireInternalSlot(duration, [[InitializedTemporalDuration]]).
         // 3. Return ! CreateNegatedTemporalDuration(duration).
-        require_internal_slot!(duration = this, Self, "Duration");
+        let duration = require_internal_slot!(this, Self, "Duration");
 
-        create_temporal_duration(duration.inner.negated(), None, context).map(Into::into)
+        create_temporal_duration(duration.borrow().data().inner.negated(), None, context)
+            .map(Into::into)
     }
 
     /// 7.3.17 `Temporal.Duration.prototype.abs ( )`
@@ -765,9 +769,10 @@ impl Duration {
         // 3. Return ! CreateTemporalDuration(abs(duration.[[Years]]), abs(duration.[[Months]]),
         //    abs(duration.[[Weeks]]), abs(duration.[[Days]]), abs(duration.[[Hours]]), abs(duration.[[Minutes]]),
         //    abs(duration.[[Seconds]]), abs(duration.[[Milliseconds]]), abs(duration.[[Microseconds]]), abs(duration.[[Nanoseconds]])).
-        require_internal_slot!(duration = this, Self, "Duration");
+        let duration = require_internal_slot!(this, Self, "Duration");
 
-        create_temporal_duration(duration.inner.abs(), None, context).map(Into::into)
+        create_temporal_duration(duration.borrow().data().inner.abs(), None, context)
+            .map(Into::into)
     }
 
     /// 7.3.18 `Temporal.Duration.prototype.add ( other [ , options ] )`
@@ -788,12 +793,13 @@ impl Duration {
     ) -> JsResult<JsValue> {
         // 1.Let duration be the this value.
         // 2. Perform ? RequireInternalSlot(duration, [[InitializedTemporalDuration]]).
-        require_internal_slot!(duration = this, Self, "Duration");
+        let duration = require_internal_slot!(this, Self, "Duration");
 
         // 3. Return ? AddDurations(add, duration, other).
         let other = to_temporal_duration_record(args.get_or_undefined(0), context)?;
 
-        create_temporal_duration(duration.inner.add(&other)?, None, context).map(Into::into)
+        create_temporal_duration(duration.borrow().data().inner.add(&other)?, None, context)
+            .map(Into::into)
     }
 
     /// 7.3.19 `Temporal.Duration.prototype.subtract ( other [ , options ] )`
@@ -814,12 +820,17 @@ impl Duration {
     ) -> JsResult<JsValue> {
         // 1.Let duration be the this value.
         // 2. Perform ? RequireInternalSlot(duration, [[InitializedTemporalDuration]]).
-        require_internal_slot!(duration = this, Self, "Duration");
+        let duration = require_internal_slot!(this, Self, "Duration");
 
         let other = to_temporal_duration_record(args.get_or_undefined(0), context)?;
 
         // 3. Return ? AddDurations(add, duration, other).
-        create_temporal_duration(duration.inner.subtract(&other)?, None, context).map(Into::into)
+        create_temporal_duration(
+            duration.borrow().data().inner.subtract(&other)?,
+            None,
+            context,
+        )
+        .map(Into::into)
     }
 
     /// 7.3.20 `Temporal.Duration.prototype.round ( roundTo )`
@@ -840,7 +851,7 @@ impl Duration {
     ) -> JsResult<JsValue> {
         // 1. Let duration be the this value.
         // 2. Perform ? RequireInternalSlot(duration, [[InitializedTemporalDuration]]).
-        require_internal_slot!(duration = this, Self, "Duration");
+        let duration = require_internal_slot!(this, Self, "Duration");
 
         let round_to = match args.first().map(JsValue::variant) {
             // 3. If roundTo is undefined, then
@@ -911,7 +922,7 @@ impl Duration {
         // NOTE: execute step 21 earlier before initial values are shadowed.
         // 21. If smallestUnitPresent is false and largestUnitPresent is false, then
 
-        let rounded_duration = duration.inner.round_with_provider(
+        let rounded_duration = duration.borrow().data().inner.round_with_provider(
             options,
             relative_to,
             context.timezone_provider(),
@@ -937,7 +948,7 @@ impl Duration {
     ) -> JsResult<JsValue> {
         // 1. Let duration be the this value.
         // 2. Perform ? RequireInternalSlot(duration, [[InitializedTemporalDuration]]).
-        require_internal_slot!(duration = this, Self, "Duration");
+        let duration = require_internal_slot!(this, Self, "Duration");
 
         let total_of = args.get_or_undefined(0);
 
@@ -985,6 +996,8 @@ impl Duration {
         .ok_or_else(|| JsNativeError::range().with_message("unit cannot be undefined."))?;
 
         Ok(duration
+            .borrow()
+            .data()
             .inner
             .total_with_provider(unit, relative_to, context.timezone_provider())?
             .as_inner()
@@ -1007,7 +1020,7 @@ impl Duration {
         args: &[JsValue],
         context: &mut Context,
     ) -> JsResult<JsValue> {
-        require_internal_slot!(duration = this, Self, "Duration");
+        let duration = require_internal_slot!(this, Self, "Duration");
 
         let options = get_options_object(args.get_or_undefined(0))?;
         let precision = get_digits_option(&options, context)?;
@@ -1015,11 +1028,16 @@ impl Duration {
             get_option::<RoundingMode>(&options, js_string!("roundingMode"), context)?;
         let smallest_unit = get_option::<Unit>(&options, js_string!("smallestUnit"), context)?;
 
-        let result = duration.inner.as_temporal_string(ToStringRoundingOptions {
-            precision,
-            smallest_unit,
-            rounding_mode,
-        })?;
+        let result =
+            duration
+                .borrow()
+                .data()
+                .inner
+                .as_temporal_string(ToStringRoundingOptions {
+                    precision,
+                    smallest_unit,
+                    rounding_mode,
+                })?;
 
         Ok(JsString::from(result).into())
     }
@@ -1034,9 +1052,11 @@ impl Duration {
     /// [spec]: https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.tojson
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Duration/toJSON
     pub(crate) fn to_json(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(duration = this, Self, "Duration");
+        let duration = require_internal_slot!(this, Self, "Duration");
 
         let result = duration
+            .borrow()
+            .data()
             .inner
             .as_temporal_string(ToStringRoundingOptions::default())?;
 
@@ -1058,9 +1078,11 @@ impl Duration {
         _: &mut Context,
     ) -> JsResult<JsValue> {
         // TODO: Update for ECMA-402 compliance
-        require_internal_slot!(duration = this, Self, "Duration");
+        let duration = require_internal_slot!(this, Self, "Duration");
 
         let result = duration
+            .borrow()
+            .data()
             .inner
             .as_temporal_string(ToStringRoundingOptions::default())?;
 

--- a/core/engine/src/builtins/temporal/duration/mod.rs
+++ b/core/engine/src/builtins/temporal/duration/mod.rs
@@ -331,13 +331,7 @@ impl BuiltInConstructor for Duration {
 impl Duration {
     // Internal utility function for getting `Duration` field values.
     fn get_internal_field(this: &JsValue, field: &DateTimeValues) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let duration = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("this value must be a Duration object.")
-            })?;
+        require_internal_slot!(duration = this, Self, "Duration");
 
         let inner = &duration.inner;
 
@@ -522,13 +516,7 @@ impl Duration {
     fn get_sign(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Let duration be the this value.
         // 2. Perform ? RequireInternalSlot(duration, [[InitializedTemporalDuration]]).
-        let object = this.as_object();
-        let duration = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("this value must be a Duration object.")
-            })?;
+        require_internal_slot!(duration = this, Self, "Duration");
 
         // 3. Return 𝔽(! DurationSign(duration.[[Years]], duration.[[Months]], duration.[[Weeks]],
         // duration.[[Days]], duration.[[Hours]], duration.[[Minutes]], duration.[[Seconds]],
@@ -550,13 +538,7 @@ impl Duration {
     fn get_blank(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Let duration be the this value.
         // 2. Perform ? RequireInternalSlot(duration, [[InitializedTemporalDuration]]).
-        let object = this.as_object();
-        let duration = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("this value must be a Duration object.")
-            })?;
+        require_internal_slot!(duration = this, Self, "Duration");
 
         // 3. Let sign be ! DurationSign(duration.[[Years]], duration.[[Months]], duration.[[Weeks]],
         // duration.[[Days]], duration.[[Hours]], duration.[[Minutes]], duration.[[Seconds]],
@@ -642,13 +624,7 @@ impl Duration {
     ) -> JsResult<JsValue> {
         // 1. Let duration be the this value.
         // 2. Perform ? RequireInternalSlot(duration, [[InitializedTemporalDuration]]).
-        let object = this.as_object();
-        let duration = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("this value must be a Duration object.")
-            })?;
+        require_internal_slot!(duration = this, Self, "Duration");
 
         // 3. Let temporalDurationLike be ? ToTemporalPartialDurationRecord(temporalDurationLike).
         let temporal_duration_like =
@@ -767,13 +743,7 @@ impl Duration {
         // 1. Let duration be the this value.
         // 2. Perform ? RequireInternalSlot(duration, [[InitializedTemporalDuration]]).
         // 3. Return ! CreateNegatedTemporalDuration(duration).
-        let object = this.as_object();
-        let duration = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("this value must be a Duration object.")
-            })?;
+        require_internal_slot!(duration = this, Self, "Duration");
 
         create_temporal_duration(duration.inner.negated(), None, context).map(Into::into)
     }
@@ -795,13 +765,7 @@ impl Duration {
         // 3. Return ! CreateTemporalDuration(abs(duration.[[Years]]), abs(duration.[[Months]]),
         //    abs(duration.[[Weeks]]), abs(duration.[[Days]]), abs(duration.[[Hours]]), abs(duration.[[Minutes]]),
         //    abs(duration.[[Seconds]]), abs(duration.[[Milliseconds]]), abs(duration.[[Microseconds]]), abs(duration.[[Nanoseconds]])).
-        let object = this.as_object();
-        let duration = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("this value must be a Duration object.")
-            })?;
+        require_internal_slot!(duration = this, Self, "Duration");
 
         create_temporal_duration(duration.inner.abs(), None, context).map(Into::into)
     }
@@ -824,13 +788,7 @@ impl Duration {
     ) -> JsResult<JsValue> {
         // 1.Let duration be the this value.
         // 2. Perform ? RequireInternalSlot(duration, [[InitializedTemporalDuration]]).
-        let object = this.as_object();
-        let duration = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("this value must be a Duration object.")
-            })?;
+        require_internal_slot!(duration = this, Self, "Duration");
 
         // 3. Return ? AddDurations(add, duration, other).
         let other = to_temporal_duration_record(args.get_or_undefined(0), context)?;
@@ -856,13 +814,7 @@ impl Duration {
     ) -> JsResult<JsValue> {
         // 1.Let duration be the this value.
         // 2. Perform ? RequireInternalSlot(duration, [[InitializedTemporalDuration]]).
-        let object = this.as_object();
-        let duration = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("this value must be a Duration object.")
-            })?;
+        require_internal_slot!(duration = this, Self, "Duration");
 
         let other = to_temporal_duration_record(args.get_or_undefined(0), context)?;
 
@@ -888,13 +840,7 @@ impl Duration {
     ) -> JsResult<JsValue> {
         // 1. Let duration be the this value.
         // 2. Perform ? RequireInternalSlot(duration, [[InitializedTemporalDuration]]).
-        let object = this.as_object();
-        let duration = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("this value must be a Duration object.")
-            })?;
+        require_internal_slot!(duration = this, Self, "Duration");
 
         let round_to = match args.first().map(JsValue::variant) {
             // 3. If roundTo is undefined, then
@@ -991,13 +937,7 @@ impl Duration {
     ) -> JsResult<JsValue> {
         // 1. Let duration be the this value.
         // 2. Perform ? RequireInternalSlot(duration, [[InitializedTemporalDuration]]).
-        let object = this.as_object();
-        let duration = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("this value must be a Duration object.")
-            })?;
+        require_internal_slot!(duration = this, Self, "Duration");
 
         let total_of = args.get_or_undefined(0);
 
@@ -1067,13 +1007,7 @@ impl Duration {
         args: &[JsValue],
         context: &mut Context,
     ) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let duration = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("this value must be a Duration object.")
-            })?;
+        require_internal_slot!(duration = this, Self, "Duration");
 
         let options = get_options_object(args.get_or_undefined(0))?;
         let precision = get_digits_option(&options, context)?;
@@ -1100,13 +1034,7 @@ impl Duration {
     /// [spec]: https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.tojson
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Duration/toJSON
     pub(crate) fn to_json(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let duration = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("this value must be a Duration object.")
-            })?;
+        require_internal_slot!(duration = this, Self, "Duration");
 
         let result = duration
             .inner
@@ -1130,13 +1058,7 @@ impl Duration {
         _: &mut Context,
     ) -> JsResult<JsValue> {
         // TODO: Update for ECMA-402 compliance
-        let object = this.as_object();
-        let duration = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("this value must be a Duration object.")
-            })?;
+        require_internal_slot!(duration = this, Self, "Duration");
 
         let result = duration
             .inner

--- a/core/engine/src/builtins/temporal/instant/mod.rs
+++ b/core/engine/src/builtins/temporal/instant/mod.rs
@@ -286,11 +286,11 @@ impl Instant {
     ) -> JsResult<JsValue> {
         // 1. Let instant be the this value.
         // 2. Perform ? RequireInternalSlot(instant, [[InitializedTemporalInstant]]).
-        require_internal_slot!(instant = this, Self, "Instant");
+        let instant = require_internal_slot!(this, Self, "Instant");
         // 3. Let ns be instant.[[Nanoseconds]].
         // 4. Let ms be floor(ℝ(ns) / 10^6).
         // 5. Return 𝔽(ms).
-        Ok(instant.inner.epoch_milliseconds().into())
+        Ok(instant.borrow().data().inner.epoch_milliseconds().into())
     }
 
     /// 8.3.6 get Temporal.Instant.prototype.epochNanoseconds
@@ -311,10 +311,10 @@ impl Instant {
     ) -> JsResult<JsValue> {
         // 1. Let instant be the this value.
         // 2. Perform ? RequireInternalSlot(instant, [[InitializedTemporalInstant]]).
-        require_internal_slot!(instant = this, Self, "Instant");
+        let instant = require_internal_slot!(this, Self, "Instant");
         // 3. Let ns be instant.[[Nanoseconds]].
         // 4. Return ns.
-        Ok(JsBigInt::from(instant.inner.epoch_nanoseconds().as_i128()).into())
+        Ok(JsBigInt::from(instant.borrow().data().inner.epoch_nanoseconds().as_i128()).into())
     }
 }
 
@@ -339,12 +339,12 @@ impl Instant {
     ) -> JsResult<JsValue> {
         // 1. Let instant be the this value.
         // 2. Perform ? RequireInternalSlot(instant, [[InitializedTemporalInstant]]).
-        require_internal_slot!(instant = this, Self, "Instant");
+        let instant = require_internal_slot!(this, Self, "Instant");
 
         // 3. Return ? AddDurationToOrSubtractDurationFromInstant(add, instant, temporalDurationLike).
         let temporal_duration_like =
             to_temporal_duration_record(args.get_or_undefined(0), context)?;
-        let result = instant.inner.add(&temporal_duration_like)?;
+        let result = instant.borrow().data().inner.add(&temporal_duration_like)?;
         create_temporal_instant(result, None, context)
     }
 
@@ -366,12 +366,16 @@ impl Instant {
     ) -> JsResult<JsValue> {
         // 1. Let instant be the this value.
         // 2. Perform ? RequireInternalSlot(instant, [[InitializedTemporalInstant]]).
-        require_internal_slot!(instant = this, Self, "Instant");
+        let instant = require_internal_slot!(this, Self, "Instant");
 
         // 3. Return ? AddDurationToOrSubtractDurationFromInstant(subtract, instant, temporalDurationLike).
         let temporal_duration_like =
             to_temporal_duration_record(args.get_or_undefined(0), context)?;
-        let result = instant.inner.subtract(&temporal_duration_like)?;
+        let result = instant
+            .borrow()
+            .data()
+            .inner
+            .subtract(&temporal_duration_like)?;
         create_temporal_instant(result, None, context)
     }
 
@@ -393,7 +397,7 @@ impl Instant {
     ) -> JsResult<JsValue> {
         // 1. Let instant be the this value.
         // 2. Perform ? RequireInternalSlot(instant, [[InitializedTemporalInstant]]).
-        require_internal_slot!(instant = this, Self, "Instant");
+        let instant = require_internal_slot!(this, Self, "Instant");
 
         // 3. Return ? DifferenceTemporalInstant(until, instant, other, options).
         let other = to_temporal_instant(args.get_or_undefined(0), context)?;
@@ -401,7 +405,7 @@ impl Instant {
         // Fetch the necessary options.
         let settings =
             get_difference_settings(&get_options_object(args.get_or_undefined(1))?, context)?;
-        let result = instant.inner.until(&other, settings)?;
+        let result = instant.borrow().data().inner.until(&other, settings)?;
         create_temporal_duration(result, None, context).map(Into::into)
     }
 
@@ -423,13 +427,13 @@ impl Instant {
     ) -> JsResult<JsValue> {
         // 1. Let instant be the this value.
         // 2. Perform ? RequireInternalSlot(instant, [[InitializedTemporalInstant]]).
-        require_internal_slot!(instant = this, Self, "Instant");
+        let instant = require_internal_slot!(this, Self, "Instant");
 
         // 3. Return ? DifferenceTemporalInstant(since, instant, other, options).
         let other = to_temporal_instant(args.get_or_undefined(0), context)?;
         let settings =
             get_difference_settings(&get_options_object(args.get_or_undefined(1))?, context)?;
-        let result = instant.inner.since(&other, settings)?;
+        let result = instant.borrow().data().inner.since(&other, settings)?;
         create_temporal_duration(result, None, context).map(Into::into)
     }
 
@@ -451,7 +455,7 @@ impl Instant {
     ) -> JsResult<JsValue> {
         // 1. Let instant be the this value.
         // 2. Perform ? RequireInternalSlot(instant, [[InitializedTemporalInstant]]).
-        require_internal_slot!(instant = this, Self, "Instant");
+        let instant = require_internal_slot!(this, Self, "Instant");
 
         let round_to = match args.first().map(JsValue::variant) {
             // 3. If roundTo is undefined, then
@@ -521,7 +525,7 @@ impl Instant {
         // unreachable here functions as 15.a.
         // 16. Perform ? ValidateTemporalRoundingIncrement(roundingIncrement, maximum, true).
         // 17. Let roundedNs be RoundTemporalInstant(instant.[[Nanoseconds]], roundingIncrement, smallestUnit, roundingMode).
-        let result = instant.inner.round(options)?;
+        let result = instant.borrow().data().inner.round(options)?;
 
         // 18. Return ! CreateTemporalInstant(roundedNs).
         create_temporal_instant(result, None, context)
@@ -547,13 +551,13 @@ impl Instant {
         // 2. Perform ? RequireInternalSlot(instant, [[InitializedTemporalInstant]]).
         // 4. If instant.[[Nanoseconds]] ≠ other.[[Nanoseconds]], return false.
         // 5. Return true.
-        require_internal_slot!(instant = this, Self, "Instant");
+        let instant = require_internal_slot!(this, Self, "Instant");
 
         // 3. Set other to ? ToTemporalInstant(other).
         let other = args.get_or_undefined(0);
         let other_instant = to_temporal_instant(other, context)?;
 
-        if *instant.inner != other_instant {
+        if *instant.borrow().data().inner != other_instant {
             return Ok(false.into());
         }
         Ok(true.into())
@@ -571,7 +575,7 @@ impl Instant {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Instant/toString
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.Instant.html#method.to_ixdtf_string
     fn to_string(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(instant = this, Self, "Instant");
+        let instant = require_internal_slot!(this, Self, "Instant");
 
         let options = get_options_object(args.get_or_undefined(0))?;
 
@@ -591,11 +595,11 @@ impl Instant {
             rounding_mode,
         };
 
-        let ixdtf = instant.inner.to_ixdtf_string_with_provider(
-            timezone,
-            options,
-            context.timezone_provider(),
-        )?;
+        let ixdtf = instant
+            .borrow()
+            .data()
+            .inner
+            .to_ixdtf_string_with_provider(timezone, options, context.timezone_provider())?;
 
         Ok(JsString::from(ixdtf).into())
     }
@@ -611,13 +615,17 @@ impl Instant {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Instant/toLocaleString
     fn to_locale_string(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // TODO: Update for ECMA-402 compliance
-        require_internal_slot!(instant = this, Self, "Instant");
+        let instant = require_internal_slot!(this, Self, "Instant");
 
-        let ixdtf = instant.inner.to_ixdtf_string_with_provider(
-            None,
-            ToStringRoundingOptions::default(),
-            context.timezone_provider(),
-        )?;
+        let ixdtf = instant
+            .borrow()
+            .data()
+            .inner
+            .to_ixdtf_string_with_provider(
+                None,
+                ToStringRoundingOptions::default(),
+                context.timezone_provider(),
+            )?;
         Ok(JsString::from(ixdtf).into())
     }
 
@@ -631,13 +639,17 @@ impl Instant {
     /// [spec]: https://tc39.es/proposal-temporal/#sec-temporal.instant.tojson
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Instant/toJSON
     fn to_json(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(instant = this, Self, "Instant");
+        let instant = require_internal_slot!(this, Self, "Instant");
 
-        let ixdtf = instant.inner.to_ixdtf_string_with_provider(
-            None,
-            ToStringRoundingOptions::default(),
-            context.timezone_provider(),
-        )?;
+        let ixdtf = instant
+            .borrow()
+            .data()
+            .inner
+            .to_ixdtf_string_with_provider(
+                None,
+                ToStringRoundingOptions::default(),
+                context.timezone_provider(),
+            )?;
         Ok(JsString::from(ixdtf).into())
     }
 
@@ -674,13 +686,15 @@ impl Instant {
     ) -> JsResult<JsValue> {
         // 1. Let instant be the this value.
         // 2. Perform ? RequireInternalSlot(instant, [[InitializedTemporalInstant]]).
-        require_internal_slot!(instant = this, Self, "Instant");
+        let instant = require_internal_slot!(this, Self, "Instant");
 
         // 3. Set timeZone to ? ToTemporalTimeZoneIdentifier(timeZone).
         let timezone = to_temporal_timezone_identifier(args.get_or_undefined(0), context)?;
 
         // 4. Return ! CreateTemporalZonedDateTime(instant.[[EpochNanoseconds]], timeZone, "iso8601").
         let zdt = instant
+            .borrow()
+            .data()
             .inner
             .to_zoned_date_time_iso_with_provider(timezone, context.timezone_provider())?;
         create_temporal_zoneddatetime(zdt, None, context).map(Into::into)

--- a/core/engine/src/builtins/temporal/instant/mod.rs
+++ b/core/engine/src/builtins/temporal/instant/mod.rs
@@ -286,13 +286,7 @@ impl Instant {
     ) -> JsResult<JsValue> {
         // 1. Let instant be the this value.
         // 2. Perform ? RequireInternalSlot(instant, [[InitializedTemporalInstant]]).
-        let object = this.as_object();
-        let instant = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be an instant object.")
-            })?;
+        require_internal_slot!(instant = this, Self, "Instant");
         // 3. Let ns be instant.[[Nanoseconds]].
         // 4. Let ms be floor(ℝ(ns) / 10^6).
         // 5. Return 𝔽(ms).
@@ -317,13 +311,7 @@ impl Instant {
     ) -> JsResult<JsValue> {
         // 1. Let instant be the this value.
         // 2. Perform ? RequireInternalSlot(instant, [[InitializedTemporalInstant]]).
-        let object = this.as_object();
-        let instant = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be an instant object.")
-            })?;
+        require_internal_slot!(instant = this, Self, "Instant");
         // 3. Let ns be instant.[[Nanoseconds]].
         // 4. Return ns.
         Ok(JsBigInt::from(instant.inner.epoch_nanoseconds().as_i128()).into())
@@ -351,13 +339,7 @@ impl Instant {
     ) -> JsResult<JsValue> {
         // 1. Let instant be the this value.
         // 2. Perform ? RequireInternalSlot(instant, [[InitializedTemporalInstant]]).
-        let object = this.as_object();
-        let instant = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be an instant object.")
-            })?;
+        require_internal_slot!(instant = this, Self, "Instant");
 
         // 3. Return ? AddDurationToOrSubtractDurationFromInstant(add, instant, temporalDurationLike).
         let temporal_duration_like =
@@ -384,13 +366,7 @@ impl Instant {
     ) -> JsResult<JsValue> {
         // 1. Let instant be the this value.
         // 2. Perform ? RequireInternalSlot(instant, [[InitializedTemporalInstant]]).
-        let object = this.as_object();
-        let instant = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be an instant object.")
-            })?;
+        require_internal_slot!(instant = this, Self, "Instant");
 
         // 3. Return ? AddDurationToOrSubtractDurationFromInstant(subtract, instant, temporalDurationLike).
         let temporal_duration_like =
@@ -417,13 +393,7 @@ impl Instant {
     ) -> JsResult<JsValue> {
         // 1. Let instant be the this value.
         // 2. Perform ? RequireInternalSlot(instant, [[InitializedTemporalInstant]]).
-        let object = this.as_object();
-        let instant = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be an instant object.")
-            })?;
+        require_internal_slot!(instant = this, Self, "Instant");
 
         // 3. Return ? DifferenceTemporalInstant(until, instant, other, options).
         let other = to_temporal_instant(args.get_or_undefined(0), context)?;
@@ -453,13 +423,7 @@ impl Instant {
     ) -> JsResult<JsValue> {
         // 1. Let instant be the this value.
         // 2. Perform ? RequireInternalSlot(instant, [[InitializedTemporalInstant]]).
-        let object = this.as_object();
-        let instant = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be an instant object.")
-            })?;
+        require_internal_slot!(instant = this, Self, "Instant");
 
         // 3. Return ? DifferenceTemporalInstant(since, instant, other, options).
         let other = to_temporal_instant(args.get_or_undefined(0), context)?;
@@ -487,13 +451,7 @@ impl Instant {
     ) -> JsResult<JsValue> {
         // 1. Let instant be the this value.
         // 2. Perform ? RequireInternalSlot(instant, [[InitializedTemporalInstant]]).
-        let object = this.as_object();
-        let instant = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be an instant object.")
-            })?;
+        require_internal_slot!(instant = this, Self, "Instant");
 
         let round_to = match args.first().map(JsValue::variant) {
             // 3. If roundTo is undefined, then
@@ -589,13 +547,7 @@ impl Instant {
         // 2. Perform ? RequireInternalSlot(instant, [[InitializedTemporalInstant]]).
         // 4. If instant.[[Nanoseconds]] ≠ other.[[Nanoseconds]], return false.
         // 5. Return true.
-        let object = this.as_object();
-        let instant = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be an instant object.")
-            })?;
+        require_internal_slot!(instant = this, Self, "Instant");
 
         // 3. Set other to ? ToTemporalInstant(other).
         let other = args.get_or_undefined(0);
@@ -619,14 +571,7 @@ impl Instant {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Instant/toString
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.Instant.html#method.to_ixdtf_string
     fn to_string(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let instant = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ()
-                    .with_message("the this object must be a Temporal.Instant object.")
-            })?;
+        require_internal_slot!(instant = this, Self, "Instant");
 
         let options = get_options_object(args.get_or_undefined(0))?;
 
@@ -666,14 +611,7 @@ impl Instant {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Instant/toLocaleString
     fn to_locale_string(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // TODO: Update for ECMA-402 compliance
-        let object = this.as_object();
-        let instant = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ()
-                    .with_message("the this object must be a Temporal.Instant object.")
-            })?;
+        require_internal_slot!(instant = this, Self, "Instant");
 
         let ixdtf = instant.inner.to_ixdtf_string_with_provider(
             None,
@@ -693,14 +631,7 @@ impl Instant {
     /// [spec]: https://tc39.es/proposal-temporal/#sec-temporal.instant.tojson
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Instant/toJSON
     fn to_json(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let instant = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ()
-                    .with_message("the this object must be a Temporal.Instant object.")
-            })?;
+        require_internal_slot!(instant = this, Self, "Instant");
 
         let ixdtf = instant.inner.to_ixdtf_string_with_provider(
             None,
@@ -743,14 +674,7 @@ impl Instant {
     ) -> JsResult<JsValue> {
         // 1. Let instant be the this value.
         // 2. Perform ? RequireInternalSlot(instant, [[InitializedTemporalInstant]]).
-        let object = this.as_object();
-        let instant = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ()
-                    .with_message("the this object must be a Temporal.Instant object.")
-            })?;
+        require_internal_slot!(instant = this, Self, "Instant");
 
         // 3. Set timeZone to ? ToTemporalTimeZoneIdentifier(timeZone).
         let timezone = to_temporal_timezone_identifier(args.get_or_undefined(0), context)?;

--- a/core/engine/src/builtins/temporal/plain_date/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_date/mod.rs
@@ -331,13 +331,7 @@ impl PlainDate {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDate/calendarId
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainDate.html#method.calendar
     fn get_calendar_id(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let date = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainDate object.")
-            })?;
+        require_internal_slot!(date = this, Self, "PlainDate");
 
         Ok(JsString::from(date.inner.calendar().identifier()).into())
     }
@@ -801,13 +795,7 @@ impl PlainDate {
     ) -> JsResult<JsValue> {
         // 1. Let temporalDate be the this value.
         // 2. Perform ? RequireInternalSlot(temporalDate, [[InitializedTemporalDate]]).
-        let object = this.as_object();
-        let date = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainDate object.")
-            })?;
+        require_internal_slot!(date = this, Self, "PlainDate");
 
         let year_month = date.inner.to_plain_year_month()?;
         create_temporal_year_month(year_month, None, context)
@@ -831,13 +819,7 @@ impl PlainDate {
     ) -> JsResult<JsValue> {
         // 1. Let temporalDate be the this value.
         // 2. Perform ? RequireInternalSlot(temporalDate, [[InitializedTemporalDate]]).
-        let object = this.as_object();
-        let date = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainDate object.")
-            })?;
+        require_internal_slot!(date = this, Self, "PlainDate");
 
         let month_day = date.inner.to_plain_month_day()?;
         create_temporal_month_day(month_day, None, context)
@@ -857,13 +839,7 @@ impl PlainDate {
     fn add(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let temporalDate be the this value.
         // 2. Perform ? RequireInternalSlot(temporalDate, [[InitializedTemporalDate]]).
-        let object = this.as_object();
-        let date = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainDate object.")
-            })?;
+        require_internal_slot!(date = this, Self, "PlainDate");
 
         // 3. Let duration be ? ToTemporalDuration(temporalDurationLike).
         let duration = to_temporal_duration_record(args.get_or_undefined(0), context)?;
@@ -893,13 +869,7 @@ impl PlainDate {
     fn subtract(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let temporalDate be the this value.
         // 2. Perform ? RequireInternalSlot(temporalDate, [[InitializedTemporalDate]]).
-        let object = this.as_object();
-        let date = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainDate object.")
-            })?;
+        require_internal_slot!(date = this, Self, "PlainDate");
 
         // 3. Let duration be ? ToTemporalDuration(temporalDurationLike).
         let duration = to_temporal_duration_record(args.get_or_undefined(0), context)?;
@@ -929,13 +899,7 @@ impl PlainDate {
     fn with(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let temporalDate be the this value.
         // 2. Perform ? RequireInternalSlot(temporalDate, [[InitializedTemporalDate]]).
-        let object = this.as_object();
-        let date = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainDate object.")
-            })?;
+        require_internal_slot!(date = this, Self, "PlainDate");
 
         // 3. If ? IsPartialTemporalObject(temporalDateLike) is false, throw a TypeError exception.
         let Some(partial_object) =
@@ -977,14 +941,8 @@ impl PlainDate {
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainDate.html#method.with_calendar
     fn with_calendar(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let plainDate be the this value.
-        let object = this.as_object();
         // 2. Perform ? RequireInternalSlot(plainDate, [[InitializedTemporalDate]]).
-        let date = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainDate object.")
-            })?;
+        require_internal_slot!(date = this, Self, "PlainDate");
 
         // 3. Let calendar be ? ToTemporalCalendarIdentifier(calendarLike).
         let calendar = to_temporal_calendar_identifier(args.get_or_undefined(0))?;
@@ -1007,13 +965,7 @@ impl PlainDate {
     fn until(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let temporalDate be the this value.
         // 2. Perform ? RequireInternalSlot(temporalDate, [[InitializedTemporalDate]]).
-        let object = this.as_object();
-        let date = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainDate object.")
-            })?;
+        require_internal_slot!(date = this, Self, "PlainDate");
 
         let other = to_temporal_date(args.get_or_undefined(0), None, context)?;
 
@@ -1038,13 +990,7 @@ impl PlainDate {
     fn since(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let temporalDate be the this value.
         // 2. Perform ? RequireInternalSlot(temporalDate, [[InitializedTemporalDate]]).
-        let object = this.as_object();
-        let date = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainDate object.")
-            })?;
+        require_internal_slot!(date = this, Self, "PlainDate");
 
         // 3. Return ? DifferenceTemporalPlainDate(since, temporalDate, other, options).
         let other = to_temporal_date(args.get_or_undefined(0), None, context)?;
@@ -1067,13 +1013,7 @@ impl PlainDate {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDate/equals
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainDate.html#impl-Eq-for-PlainDate
     fn equals(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let date = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainDate object.")
-            })?;
+        require_internal_slot!(date = this, Self, "PlainDate");
 
         let other = to_temporal_date(args.get_or_undefined(0), None, context)?;
 
@@ -1098,13 +1038,7 @@ impl PlainDate {
     ) -> JsResult<JsValue> {
         // 1. Let temporalDate be the this value.
         // 2. Perform ? RequireInternalSlot(temporalDate, [[InitializedTemporalDate]]).
-        let object = this.as_object();
-        let date = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainDate object.")
-            })?;
+        require_internal_slot!(date = this, Self, "PlainDate");
 
         // 3. Set temporalTime to ? ToTemporalTimeOrMidnight(temporalTime).
         let time = args
@@ -1134,13 +1068,7 @@ impl PlainDate {
     ) -> JsResult<JsValue> {
         // 1. Let temporalDate be the this value.
         // 2. Perform ? RequireInternalSlot(temporalDate, [[InitializedTemporalDate]]).
-        let object = this.as_object();
-        let date = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainDate object.")
-            })?;
+        require_internal_slot!(date = this, Self, "PlainDate");
 
         let item = args.get_or_undefined(0);
         // 3. If item is an Object, then
@@ -1196,13 +1124,7 @@ impl PlainDate {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDate/toString
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainDate.html#method.to_ixdtf_string
     fn to_string(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let date = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainDate object.")
-            })?;
+        require_internal_slot!(date = this, Self, "PlainDate");
 
         let options = get_options_object(args.get_or_undefined(0))?;
         let display_calendar =
@@ -1222,13 +1144,7 @@ impl PlainDate {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDate/toLocaleString
     fn to_locale_string(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // TODO: Update for ECMA-402 compliance
-        let object = this.as_object();
-        let date = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainDate object.")
-            })?;
+        require_internal_slot!(date = this, Self, "PlainDate");
 
         Ok(JsString::from(date.inner.to_string()).into())
     }
@@ -1243,13 +1159,7 @@ impl PlainDate {
     /// [spec]: https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.toJSON
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDate/toJSON
     fn to_json(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let date = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainDate object.")
-            })?;
+        require_internal_slot!(date = this, Self, "PlainDate");
 
         Ok(JsString::from(date.inner.to_string()).into())
     }

--- a/core/engine/src/builtins/temporal/plain_date/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_date/mod.rs
@@ -331,9 +331,9 @@ impl PlainDate {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDate/calendarId
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainDate.html#method.calendar
     fn get_calendar_id(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(date = this, Self, "PlainDate");
+        let date = require_internal_slot!(this, Self, "PlainDate");
 
-        Ok(JsString::from(date.inner.calendar().identifier()).into())
+        Ok(JsString::from(date.borrow().data().inner.calendar().identifier()).into())
     }
 
     /// 3.3.4 get `Temporal.PlainDate.prototype.era`
@@ -795,9 +795,9 @@ impl PlainDate {
     ) -> JsResult<JsValue> {
         // 1. Let temporalDate be the this value.
         // 2. Perform ? RequireInternalSlot(temporalDate, [[InitializedTemporalDate]]).
-        require_internal_slot!(date = this, Self, "PlainDate");
+        let date = require_internal_slot!(this, Self, "PlainDate");
 
-        let year_month = date.inner.to_plain_year_month()?;
+        let year_month = date.borrow().data().inner.to_plain_year_month()?;
         create_temporal_year_month(year_month, None, context)
     }
 
@@ -819,9 +819,9 @@ impl PlainDate {
     ) -> JsResult<JsValue> {
         // 1. Let temporalDate be the this value.
         // 2. Perform ? RequireInternalSlot(temporalDate, [[InitializedTemporalDate]]).
-        require_internal_slot!(date = this, Self, "PlainDate");
+        let date = require_internal_slot!(this, Self, "PlainDate");
 
-        let month_day = date.inner.to_plain_month_day()?;
+        let month_day = date.borrow().data().inner.to_plain_month_day()?;
         create_temporal_month_day(month_day, None, context)
     }
 
@@ -839,7 +839,7 @@ impl PlainDate {
     fn add(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let temporalDate be the this value.
         // 2. Perform ? RequireInternalSlot(temporalDate, [[InitializedTemporalDate]]).
-        require_internal_slot!(date = this, Self, "PlainDate");
+        let date = require_internal_slot!(this, Self, "PlainDate");
 
         // 3. Let duration be ? ToTemporalDuration(temporalDurationLike).
         let duration = to_temporal_duration_record(args.get_or_undefined(0), context)?;
@@ -851,7 +851,7 @@ impl PlainDate {
 
         // 5. Let calendarRec be ? CreateCalendarMethodsRecord(temporalDate.[[Calendar]], « date-add »).
         // 6. Return ? AddDate(calendarRec, temporalDate, duration, options).
-        let resolved_date = date.inner.add(&duration, overflow)?;
+        let resolved_date = date.borrow().data().inner.add(&duration, overflow)?;
         create_temporal_date(resolved_date, None, context).map(Into::into)
     }
 
@@ -869,7 +869,7 @@ impl PlainDate {
     fn subtract(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let temporalDate be the this value.
         // 2. Perform ? RequireInternalSlot(temporalDate, [[InitializedTemporalDate]]).
-        require_internal_slot!(date = this, Self, "PlainDate");
+        let date = require_internal_slot!(this, Self, "PlainDate");
 
         // 3. Let duration be ? ToTemporalDuration(temporalDurationLike).
         let duration = to_temporal_duration_record(args.get_or_undefined(0), context)?;
@@ -881,7 +881,7 @@ impl PlainDate {
         // 5. Let negatedDuration be CreateNegatedTemporalDuration(duration).
         // 6. Let calendarRec be ? CreateCalendarMethodsRecord(temporalDate.[[Calendar]], « date-add »).
         // 7. Return ? AddDate(calendarRec, temporalDate, negatedDuration, options).
-        let resolved_date = date.inner.subtract(&duration, overflow)?;
+        let resolved_date = date.borrow().data().inner.subtract(&duration, overflow)?;
         create_temporal_date(resolved_date, None, context).map(Into::into)
     }
 
@@ -899,7 +899,7 @@ impl PlainDate {
     fn with(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let temporalDate be the this value.
         // 2. Perform ? RequireInternalSlot(temporalDate, [[InitializedTemporalDate]]).
-        require_internal_slot!(date = this, Self, "PlainDate");
+        let date = require_internal_slot!(this, Self, "PlainDate");
 
         // 3. If ? IsPartialTemporalObject(temporalDateLike) is false, throw a TypeError exception.
         let Some(partial_object) =
@@ -915,7 +915,11 @@ impl PlainDate {
         // 5. Let fields be ISODateToFields(calendar, temporalDate.[[ISODate]], date).
         // 6. Let partialDate be ? PrepareCalendarFields(calendar, temporalDateLike, « year, month, month-code, day », « », partial).
         // 7. Set fields to CalendarMergeFields(calendar, fields, partialDate).
-        let fields = to_calendar_fields(&partial_object, date.inner.calendar(), context)?;
+        let fields = to_calendar_fields(
+            &partial_object,
+            date.borrow().data().inner.calendar(),
+            context,
+        )?;
 
         // 8. Let resolvedOptions be ? GetOptionsObject(options).
         let options = get_options_object(args.get_or_undefined(1))?;
@@ -923,7 +927,7 @@ impl PlainDate {
         let overflow = get_option::<Overflow>(&options, js_string!("overflow"), context)?;
 
         // 10. Return ? CalendarDateFromFields(calendarRec, fields, resolvedOptions).
-        let resolved_date = date.inner.with(fields, overflow)?;
+        let resolved_date = date.borrow().data().inner.with(fields, overflow)?;
         create_temporal_date(resolved_date, None, context).map(Into::into)
     }
 
@@ -942,12 +946,12 @@ impl PlainDate {
     fn with_calendar(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let plainDate be the this value.
         // 2. Perform ? RequireInternalSlot(plainDate, [[InitializedTemporalDate]]).
-        require_internal_slot!(date = this, Self, "PlainDate");
+        let date = require_internal_slot!(this, Self, "PlainDate");
 
         // 3. Let calendar be ? ToTemporalCalendarIdentifier(calendarLike).
         let calendar = to_temporal_calendar_identifier(args.get_or_undefined(0))?;
         // 4. Return ! CreateTemporalDate(plainDate.[[ISODate]], calendar).
-        let resolved_date = date.inner.with_calendar(calendar);
+        let resolved_date = date.borrow().data().inner.with_calendar(calendar);
         create_temporal_date(resolved_date, None, context).map(Into::into)
     }
 
@@ -965,7 +969,7 @@ impl PlainDate {
     fn until(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let temporalDate be the this value.
         // 2. Perform ? RequireInternalSlot(temporalDate, [[InitializedTemporalDate]]).
-        require_internal_slot!(date = this, Self, "PlainDate");
+        let date = require_internal_slot!(this, Self, "PlainDate");
 
         let other = to_temporal_date(args.get_or_undefined(0), None, context)?;
 
@@ -973,7 +977,12 @@ impl PlainDate {
         let options = get_options_object(args.get_or_undefined(1))?;
         let settings = get_difference_settings(&options, context)?;
 
-        create_temporal_duration(date.inner.until(&other, settings)?, None, context).map(Into::into)
+        create_temporal_duration(
+            date.borrow().data().inner.until(&other, settings)?,
+            None,
+            context,
+        )
+        .map(Into::into)
     }
 
     /// 3.3.26 `Temporal.PlainDate.prototype.since ( other [ , options ] )`
@@ -990,7 +999,7 @@ impl PlainDate {
     fn since(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let temporalDate be the this value.
         // 2. Perform ? RequireInternalSlot(temporalDate, [[InitializedTemporalDate]]).
-        require_internal_slot!(date = this, Self, "PlainDate");
+        let date = require_internal_slot!(this, Self, "PlainDate");
 
         // 3. Return ? DifferenceTemporalPlainDate(since, temporalDate, other, options).
         let other = to_temporal_date(args.get_or_undefined(0), None, context)?;
@@ -998,7 +1007,12 @@ impl PlainDate {
         let options = get_options_object(args.get_or_undefined(1))?;
         let settings = get_difference_settings(&options, context)?;
 
-        create_temporal_duration(date.inner.since(&other, settings)?, None, context).map(Into::into)
+        create_temporal_duration(
+            date.borrow().data().inner.since(&other, settings)?,
+            None,
+            context,
+        )
+        .map(Into::into)
     }
 
     /// 3.3.27 `Temporal.PlainDate.prototype.equals ( other )`
@@ -1013,11 +1027,11 @@ impl PlainDate {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDate/equals
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainDate.html#impl-Eq-for-PlainDate
     fn equals(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(date = this, Self, "PlainDate");
+        let date = require_internal_slot!(this, Self, "PlainDate");
 
         let other = to_temporal_date(args.get_or_undefined(0), None, context)?;
 
-        Ok((date.inner == other).into())
+        Ok((date.borrow().data().inner == other).into())
     }
 
     /// 3.3.28 `Temporal.PlainDate.prototype.toPlainDateTime ( [ temporalTime ] )`
@@ -1038,7 +1052,7 @@ impl PlainDate {
     ) -> JsResult<JsValue> {
         // 1. Let temporalDate be the this value.
         // 2. Perform ? RequireInternalSlot(temporalDate, [[InitializedTemporalDate]]).
-        require_internal_slot!(date = this, Self, "PlainDate");
+        let date = require_internal_slot!(this, Self, "PlainDate");
 
         // 3. Set temporalTime to ? ToTemporalTimeOrMidnight(temporalTime).
         let time = args
@@ -1046,8 +1060,12 @@ impl PlainDate {
             .map(|v| to_temporal_time(v, None, context))
             .transpose()?;
         // 4. Return ? CreateTemporalDateTime(temporalDate.[[ISOYear]], temporalDate.[[ISOMonth]], temporalDate.[[ISODay]], temporalTime.[[ISOHour]], temporalTime.[[ISOMinute]], temporalTime.[[ISOSecond]], temporalTime.[[ISOMillisecond]], temporalTime.[[ISOMicrosecond]], temporalTime.[[ISONanosecond]], temporalDate.[[Calendar]]).
-        create_temporal_datetime(date.inner.to_plain_date_time(time)?, None, context)
-            .map(Into::into)
+        create_temporal_datetime(
+            date.borrow().data().inner.to_plain_date_time(time)?,
+            None,
+            context,
+        )
+        .map(Into::into)
     }
 
     /// 3.3.29 `Temporal.PlainDate.prototype.toZonedDateTime ( item )`
@@ -1068,7 +1086,7 @@ impl PlainDate {
     ) -> JsResult<JsValue> {
         // 1. Let temporalDate be the this value.
         // 2. Perform ? RequireInternalSlot(temporalDate, [[InitializedTemporalDate]]).
-        require_internal_slot!(date = this, Self, "PlainDate");
+        let date = require_internal_slot!(this, Self, "PlainDate");
 
         let item = args.get_or_undefined(0);
         // 3. If item is an Object, then
@@ -1102,11 +1120,11 @@ impl PlainDate {
             (to_temporal_timezone_identifier(item, context)?, None)
         };
 
-        let result = date.inner.to_zoned_date_time_with_provider(
-            timezone,
-            time,
-            context.timezone_provider(),
-        )?;
+        let result = date
+            .borrow()
+            .data()
+            .inner
+            .to_zoned_date_time_with_provider(timezone, time, context.timezone_provider())?;
 
         // 7. Return ! CreateTemporalZonedDateTime(epochNs, timeZone, temporalDate.[[Calendar]]).
         create_temporal_zoneddatetime(result, None, context).map(Into::into)
@@ -1124,13 +1142,13 @@ impl PlainDate {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDate/toString
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainDate.html#method.to_ixdtf_string
     fn to_string(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(date = this, Self, "PlainDate");
+        let date = require_internal_slot!(this, Self, "PlainDate");
 
         let options = get_options_object(args.get_or_undefined(0))?;
         let display_calendar =
             get_option::<DisplayCalendar>(&options, js_string!("calendarName"), context)?
                 .unwrap_or(DisplayCalendar::Auto);
-        Ok(JsString::from(date.inner.to_ixdtf_string(display_calendar)).into())
+        Ok(JsString::from(date.borrow().data().inner.to_ixdtf_string(display_calendar)).into())
     }
 
     /// 3.3.31 `Temporal.PlainDate.prototype.toLocaleString ( [ locales [ , options ] ] )`
@@ -1144,9 +1162,9 @@ impl PlainDate {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDate/toLocaleString
     fn to_locale_string(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // TODO: Update for ECMA-402 compliance
-        require_internal_slot!(date = this, Self, "PlainDate");
+        let date = require_internal_slot!(this, Self, "PlainDate");
 
-        Ok(JsString::from(date.inner.to_string()).into())
+        Ok(JsString::from(date.borrow().data().inner.to_string()).into())
     }
 
     /// 3.3.32 `Temporal.PlainDate.prototype.toJSON ( )`
@@ -1159,9 +1177,9 @@ impl PlainDate {
     /// [spec]: https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.toJSON
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDate/toJSON
     fn to_json(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(date = this, Self, "PlainDate");
+        let date = require_internal_slot!(this, Self, "PlainDate");
 
-        Ok(JsString::from(date.inner.to_string()).into())
+        Ok(JsString::from(date.borrow().data().inner.to_string()).into())
     }
 
     /// 3.3.33 `Temporal.PlainDate.prototype.valueOf ( )`

--- a/core/engine/src/builtins/temporal/plain_date_time/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_date_time/mod.rs
@@ -488,9 +488,9 @@ impl PlainDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDateTime/calendarId
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainDateTime.html#method.calendar
     fn get_calendar_id(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(dt = this, Self, "PlainDateTime");
+        let dt = require_internal_slot!(this, Self, "PlainDateTime");
 
-        Ok(JsString::from(dt.inner.calendar().identifier()).into())
+        Ok(JsString::from(dt.borrow().data().inner.calendar().identifier()).into())
     }
 
     /// 5.3.4 get `Temporal.PlainDateTime.prototype.era`
@@ -505,9 +505,11 @@ impl PlainDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDateTime/era
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainDateTime.html#method.era
     fn get_era(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(dt = this, Self, "PlainDateTime");
+        let dt = require_internal_slot!(this, Self, "PlainDateTime");
 
         Ok(dt
+            .borrow()
+            .data()
             .inner
             .era()
             .map(|s| JsString::from(s.as_str()))
@@ -526,9 +528,9 @@ impl PlainDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDateTime/eraYear
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainDateTime.html#method.era_year
     fn get_era_year(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(dt = this, Self, "PlainDateTime");
+        let dt = require_internal_slot!(this, Self, "PlainDateTime");
 
-        Ok(dt.inner.era_year().into_or_undefined())
+        Ok(dt.borrow().data().inner.era_year().into_or_undefined())
     }
 
     /// 5.3.6 get `Temporal.PlainDateTime.prototype.year`
@@ -543,9 +545,9 @@ impl PlainDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDateTime/year
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainDateTime.html#method.year
     fn get_year(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(dt = this, Self, "PlainDateTime");
+        let dt = require_internal_slot!(this, Self, "PlainDateTime");
 
-        Ok(dt.inner.year().into())
+        Ok(dt.borrow().data().inner.year().into())
     }
 
     /// 5.3.7 get `Temporal.PlainDateTime.prototype.month`
@@ -560,9 +562,9 @@ impl PlainDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDateTime/month
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainDateTime.html
     fn get_month(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(dt = this, Self, "PlainDateTime");
+        let dt = require_internal_slot!(this, Self, "PlainDateTime");
 
-        Ok(dt.inner.month().into())
+        Ok(dt.borrow().data().inner.month().into())
     }
 
     /// 5.3.8 get `Temporal.PlainDateTime.prototype.monthCode`
@@ -577,9 +579,9 @@ impl PlainDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDateTime/monthCode
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainDateTime.html#method.month_code
     fn get_month_code(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(dt = this, Self, "PlainDateTime");
+        let dt = require_internal_slot!(this, Self, "PlainDateTime");
 
-        Ok(JsString::from(dt.inner.month_code().as_str()).into())
+        Ok(JsString::from(dt.borrow().data().inner.month_code().as_str()).into())
     }
 
     /// 5.3.9 get `Temporal.PlainDateTime.prototype.day`
@@ -594,9 +596,9 @@ impl PlainDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDateTime/day
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainDateTime.html#method.day
     fn get_day(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(dt = this, Self, "PlainDateTime");
+        let dt = require_internal_slot!(this, Self, "PlainDateTime");
 
-        Ok(dt.inner.day().into())
+        Ok(dt.borrow().data().inner.day().into())
     }
 
     /// 5.3.10 get `Temporal.PlainDateTime.prototype.hour`
@@ -613,10 +615,10 @@ impl PlainDateTime {
     fn get_hour(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Let dateTime be the this value.
         // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
-        require_internal_slot!(dt = this, Self, "PlainDateTime");
+        let dt = require_internal_slot!(this, Self, "PlainDateTime");
 
         // 3. Return 𝔽(datedt.[[ISOHour]]).
-        Ok(dt.inner.hour().into())
+        Ok(dt.borrow().data().inner.hour().into())
     }
 
     /// 5.3.11 get `Temporal.PlainDateTime.prototype.minute`
@@ -633,10 +635,10 @@ impl PlainDateTime {
     fn get_minute(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Let dateTime be the this value.
         // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
-        require_internal_slot!(dt = this, Self, "PlainDateTime");
+        let dt = require_internal_slot!(this, Self, "PlainDateTime");
 
         // 3. Return 𝔽(datedt.[[ISOMinute]]).
-        Ok(dt.inner.minute().into())
+        Ok(dt.borrow().data().inner.minute().into())
     }
 
     /// 5.3.12 get `Temporal.PlainDateTime.prototype.second`
@@ -653,10 +655,10 @@ impl PlainDateTime {
     fn get_second(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Let dateTime be the this value.
         // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
-        require_internal_slot!(dt = this, Self, "PlainDateTime");
+        let dt = require_internal_slot!(this, Self, "PlainDateTime");
 
         // 3. Return 𝔽(datedt.[[ISOSecond]]).
-        Ok(dt.inner.second().into())
+        Ok(dt.borrow().data().inner.second().into())
     }
 
     /// 5.3.13 get `Temporal.PlainDateTime.prototype.millisecond`
@@ -673,10 +675,10 @@ impl PlainDateTime {
     fn get_millisecond(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Let dateTime be the this value.
         // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
-        require_internal_slot!(dt = this, Self, "PlainDateTime");
+        let dt = require_internal_slot!(this, Self, "PlainDateTime");
 
         // 3. Return 𝔽(datedt.[[ISOMillisecond]]).
-        Ok(dt.inner.millisecond().into())
+        Ok(dt.borrow().data().inner.millisecond().into())
     }
 
     /// 5.3.14 get `Temporal.PlainDateTime.prototype.microsecond`
@@ -693,10 +695,10 @@ impl PlainDateTime {
     fn get_microsecond(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Let dateTime be the this value.
         // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
-        require_internal_slot!(dt = this, Self, "PlainDateTime");
+        let dt = require_internal_slot!(this, Self, "PlainDateTime");
 
         // 3. Return 𝔽(datedt.[[ISOMicrosecond]]).
-        Ok(dt.inner.microsecond().into())
+        Ok(dt.borrow().data().inner.microsecond().into())
     }
 
     /// 5.3.15 get `Temporal.PlainDateTime.prototype.nanosecond`
@@ -713,10 +715,10 @@ impl PlainDateTime {
     fn get_nanosecond(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Let dateTime be the this value.
         // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
-        require_internal_slot!(dt = this, Self, "PlainDateTime");
+        let dt = require_internal_slot!(this, Self, "PlainDateTime");
 
         // 3. Return 𝔽(datedt.[[ISONanosecond]]).
-        Ok(dt.inner.nanosecond().into())
+        Ok(dt.borrow().data().inner.nanosecond().into())
     }
 
     /// 5.3.16 get `Temporal.PlainDateTime.prototype.dayOfWeek`
@@ -731,9 +733,9 @@ impl PlainDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDateTime/dayOfWeek
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainDateTime.html#method.day_of_week
     fn get_day_of_week(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(dt = this, Self, "PlainDateTime");
+        let dt = require_internal_slot!(this, Self, "PlainDateTime");
 
-        Ok(dt.inner.day_of_week().into())
+        Ok(dt.borrow().data().inner.day_of_week().into())
     }
 
     /// 5.3.17 get `Temporal.PlainDateTime.prototype.dayOfYear`
@@ -748,9 +750,9 @@ impl PlainDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDateTime/dayOfYear
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainDateTime.html#method.day_of_year
     fn get_day_of_year(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(dt = this, Self, "PlainDateTime");
+        let dt = require_internal_slot!(this, Self, "PlainDateTime");
 
-        Ok(dt.inner.day_of_year().into())
+        Ok(dt.borrow().data().inner.day_of_year().into())
     }
 
     /// 5.3.18 get `Temporal.PlainDateTime.prototype.weekOfYear`
@@ -765,9 +767,9 @@ impl PlainDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDateTime/weekOfYear
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainDateTime.html#method.week_of_year
     fn get_week_of_year(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(dt = this, Self, "PlainDateTime");
+        let dt = require_internal_slot!(this, Self, "PlainDateTime");
 
-        Ok(dt.inner.week_of_year().into_or_undefined())
+        Ok(dt.borrow().data().inner.week_of_year().into_or_undefined())
     }
 
     /// 5.3.19 get `Temporal.PlainDateTime.prototype.yearOfWeek`
@@ -782,9 +784,9 @@ impl PlainDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDateTime/yearOfWeek
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainDateTime.html#method.year_of_week
     fn get_year_of_week(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(dt = this, Self, "PlainDateTime");
+        let dt = require_internal_slot!(this, Self, "PlainDateTime");
 
-        Ok(dt.inner.year_of_week().into_or_undefined())
+        Ok(dt.borrow().data().inner.year_of_week().into_or_undefined())
     }
 
     /// 5.3.20 get `Temporal.PlainDateTime.prototype.daysInWeek`
@@ -799,9 +801,9 @@ impl PlainDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDateTime/daysInWeek
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainDateTime.html#method.days_in_week
     fn get_days_in_week(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(dt = this, Self, "PlainDateTime");
+        let dt = require_internal_slot!(this, Self, "PlainDateTime");
 
-        Ok(dt.inner.days_in_week().into())
+        Ok(dt.borrow().data().inner.days_in_week().into())
     }
 
     /// 5.3.21 get `Temporal.PlainDateTime.prototype.daysInMonth`
@@ -816,9 +818,9 @@ impl PlainDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDateTime/daysInMonth
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainDateTime.html#method.days_in_month
     fn get_days_in_month(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(dt = this, Self, "PlainDateTime");
+        let dt = require_internal_slot!(this, Self, "PlainDateTime");
 
-        Ok(dt.inner.days_in_month().into())
+        Ok(dt.borrow().data().inner.days_in_month().into())
     }
 
     /// 5.3.22 get `Temporal.PlainDateTime.prototype.daysInYear`
@@ -833,9 +835,9 @@ impl PlainDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDateTime/daysInYear
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainDateTime.html#method.days_in_year
     fn get_days_in_year(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(dt = this, Self, "PlainDateTime");
+        let dt = require_internal_slot!(this, Self, "PlainDateTime");
 
-        Ok(dt.inner.days_in_year().into())
+        Ok(dt.borrow().data().inner.days_in_year().into())
     }
 
     /// 5.3.23 get `Temporal.PlainDateTime.prototype.monthsInYear`
@@ -850,9 +852,9 @@ impl PlainDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDateTime/monthsInYear
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainDateTime.html#method.months_in_year
     fn get_months_in_year(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(dt = this, Self, "PlainDateTime");
+        let dt = require_internal_slot!(this, Self, "PlainDateTime");
 
-        Ok(dt.inner.months_in_year().into())
+        Ok(dt.borrow().data().inner.months_in_year().into())
     }
 
     /// 5.3.24 get `Temporal.PlainDateTime.prototype.inLeapYear`
@@ -867,9 +869,9 @@ impl PlainDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDateTime/inLeapYear
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainDateTime.html#method.in_leap_year
     fn get_in_leap_year(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(dt = this, Self, "PlainDateTime");
+        let dt = require_internal_slot!(this, Self, "PlainDateTime");
 
-        Ok(dt.inner.in_leap_year().into())
+        Ok(dt.borrow().data().inner.in_leap_year().into())
     }
 }
 
@@ -951,7 +953,7 @@ impl PlainDateTime {
     fn with(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let plainDateTime be the this value.
         // 2. Perform ? RequireInternalSlot(plainDateTime, [[InitializedTemporalDateTime]]).
-        require_internal_slot!(dt = this, Self, "PlainDateTime");
+        let dt = require_internal_slot!(this, Self, "PlainDateTime");
 
         // 3. If ? IsPartialTemporalObject(temporalDateTimeLike) is false, throw a TypeError exception.
         let Some(partial_object) =
@@ -971,7 +973,11 @@ impl PlainDateTime {
         // 11. Set fields.[[Nanosecond]] to plainDateTime.[[ISODateTime]].[[Time]].[[Nanosecond]].
         // 12. Let partialDateTime be ? PrepareCalendarFields(calendar, temporalDateTimeLike, « year, month, month-code, day », « hour, minute, second, millisecond, microsecond, nanosecond », partial).
         // 13. Set fields to CalendarMergeFields(calendar, fields, partialDateTime).
-        let fields = to_date_time_fields(&partial_object, dt.inner.calendar(), context)?;
+        let fields = to_date_time_fields(
+            &partial_object,
+            dt.borrow().data().inner.calendar(),
+            context,
+        )?;
         // 14. Let resolvedOptions be ? GetOptionsObject(options).
         let options = get_options_object(args.get_or_undefined(1))?;
         // 15. Let overflow be ? GetTemporalOverflowOption(resolvedOptions).
@@ -979,7 +985,12 @@ impl PlainDateTime {
 
         // 16. Let result be ? InterpretTemporalDateTimeFields(calendar, fields, overflow).
         // 17. Return ? CreateTemporalDateTime(result, calendar).
-        create_temporal_datetime(dt.inner.with(fields, overflow)?, None, context).map(Into::into)
+        create_temporal_datetime(
+            dt.borrow().data().inner.with(fields, overflow)?,
+            None,
+            context,
+        )
+        .map(Into::into)
     }
 
     /// 5.3.26 Temporal.PlainDateTime.prototype.withPlainTime ( `[ plainTimeLike ]` )
@@ -998,14 +1009,15 @@ impl PlainDateTime {
         args: &[JsValue],
         context: &mut Context,
     ) -> JsResult<JsValue> {
-        require_internal_slot!(dt = this, Self, "PlainDateTime");
+        let dt = require_internal_slot!(this, Self, "PlainDateTime");
 
         let time = args
             .get_or_undefined(0)
             .map(|v| to_temporal_time(v, None, context))
             .transpose()?;
 
-        create_temporal_datetime(dt.inner.with_time(time)?, None, context).map(Into::into)
+        create_temporal_datetime(dt.borrow().data().inner.with_time(time)?, None, context)
+            .map(Into::into)
     }
 
     /// 5.3.27 `Temporal.PlainDateTime.prototype.withCalendar ( calendarLike )`
@@ -1020,11 +1032,16 @@ impl PlainDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDateTime/withCalendar
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainDateTime.html#method.with_calendar
     fn with_calendar(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(dt = this, Self, "PlainDateTime");
+        let dt = require_internal_slot!(this, Self, "PlainDateTime");
 
         let calendar = to_temporal_calendar_identifier(args.get_or_undefined(0))?;
 
-        create_temporal_datetime(dt.inner.with_calendar(calendar), None, context).map(Into::into)
+        create_temporal_datetime(
+            dt.borrow().data().inner.with_calendar(calendar),
+            None,
+            context,
+        )
+        .map(Into::into)
     }
 
     /// 5.3.28 `Temporal.PlainDateTime.prototype.add ( temporalDurationLike [ , options ] )`
@@ -1041,7 +1058,7 @@ impl PlainDateTime {
     fn add(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let temporalDate be the this value.
         // 2. Perform ? RequireInternalSlot(temporalDate, [[InitializedTemporalDate]]).
-        require_internal_slot!(dt = this, Self, "PlainDateTime");
+        let dt = require_internal_slot!(this, Self, "PlainDateTime");
 
         // 3. Let duration be ? ToTemporalDuration(temporalDurationLike).
         let duration = to_temporal_duration_record(args.get_or_undefined(0), context)?;
@@ -1052,7 +1069,12 @@ impl PlainDateTime {
 
         // 5. Let calendarRec be ? CreateCalendarMethodsRecord(temporalDate.[[Calendar]], « date-add »).
         // 6. Return ? AddDate(calendarRec, temporalDate, duration, options).
-        create_temporal_datetime(dt.inner.add(&duration, overflow)?, None, context).map(Into::into)
+        create_temporal_datetime(
+            dt.borrow().data().inner.add(&duration, overflow)?,
+            None,
+            context,
+        )
+        .map(Into::into)
     }
 
     /// 5.3.29 `Temporal.PlainDateTime.prototype.subtract ( temporalDurationLike [ , options ] )`
@@ -1069,7 +1091,7 @@ impl PlainDateTime {
     fn subtract(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let temporalDate be the this value.
         // 2. Perform ? RequireInternalSlot(temporalDate, [[InitializedTemporalDate]]).
-        require_internal_slot!(dt = this, Self, "PlainDateTime");
+        let dt = require_internal_slot!(this, Self, "PlainDateTime");
 
         // 3. Let duration be ? ToTemporalDuration(temporalDurationLike).
         let duration = to_temporal_duration_record(args.get_or_undefined(0), context)?;
@@ -1081,8 +1103,12 @@ impl PlainDateTime {
         // 5. Let negatedDuration be CreateNegatedTemporalDuration(duration).
         // 6. Let calendarRec be ? CreateCalendarMethodsRecord(temporalDate.[[Calendar]], « date-add »).
         // 7. Return ? AddDate(calendarRec, temporalDate, negatedDuration, options).
-        create_temporal_datetime(dt.inner.subtract(&duration, overflow)?, None, context)
-            .map(Into::into)
+        create_temporal_datetime(
+            dt.borrow().data().inner.subtract(&duration, overflow)?,
+            None,
+            context,
+        )
+        .map(Into::into)
     }
 
     /// 5.3.30 `Temporal.PlainDateTime.prototype.until ( other [ , options ] )`
@@ -1097,14 +1123,19 @@ impl PlainDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDateTime/until
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainDateTime.html#method.until
     fn until(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(dt = this, Self, "PlainDateTime");
+        let dt = require_internal_slot!(this, Self, "PlainDateTime");
 
         let other = to_temporal_datetime(args.get_or_undefined(0), None, context)?;
 
         let options = get_options_object(args.get_or_undefined(1))?;
         let settings = get_difference_settings(&options, context)?;
 
-        create_temporal_duration(dt.inner.until(&other, settings)?, None, context).map(Into::into)
+        create_temporal_duration(
+            dt.borrow().data().inner.until(&other, settings)?,
+            None,
+            context,
+        )
+        .map(Into::into)
     }
 
     /// 5.3.31 `Temporal.PlainDateTime.prototype.since ( other [ , options ] )`
@@ -1119,14 +1150,19 @@ impl PlainDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDateTime/since
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainDateTime.html#method.since
     fn since(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(dt = this, Self, "PlainDateTime");
+        let dt = require_internal_slot!(this, Self, "PlainDateTime");
 
         let other = to_temporal_datetime(args.get_or_undefined(0), None, context)?;
 
         let options = get_options_object(args.get_or_undefined(1))?;
         let settings = get_difference_settings(&options, context)?;
 
-        create_temporal_duration(dt.inner.since(&other, settings)?, None, context).map(Into::into)
+        create_temporal_duration(
+            dt.borrow().data().inner.since(&other, settings)?,
+            None,
+            context,
+        )
+        .map(Into::into)
     }
 
     /// 5.3.32 Temporal.PlainDateTime.prototype.round ( roundTo )
@@ -1141,7 +1177,7 @@ impl PlainDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDateTime/round
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainDateTime.html#method.round
     fn round(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(dt = this, Self, "PlainDateTime");
+        let dt = require_internal_slot!(this, Self, "PlainDateTime");
 
         let round_to = match args.first().map(JsValue::variant) {
             // 3. If roundTo is undefined, then
@@ -1189,7 +1225,8 @@ impl PlainDateTime {
             context,
         )?;
 
-        create_temporal_datetime(dt.inner().round(options)?, None, context).map(Into::into)
+        create_temporal_datetime(dt.borrow().data().inner().round(options)?, None, context)
+            .map(Into::into)
     }
 
     /// 5.3.33 Temporal.PlainDateTime.prototype.equals ( other )
@@ -1206,7 +1243,7 @@ impl PlainDateTime {
     fn equals(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let dateTime be the this value.
         // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
-        require_internal_slot!(dt = this, Self, "PlainDateTime");
+        let dt = require_internal_slot!(this, Self, "PlainDateTime");
 
         // 3. Set other to ? ToTemporalDateTime(other).
         let other = to_temporal_datetime(args.get_or_undefined(0), None, context)?;
@@ -1219,7 +1256,7 @@ impl PlainDateTime {
         // other.[[ISOMicrosecond]], other.[[ISONanosecond]]).
         // 5. If result is not 0, return false.
         // 6. Return ? CalendarEquals(dateTime.[[Calendar]], other.[[Calendar]]).
-        Ok((dt.inner == other).into())
+        Ok((dt.borrow().data().inner == other).into())
     }
 
     /// 5.3.34 `Temporal.PlainDateTime.prototype.toString ( [ options ] )`
@@ -1234,7 +1271,7 @@ impl PlainDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDateTime/with
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainDateTime.html#method.to_ixdtf_string
     fn to_string(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(dt = this, Self, "PlainDateTime");
+        let dt = require_internal_slot!(this, Self, "PlainDateTime");
 
         let options = get_options_object(args.get_or_undefined(0))?;
 
@@ -1246,7 +1283,7 @@ impl PlainDateTime {
             get_option::<RoundingMode>(&options, js_string!("roundingMode"), context)?;
         let smallest_unit = get_option::<Unit>(&options, js_string!("smallestUnit"), context)?;
 
-        let ixdtf = dt.inner.to_ixdtf_string(
+        let ixdtf = dt.borrow().data().inner.to_ixdtf_string(
             ToStringRoundingOptions {
                 precision,
                 smallest_unit,
@@ -1268,9 +1305,11 @@ impl PlainDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDateTime/with
     fn to_locale_string(this: &JsValue, _args: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // TODO: Update for ECMA-402 compliance
-        require_internal_slot!(dt = this, Self, "PlainDateTime");
+        let dt = require_internal_slot!(this, Self, "PlainDateTime");
 
         let ixdtf = dt
+            .borrow()
+            .data()
             .inner
             .to_ixdtf_string(ToStringRoundingOptions::default(), DisplayCalendar::Auto)?;
         Ok(JsString::from(ixdtf).into())
@@ -1286,9 +1325,11 @@ impl PlainDateTime {
     /// [spec]: https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.with
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDateTime/with
     fn to_json(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(dt = this, Self, "PlainDateTime");
+        let dt = require_internal_slot!(this, Self, "PlainDateTime");
 
         let ixdtf = dt
+            .borrow()
+            .data()
             .inner
             .to_ixdtf_string(ToStringRoundingOptions::default(), DisplayCalendar::Auto)?;
         Ok(JsString::from(ixdtf).into())
@@ -1327,7 +1368,7 @@ impl PlainDateTime {
     ) -> JsResult<JsValue> {
         // 1. Let dateTime be the this value.
         // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
-        require_internal_slot!(dt = this, Self, "PlainDateTime");
+        let dt = require_internal_slot!(this, Self, "PlainDateTime");
         // 3. Let timeZone be ? ToTemporalTimeZoneIdentifier(temporalTimeZoneLike).
         let timezone = to_temporal_timezone_identifier(args.get_or_undefined(0), context)?;
         // 4. Let resolvedOptions be ? GetOptionsObject(options).
@@ -1340,7 +1381,7 @@ impl PlainDateTime {
         // 6. Let epochNs be ? GetEpochNanosecondsFor(timeZone, dateTime.[[ISODateTime]], disambiguation).
         // 7. Return ! CreateTemporalZonedDateTime(epochNs, timeZone, dateTime.[[Calendar]]).
 
-        let result = dt.inner.to_zoned_date_time_with_provider(
+        let result = dt.borrow().data().inner.to_zoned_date_time_with_provider(
             timezone,
             disambiguation,
             context.timezone_provider(),
@@ -1360,9 +1401,9 @@ impl PlainDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDateTime/toPlainDate
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainDateTime.html#method.to_plain_date
     fn to_plain_date(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(dt = this, Self, "PlainDateTime");
+        let dt = require_internal_slot!(this, Self, "PlainDateTime");
 
-        let result = dt.inner.to_plain_date();
+        let result = dt.borrow().data().inner.to_plain_date();
         create_temporal_date(result, None, context).map(Into::into)
     }
 
@@ -1378,9 +1419,9 @@ impl PlainDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDateTime/toPlainTime
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainDateTime.html#method.to_plain_time
     fn to_plain_time(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(dt = this, Self, "PlainDateTime");
+        let dt = require_internal_slot!(this, Self, "PlainDateTime");
 
-        let result = dt.inner.to_plain_time();
+        let result = dt.borrow().data().inner.to_plain_time();
         create_temporal_time(result, None, context).map(Into::into)
     }
 }

--- a/core/engine/src/builtins/temporal/plain_date_time/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_date_time/mod.rs
@@ -488,13 +488,7 @@ impl PlainDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDateTime/calendarId
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainDateTime.html#method.calendar
     fn get_calendar_id(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let dt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
-            })?;
+        require_internal_slot!(dt = this, Self, "PlainDateTime");
 
         Ok(JsString::from(dt.inner.calendar().identifier()).into())
     }
@@ -511,13 +505,7 @@ impl PlainDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDateTime/era
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainDateTime.html#method.era
     fn get_era(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let dt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
-            })?;
+        require_internal_slot!(dt = this, Self, "PlainDateTime");
 
         Ok(dt
             .inner
@@ -538,13 +526,7 @@ impl PlainDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDateTime/eraYear
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainDateTime.html#method.era_year
     fn get_era_year(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let dt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
-            })?;
+        require_internal_slot!(dt = this, Self, "PlainDateTime");
 
         Ok(dt.inner.era_year().into_or_undefined())
     }
@@ -561,13 +543,7 @@ impl PlainDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDateTime/year
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainDateTime.html#method.year
     fn get_year(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let dt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
-            })?;
+        require_internal_slot!(dt = this, Self, "PlainDateTime");
 
         Ok(dt.inner.year().into())
     }
@@ -584,13 +560,7 @@ impl PlainDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDateTime/month
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainDateTime.html
     fn get_month(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let dt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
-            })?;
+        require_internal_slot!(dt = this, Self, "PlainDateTime");
 
         Ok(dt.inner.month().into())
     }
@@ -607,13 +577,7 @@ impl PlainDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDateTime/monthCode
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainDateTime.html#method.month_code
     fn get_month_code(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let dt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
-            })?;
+        require_internal_slot!(dt = this, Self, "PlainDateTime");
 
         Ok(JsString::from(dt.inner.month_code().as_str()).into())
     }
@@ -630,13 +594,7 @@ impl PlainDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDateTime/day
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainDateTime.html#method.day
     fn get_day(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let dt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
-            })?;
+        require_internal_slot!(dt = this, Self, "PlainDateTime");
 
         Ok(dt.inner.day().into())
     }
@@ -655,13 +613,7 @@ impl PlainDateTime {
     fn get_hour(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Let dateTime be the this value.
         // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
-        let object = this.as_object();
-        let dt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
-            })?;
+        require_internal_slot!(dt = this, Self, "PlainDateTime");
 
         // 3. Return 𝔽(datedt.[[ISOHour]]).
         Ok(dt.inner.hour().into())
@@ -681,13 +633,7 @@ impl PlainDateTime {
     fn get_minute(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Let dateTime be the this value.
         // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
-        let object = this.as_object();
-        let dt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
-            })?;
+        require_internal_slot!(dt = this, Self, "PlainDateTime");
 
         // 3. Return 𝔽(datedt.[[ISOMinute]]).
         Ok(dt.inner.minute().into())
@@ -707,13 +653,7 @@ impl PlainDateTime {
     fn get_second(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Let dateTime be the this value.
         // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
-        let object = this.as_object();
-        let dt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
-            })?;
+        require_internal_slot!(dt = this, Self, "PlainDateTime");
 
         // 3. Return 𝔽(datedt.[[ISOSecond]]).
         Ok(dt.inner.second().into())
@@ -733,13 +673,7 @@ impl PlainDateTime {
     fn get_millisecond(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Let dateTime be the this value.
         // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
-        let object = this.as_object();
-        let dt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
-            })?;
+        require_internal_slot!(dt = this, Self, "PlainDateTime");
 
         // 3. Return 𝔽(datedt.[[ISOMillisecond]]).
         Ok(dt.inner.millisecond().into())
@@ -759,13 +693,7 @@ impl PlainDateTime {
     fn get_microsecond(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Let dateTime be the this value.
         // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
-        let object = this.as_object();
-        let dt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
-            })?;
+        require_internal_slot!(dt = this, Self, "PlainDateTime");
 
         // 3. Return 𝔽(datedt.[[ISOMicrosecond]]).
         Ok(dt.inner.microsecond().into())
@@ -785,13 +713,7 @@ impl PlainDateTime {
     fn get_nanosecond(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Let dateTime be the this value.
         // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
-        let object = this.as_object();
-        let dt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
-            })?;
+        require_internal_slot!(dt = this, Self, "PlainDateTime");
 
         // 3. Return 𝔽(datedt.[[ISONanosecond]]).
         Ok(dt.inner.nanosecond().into())
@@ -809,13 +731,7 @@ impl PlainDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDateTime/dayOfWeek
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainDateTime.html#method.day_of_week
     fn get_day_of_week(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let dt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
-            })?;
+        require_internal_slot!(dt = this, Self, "PlainDateTime");
 
         Ok(dt.inner.day_of_week().into())
     }
@@ -832,13 +748,7 @@ impl PlainDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDateTime/dayOfYear
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainDateTime.html#method.day_of_year
     fn get_day_of_year(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let dt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
-            })?;
+        require_internal_slot!(dt = this, Self, "PlainDateTime");
 
         Ok(dt.inner.day_of_year().into())
     }
@@ -855,13 +765,7 @@ impl PlainDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDateTime/weekOfYear
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainDateTime.html#method.week_of_year
     fn get_week_of_year(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let dt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
-            })?;
+        require_internal_slot!(dt = this, Self, "PlainDateTime");
 
         Ok(dt.inner.week_of_year().into_or_undefined())
     }
@@ -878,13 +782,7 @@ impl PlainDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDateTime/yearOfWeek
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainDateTime.html#method.year_of_week
     fn get_year_of_week(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let dt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
-            })?;
+        require_internal_slot!(dt = this, Self, "PlainDateTime");
 
         Ok(dt.inner.year_of_week().into_or_undefined())
     }
@@ -901,13 +799,7 @@ impl PlainDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDateTime/daysInWeek
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainDateTime.html#method.days_in_week
     fn get_days_in_week(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let dt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
-            })?;
+        require_internal_slot!(dt = this, Self, "PlainDateTime");
 
         Ok(dt.inner.days_in_week().into())
     }
@@ -924,13 +816,7 @@ impl PlainDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDateTime/daysInMonth
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainDateTime.html#method.days_in_month
     fn get_days_in_month(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let dt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
-            })?;
+        require_internal_slot!(dt = this, Self, "PlainDateTime");
 
         Ok(dt.inner.days_in_month().into())
     }
@@ -947,13 +833,7 @@ impl PlainDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDateTime/daysInYear
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainDateTime.html#method.days_in_year
     fn get_days_in_year(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let dt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
-            })?;
+        require_internal_slot!(dt = this, Self, "PlainDateTime");
 
         Ok(dt.inner.days_in_year().into())
     }
@@ -970,13 +850,7 @@ impl PlainDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDateTime/monthsInYear
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainDateTime.html#method.months_in_year
     fn get_months_in_year(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let dt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
-            })?;
+        require_internal_slot!(dt = this, Self, "PlainDateTime");
 
         Ok(dt.inner.months_in_year().into())
     }
@@ -993,13 +867,7 @@ impl PlainDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDateTime/inLeapYear
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainDateTime.html#method.in_leap_year
     fn get_in_leap_year(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let dt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
-            })?;
+        require_internal_slot!(dt = this, Self, "PlainDateTime");
 
         Ok(dt.inner.in_leap_year().into())
     }
@@ -1083,13 +951,7 @@ impl PlainDateTime {
     fn with(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let plainDateTime be the this value.
         // 2. Perform ? RequireInternalSlot(plainDateTime, [[InitializedTemporalDateTime]]).
-        let object = this.as_object();
-        let dt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
-            })?;
+        require_internal_slot!(dt = this, Self, "PlainDateTime");
 
         // 3. If ? IsPartialTemporalObject(temporalDateTimeLike) is false, throw a TypeError exception.
         let Some(partial_object) =
@@ -1136,13 +998,7 @@ impl PlainDateTime {
         args: &[JsValue],
         context: &mut Context,
     ) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let dt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
-            })?;
+        require_internal_slot!(dt = this, Self, "PlainDateTime");
 
         let time = args
             .get_or_undefined(0)
@@ -1164,13 +1020,7 @@ impl PlainDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDateTime/withCalendar
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainDateTime.html#method.with_calendar
     fn with_calendar(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let dt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
-            })?;
+        require_internal_slot!(dt = this, Self, "PlainDateTime");
 
         let calendar = to_temporal_calendar_identifier(args.get_or_undefined(0))?;
 
@@ -1191,13 +1041,7 @@ impl PlainDateTime {
     fn add(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let temporalDate be the this value.
         // 2. Perform ? RequireInternalSlot(temporalDate, [[InitializedTemporalDate]]).
-        let object = this.as_object();
-        let dt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
-            })?;
+        require_internal_slot!(dt = this, Self, "PlainDateTime");
 
         // 3. Let duration be ? ToTemporalDuration(temporalDurationLike).
         let duration = to_temporal_duration_record(args.get_or_undefined(0), context)?;
@@ -1225,13 +1069,7 @@ impl PlainDateTime {
     fn subtract(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let temporalDate be the this value.
         // 2. Perform ? RequireInternalSlot(temporalDate, [[InitializedTemporalDate]]).
-        let object = this.as_object();
-        let dt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
-            })?;
+        require_internal_slot!(dt = this, Self, "PlainDateTime");
 
         // 3. Let duration be ? ToTemporalDuration(temporalDurationLike).
         let duration = to_temporal_duration_record(args.get_or_undefined(0), context)?;
@@ -1259,13 +1097,7 @@ impl PlainDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDateTime/until
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainDateTime.html#method.until
     fn until(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let dt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
-            })?;
+        require_internal_slot!(dt = this, Self, "PlainDateTime");
 
         let other = to_temporal_datetime(args.get_or_undefined(0), None, context)?;
 
@@ -1287,13 +1119,7 @@ impl PlainDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDateTime/since
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainDateTime.html#method.since
     fn since(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let dt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
-            })?;
+        require_internal_slot!(dt = this, Self, "PlainDateTime");
 
         let other = to_temporal_datetime(args.get_or_undefined(0), None, context)?;
 
@@ -1315,13 +1141,7 @@ impl PlainDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDateTime/round
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainDateTime.html#method.round
     fn round(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let dt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainTime object.")
-            })?;
+        require_internal_slot!(dt = this, Self, "PlainDateTime");
 
         let round_to = match args.first().map(JsValue::variant) {
             // 3. If roundTo is undefined, then
@@ -1386,13 +1206,7 @@ impl PlainDateTime {
     fn equals(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let dateTime be the this value.
         // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
-        let object = this.as_object();
-        let dt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
-            })?;
+        require_internal_slot!(dt = this, Self, "PlainDateTime");
 
         // 3. Set other to ? ToTemporalDateTime(other).
         let other = to_temporal_datetime(args.get_or_undefined(0), None, context)?;
@@ -1420,13 +1234,7 @@ impl PlainDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDateTime/with
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainDateTime.html#method.to_ixdtf_string
     fn to_string(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let dt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
-            })?;
+        require_internal_slot!(dt = this, Self, "PlainDateTime");
 
         let options = get_options_object(args.get_or_undefined(0))?;
 
@@ -1460,13 +1268,7 @@ impl PlainDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDateTime/with
     fn to_locale_string(this: &JsValue, _args: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // TODO: Update for ECMA-402 compliance
-        let object = this.as_object();
-        let dt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
-            })?;
+        require_internal_slot!(dt = this, Self, "PlainDateTime");
 
         let ixdtf = dt
             .inner
@@ -1484,13 +1286,7 @@ impl PlainDateTime {
     /// [spec]: https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.with
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDateTime/with
     fn to_json(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let dt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
-            })?;
+        require_internal_slot!(dt = this, Self, "PlainDateTime");
 
         let ixdtf = dt
             .inner
@@ -1531,13 +1327,7 @@ impl PlainDateTime {
     ) -> JsResult<JsValue> {
         // 1. Let dateTime be the this value.
         // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
-        let object = this.as_object();
-        let dt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
-            })?;
+        require_internal_slot!(dt = this, Self, "PlainDateTime");
         // 3. Let timeZone be ? ToTemporalTimeZoneIdentifier(temporalTimeZoneLike).
         let timezone = to_temporal_timezone_identifier(args.get_or_undefined(0), context)?;
         // 4. Let resolvedOptions be ? GetOptionsObject(options).
@@ -1570,13 +1360,7 @@ impl PlainDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDateTime/toPlainDate
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainDateTime.html#method.to_plain_date
     fn to_plain_date(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let dt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
-            })?;
+        require_internal_slot!(dt = this, Self, "PlainDateTime");
 
         let result = dt.inner.to_plain_date();
         create_temporal_date(result, None, context).map(Into::into)
@@ -1594,13 +1378,7 @@ impl PlainDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDateTime/toPlainTime
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainDateTime.html#method.to_plain_time
     fn to_plain_time(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let dt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
-            })?;
+        require_internal_slot!(dt = this, Self, "PlainDateTime");
 
         let result = dt.inner.to_plain_time();
         create_temporal_time(result, None, context).map(Into::into)

--- a/core/engine/src/builtins/temporal/plain_month_day/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_month_day/mod.rs
@@ -192,13 +192,7 @@ impl PlainMonthDay {
 impl PlainMonthDay {
     // Helper for retrieving internal fields
     fn get_internal_field(this: &JsValue, field: &DateTimeValues) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let month_day = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("this value must be a PlainMonthDay object.")
-            })?;
+        require_internal_slot!(month_day = this, Self, "PlainMonthDay");
         let inner = &month_day.inner;
         match field {
             DateTimeValues::Day => Ok(inner.day().into()),
@@ -219,13 +213,7 @@ impl PlainMonthDay {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainMonthDay/calendarId
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainMonthDay.html#method.calendar
     fn get_calendar_id(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let month_day = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("this value must be a PlainMonthDay object.")
-            })?;
+        require_internal_slot!(month_day = this, Self, "PlainMonthDay");
         Ok(js_string!(month_day.inner.calendar().identifier()).into())
     }
 
@@ -277,13 +265,7 @@ impl PlainMonthDay {
     fn with(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let monthDay be the this value.
         // 2. Perform ? RequireInternalSlot(monthDay, [[InitializedTemporalMonthDay]]).
-        let object = this.as_object();
-        let month_day = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("this value must be a PlainMonthDay object.")
-            })?;
+        require_internal_slot!(month_day = this, Self, "PlainMonthDay");
 
         // 3. If ? IsPartialTemporalObject(temporalMonthDayLike) is false, throw a TypeError exception.
         let Some(object) = is_partial_temporal_object(args.get_or_undefined(0), context)? else {
@@ -317,13 +299,7 @@ impl PlainMonthDay {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainMonthDay/equals
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainMonthDay.html#impl-PartialEq-for-PlainMonthDay
     fn equals(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let month_day = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("this value must be a PlainMonthDay object.")
-            })?;
+        require_internal_slot!(month_day = this, Self, "PlainMonthDay");
 
         let other =
             to_temporal_month_day(args.get_or_undefined(0), &JsValue::undefined(), context)?;
@@ -345,13 +321,7 @@ impl PlainMonthDay {
     fn to_string(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let monthDay be the this value.
         // 2. Perform ? RequireInternalSlot(monthDay, [[InitializedTemporalMonthDay]]).
-        let object = this.as_object();
-        let month_day = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("this value must be a PlainMonthDay object.")
-            })?;
+        require_internal_slot!(month_day = this, Self, "PlainMonthDay");
 
         // 3. Set options to ? NormalizeOptionsObject(options).
         let options = get_options_object(args.get_or_undefined(0))?;
@@ -380,13 +350,7 @@ impl PlainMonthDay {
         _: &mut Context,
     ) -> JsResult<JsValue> {
         // TODO: Update for ECMA-402 compliance
-        let object = this.as_object();
-        let month_day = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("this value must be a PlainMonthDay object.")
-            })?;
+        require_internal_slot!(month_day = this, Self, "PlainMonthDay");
 
         Ok(JsString::from(month_day.inner.to_string()).into())
     }
@@ -401,13 +365,7 @@ impl PlainMonthDay {
     /// [spec]: https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.tojson
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainMonthDay/toJSON
     pub(crate) fn to_json(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let month_day = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("this value must be a PlainMonthDay object.")
-            })?;
+        require_internal_slot!(month_day = this, Self, "PlainMonthDay");
 
         Ok(JsString::from(month_day.inner.to_string()).into())
     }
@@ -441,13 +399,7 @@ impl PlainMonthDay {
     fn to_plain_date(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let monthDay be the this value.
         // 2. Perform ? RequireInternalSlot(monthDay, [[InitializedTemporalMonthDay]]).
-        let object = this.as_object();
-        let month_day = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("this value must be a PlainMonthDay object.")
-            })?;
+        require_internal_slot!(month_day = this, Self, "PlainMonthDay");
 
         // 3. If item is not an Object, then
         let Some(item) = args.get_or_undefined(0).as_object() else {

--- a/core/engine/src/builtins/temporal/plain_month_day/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_month_day/mod.rs
@@ -192,8 +192,9 @@ impl PlainMonthDay {
 impl PlainMonthDay {
     // Helper for retrieving internal fields
     fn get_internal_field(this: &JsValue, field: &DateTimeValues) -> JsResult<JsValue> {
-        require_internal_slot!(month_day = this, Self, "PlainMonthDay");
-        let inner = &month_day.inner;
+        let month_day = require_internal_slot!(this, Self, "PlainMonthDay");
+        let month_day_data = month_day.borrow();
+        let inner = &month_day_data.data().inner;
         match field {
             DateTimeValues::Day => Ok(inner.day().into()),
             DateTimeValues::MonthCode => Ok(js_string!(inner.month_code().as_str()).into()),
@@ -213,8 +214,8 @@ impl PlainMonthDay {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainMonthDay/calendarId
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainMonthDay.html#method.calendar
     fn get_calendar_id(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(month_day = this, Self, "PlainMonthDay");
-        Ok(js_string!(month_day.inner.calendar().identifier()).into())
+        let month_day = require_internal_slot!(this, Self, "PlainMonthDay");
+        Ok(js_string!(month_day.borrow().data().inner.calendar().identifier()).into())
     }
 
     /// 10.3.4 get `Temporal.PlainMonthDay.prototype.day`
@@ -265,7 +266,7 @@ impl PlainMonthDay {
     fn with(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let monthDay be the this value.
         // 2. Perform ? RequireInternalSlot(monthDay, [[InitializedTemporalMonthDay]]).
-        require_internal_slot!(month_day = this, Self, "PlainMonthDay");
+        let month_day = require_internal_slot!(this, Self, "PlainMonthDay");
 
         // 3. If ? IsPartialTemporalObject(temporalMonthDayLike) is false, throw a TypeError exception.
         let Some(object) = is_partial_temporal_object(args.get_or_undefined(0), context)? else {
@@ -276,7 +277,8 @@ impl PlainMonthDay {
         // 4. Let calendar be monthDay.[[Calendar]].
         // 5. Let fields be ISODateToFields(calendar, monthDay.[[ISODate]], month-day).
         // 6. Let partialMonthDay be ? PrepareCalendarFields(calendar, temporalMonthDayLike, « year, month, month-code, day », « », partial).
-        let fields = to_calendar_fields(&object, month_day.inner.calendar(), context)?;
+        let fields =
+            to_calendar_fields(&object, month_day.borrow().data().inner.calendar(), context)?;
         // 7. Set fields to CalendarMergeFields(calendar, fields, partialMonthDay).
         // 8. Let resolvedOptions be ? GetOptionsObject(options).
         let resolved_options = get_options_object(args.get_or_undefined(1))?;
@@ -284,7 +286,11 @@ impl PlainMonthDay {
         let overflow = get_option::<Overflow>(&resolved_options, js_string!("overflow"), context)?;
         // 10. Let isoDate be ? CalendarMonthDayFromFields(calendar, fields, overflow).
         // 11. Return ! CreateTemporalMonthDay(isoDate, calendar).
-        create_temporal_month_day(month_day.inner.with(fields, overflow)?, None, context)
+        create_temporal_month_day(
+            month_day.borrow().data().inner.with(fields, overflow)?,
+            None,
+            context,
+        )
     }
 
     /// 10.3.7 `Temporal.PlainMonthDay.prototype.equals ( other )`
@@ -299,12 +305,12 @@ impl PlainMonthDay {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainMonthDay/equals
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainMonthDay.html#impl-PartialEq-for-PlainMonthDay
     fn equals(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(month_day = this, Self, "PlainMonthDay");
+        let month_day = require_internal_slot!(this, Self, "PlainMonthDay");
 
         let other =
             to_temporal_month_day(args.get_or_undefined(0), &JsValue::undefined(), context)?;
 
-        Ok((month_day.inner == other).into())
+        Ok((month_day.borrow().data().inner == other).into())
     }
 
     /// 10.3.8 `Temporal.PlainMonthDay.prototype.toString ( [ options ] )`
@@ -321,7 +327,7 @@ impl PlainMonthDay {
     fn to_string(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let monthDay be the this value.
         // 2. Perform ? RequireInternalSlot(monthDay, [[InitializedTemporalMonthDay]]).
-        require_internal_slot!(month_day = this, Self, "PlainMonthDay");
+        let month_day = require_internal_slot!(this, Self, "PlainMonthDay");
 
         // 3. Set options to ? NormalizeOptionsObject(options).
         let options = get_options_object(args.get_or_undefined(0))?;
@@ -331,7 +337,11 @@ impl PlainMonthDay {
             get_option::<DisplayCalendar>(&options, js_string!("calendarName"), context)?
                 .unwrap_or(DisplayCalendar::Auto);
 
-        let ixdtf = month_day.inner.to_ixdtf_string(show_calendar);
+        let ixdtf = month_day
+            .borrow()
+            .data()
+            .inner
+            .to_ixdtf_string(show_calendar);
         Ok(JsString::from(ixdtf).into())
     }
 
@@ -350,9 +360,9 @@ impl PlainMonthDay {
         _: &mut Context,
     ) -> JsResult<JsValue> {
         // TODO: Update for ECMA-402 compliance
-        require_internal_slot!(month_day = this, Self, "PlainMonthDay");
+        let month_day = require_internal_slot!(this, Self, "PlainMonthDay");
 
-        Ok(JsString::from(month_day.inner.to_string()).into())
+        Ok(JsString::from(month_day.borrow().data().inner.to_string()).into())
     }
 
     /// 10.3.10 `Temporal.PlainMonthDay.prototype.toJSON ( )`
@@ -365,9 +375,9 @@ impl PlainMonthDay {
     /// [spec]: https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.tojson
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainMonthDay/toJSON
     pub(crate) fn to_json(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(month_day = this, Self, "PlainMonthDay");
+        let month_day = require_internal_slot!(this, Self, "PlainMonthDay");
 
-        Ok(JsString::from(month_day.inner.to_string()).into())
+        Ok(JsString::from(month_day.borrow().data().inner.to_string()).into())
     }
 
     /// 9.3.11 `Temporal.PlainMonthDay.prototype.valueOf ( )`
@@ -399,7 +409,7 @@ impl PlainMonthDay {
     fn to_plain_date(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let monthDay be the this value.
         // 2. Perform ? RequireInternalSlot(monthDay, [[InitializedTemporalMonthDay]]).
-        require_internal_slot!(month_day = this, Self, "PlainMonthDay");
+        let month_day = require_internal_slot!(this, Self, "PlainMonthDay");
 
         // 3. If item is not an Object, then
         let Some(item) = args.get_or_undefined(0).as_object() else {
@@ -426,7 +436,11 @@ impl PlainMonthDay {
         // 7. Let mergedFields be CalendarMergeFields(calendar, fields, inputFields).
         // 8. Let isoDate be ? CalendarDateFromFields(calendar, mergedFields, constrain).
         // 9. Return ! CreateTemporalDate(isoDate, calendar).
-        let result = month_day.inner.to_plain_date(Some(fields))?;
+        let result = month_day
+            .borrow()
+            .data()
+            .inner
+            .to_plain_date(Some(fields))?;
         create_temporal_date(result, None, context).map(Into::into)
     }
 }

--- a/core/engine/src/builtins/temporal/plain_time/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_time/mod.rs
@@ -266,10 +266,10 @@ impl PlainTime {
     fn get_hour(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Let temporalTime be the this value.
         // 2. Perform ? RequireInternalSlot(temporalTime, [[InitializedTemporalTime]]).
-        require_internal_slot!(time = this, Self, "PlainTime");
+        let time = require_internal_slot!(this, Self, "PlainTime");
 
         // 3. Return 𝔽(temporalTime.[[ISOHour]]).
-        Ok(time.inner.hour().into())
+        Ok(time.borrow().data().inner.hour().into())
     }
 
     /// 4.3.4 get `Temporal.PlainTime.prototype.minute`
@@ -286,10 +286,10 @@ impl PlainTime {
     fn get_minute(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Let temporalTime be the this value.
         // 2. Perform ? RequireInternalSlot(temporalTime, [[InitializedTemporalTime]]).
-        require_internal_slot!(time = this, Self, "PlainTime");
+        let time = require_internal_slot!(this, Self, "PlainTime");
 
         // 3. Return 𝔽(temporalTime.[[ISOMinute]]).
-        Ok(time.inner.minute().into())
+        Ok(time.borrow().data().inner.minute().into())
     }
 
     /// 4.3.5 get `Temporal.PlainTime.prototype.second`
@@ -306,10 +306,10 @@ impl PlainTime {
     fn get_second(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Let temporalTime be the this value.
         // 2. Perform ? RequireInternalSlot(temporalTime, [[InitializedTemporalTime]]).
-        require_internal_slot!(time = this, Self, "PlainTime");
+        let time = require_internal_slot!(this, Self, "PlainTime");
 
         // 3. Return 𝔽(temporalTime.[[ISOSecond]]).
-        Ok(time.inner.second().into())
+        Ok(time.borrow().data().inner.second().into())
     }
 
     /// 4.3.6 get `Temporal.PlainTime.prototype.millisecond`
@@ -326,10 +326,10 @@ impl PlainTime {
     fn get_millisecond(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Let temporalTime be the this value.
         // 2. Perform ? RequireInternalSlot(temporalTime, [[InitializedTemporalTime]]).
-        require_internal_slot!(time = this, Self, "PlainTime");
+        let time = require_internal_slot!(this, Self, "PlainTime");
 
         // 3. Return 𝔽(temporalTime.[[ISOMillisecond]]).
-        Ok(time.inner.millisecond().into())
+        Ok(time.borrow().data().inner.millisecond().into())
     }
 
     /// 4.3.7 get `Temporal.PlainTime.prototype.microsecond`
@@ -346,10 +346,10 @@ impl PlainTime {
     fn get_microsecond(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Let temporalTime be the this value.
         // 2. Perform ? RequireInternalSlot(temporalTime, [[InitializedTemporalTime]]).
-        require_internal_slot!(time = this, Self, "PlainTime");
+        let time = require_internal_slot!(this, Self, "PlainTime");
 
         // 3. Return 𝔽(temporalTime.[[ISOMicrosecond]]).
-        Ok(time.inner.microsecond().into())
+        Ok(time.borrow().data().inner.microsecond().into())
     }
 
     /// 4.3.8 get `Temporal.PlainTime.prototype.nanosecond`
@@ -366,10 +366,10 @@ impl PlainTime {
     fn get_nanosecond(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Let temporalTime be the this value.
         // 2. Perform ? RequireInternalSlot(temporalTime, [[InitializedTemporalTime]]).
-        require_internal_slot!(time = this, Self, "PlainTime");
+        let time = require_internal_slot!(this, Self, "PlainTime");
 
         // 3. Return 𝔽(temporalTime.[[ISONanosecond]]).
-        Ok(time.inner.nanosecond().into())
+        Ok(time.borrow().data().inner.nanosecond().into())
     }
 }
 
@@ -432,13 +432,14 @@ impl PlainTime {
     fn add(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let temporalTime be the this value.
         // 2. Perform ? RequireInternalSlot(temporalTime, [[InitializedTemporalTime]]).
-        require_internal_slot!(time = this, Self, "PlainTime");
+        let time = require_internal_slot!(this, Self, "PlainTime");
 
         let temporal_duration_like = args.get_or_undefined(0);
         let duration = to_temporal_duration_record(temporal_duration_like, context)?;
 
         // 3. Return ? AddDurationToOrSubtractDurationFromPlainTime(add, temporalTime, temporalDurationLike).
-        create_temporal_time(time.inner.add(&duration)?, None, context).map(Into::into)
+        create_temporal_time(time.borrow().data().inner.add(&duration)?, None, context)
+            .map(Into::into)
     }
 
     /// 4.3.10 `Temporal.PlainTime.prototype.subtract ( temporalDurationLike )`
@@ -455,13 +456,18 @@ impl PlainTime {
     fn subtract(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let temporalTime be the this value.
         // 2. Perform ? RequireInternalSlot(temporalTime, [[InitializedTemporalTime]]).
-        require_internal_slot!(time = this, Self, "PlainTime");
+        let time = require_internal_slot!(this, Self, "PlainTime");
 
         let temporal_duration_like = args.get_or_undefined(0);
         let duration = to_temporal_duration_record(temporal_duration_like, context)?;
 
         // 3. Return ? AddDurationToOrSubtractDurationFromPlainTime(subtract, temporalTime, temporalDurationLike).
-        create_temporal_time(time.inner.subtract(&duration)?, None, context).map(Into::into)
+        create_temporal_time(
+            time.borrow().data().inner.subtract(&duration)?,
+            None,
+            context,
+        )
+        .map(Into::into)
     }
 
     /// 4.3.11 `Temporal.PlainTime.prototype.with ( temporalTimeLike [ , options ] )`
@@ -478,7 +484,7 @@ impl PlainTime {
     fn with(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1.Let temporalTime be the this value.
         // 2. Perform ? RequireInternalSlot(temporalTime, [[InitializedTemporalTime]]).
-        require_internal_slot!(time = this, Self, "PlainTime");
+        let time = require_internal_slot!(this, Self, "PlainTime");
 
         // 3. If ? IsPartialTemporalObject(temporalTimeLike) is false, throw a TypeError exception.
         // 4. Set options to ? GetOptionsObject(options).
@@ -498,7 +504,9 @@ impl PlainTime {
         let overflow = get_option::<Overflow>(&options, js_string!("overflow"), context)?;
 
         create_temporal_time(
-            time.inner
+            time.borrow()
+                .data()
+                .inner
                 .with(partial.as_temporal_partial_time(overflow)?, overflow)?,
             None,
             context,
@@ -518,14 +526,14 @@ impl PlainTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainTime/until
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainTime.html#method.until
     fn until(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(time = this, Self, "PlainTime");
+        let time = require_internal_slot!(this, Self, "PlainTime");
 
         let other = to_temporal_time(args.get_or_undefined(0), None, context)?;
 
         let settings =
             get_difference_settings(&get_options_object(args.get_or_undefined(1))?, context)?;
 
-        let result = time.inner.until(&other, settings)?;
+        let result = time.borrow().data().inner.until(&other, settings)?;
 
         create_temporal_duration(result, None, context).map(Into::into)
     }
@@ -542,14 +550,14 @@ impl PlainTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainTime/since
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainTime.html#method.since
     fn since(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(time = this, Self, "PlainTime");
+        let time = require_internal_slot!(this, Self, "PlainTime");
 
         let other = to_temporal_time(args.get_or_undefined(0), None, context)?;
 
         let settings =
             get_difference_settings(&get_options_object(args.get_or_undefined(1))?, context)?;
 
-        let result = time.inner.since(&other, settings)?;
+        let result = time.borrow().data().inner.since(&other, settings)?;
 
         create_temporal_duration(result, None, context).map(Into::into)
     }
@@ -568,7 +576,7 @@ impl PlainTime {
     fn round(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let temporalTime be the this value.
         // 2. Perform ? RequireInternalSlot(temporalTime, [[InitializedTemporalTime]]).
-        require_internal_slot!(time = this, Self, "PlainTime");
+        let time = require_internal_slot!(this, Self, "PlainTime");
 
         let round_to = match args.first().map(JsValue::variant) {
             // 3. If roundTo is undefined, then
@@ -621,7 +629,7 @@ impl PlainTime {
         // 11. Assert: maximum is not undefined.
         // 12. Perform ? ValidateTemporalRoundingIncrement(roundingIncrement, maximum, false).
         // 13. Let result be RoundTime(temporalTime.[[ISOHour]], temporalTime.[[ISOMinute]], temporalTime.[[ISOSecond]], temporalTime.[[ISOMillisecond]], temporalTime.[[ISOMicrosecond]], temporalTime.[[ISONanosecond]], roundingIncrement, smallestUnit, roundingMode).
-        let result = time.inner.round(options)?;
+        let result = time.borrow().data().inner.round(options)?;
 
         // 14. Return ! CreateTemporalTime(result.[[Hour]], result.[[Minute]], result.[[Second]], result.[[Millisecond]], result.[[Microsecond]], result.[[Nanosecond]]).
         create_temporal_time(result, None, context).map(Into::into)
@@ -641,7 +649,7 @@ impl PlainTime {
     fn equals(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let temporalTime be the this value.
         // 2. Perform ? RequireInternalSlot(temporalTime, [[InitializedTemporalTime]]).
-        require_internal_slot!(time = this, Self, "PlainTime");
+        let time = require_internal_slot!(this, Self, "PlainTime");
 
         // 3. Set other to ? ToTemporalTime(other).
         let other = to_temporal_time(args.get_or_undefined(0), None, context)?;
@@ -652,7 +660,7 @@ impl PlainTime {
         // 8. If temporalTime.[[ISOMicrosecond]] ≠ other.[[ISOMicrosecond]], return false.
         // 9. If temporalTime.[[ISONanosecond]] ≠ other.[[ISONanosecond]], return false.
         // 10. Return true.
-        Ok((time.inner == other).into())
+        Ok((time.borrow().data().inner == other).into())
     }
 
     /// 4.3.16 `Temporal.PlainTime.prototype.toString ( [ options ] )`
@@ -667,7 +675,7 @@ impl PlainTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainTime/toString
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainTime.html#method.to_ixdtf_string
     fn to_string(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(time = this, Self, "PlainTime");
+        let time = require_internal_slot!(this, Self, "PlainTime");
 
         let options = get_options_object(args.get_or_undefined(0))?;
 
@@ -682,7 +690,7 @@ impl PlainTime {
             smallest_unit,
         };
 
-        let ixdtf = time.inner.to_ixdtf_string(options)?;
+        let ixdtf = time.borrow().data().inner.to_ixdtf_string(options)?;
 
         Ok(JsString::from(ixdtf).into())
     }
@@ -698,9 +706,11 @@ impl PlainTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainTime/toLocaleString
     fn to_locale_string(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // TODO: Update for ECMA-402 compliance
-        require_internal_slot!(time = this, Self, "PlainTime");
+        let time = require_internal_slot!(this, Self, "PlainTime");
 
         let ixdtf = time
+            .borrow()
+            .data()
             .inner
             .to_ixdtf_string(ToStringRoundingOptions::default())?;
         Ok(JsString::from(ixdtf).into())
@@ -716,9 +726,11 @@ impl PlainTime {
     /// [spec]: https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.tojson
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainTime/toJSON
     fn to_json(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(time = this, Self, "PlainTime");
+        let time = require_internal_slot!(this, Self, "PlainTime");
 
         let ixdtf = time
+            .borrow()
+            .data()
             .inner
             .to_ixdtf_string(ToStringRoundingOptions::default())?;
         Ok(JsString::from(ixdtf).into())

--- a/core/engine/src/builtins/temporal/plain_time/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_time/mod.rs
@@ -266,13 +266,7 @@ impl PlainTime {
     fn get_hour(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Let temporalTime be the this value.
         // 2. Perform ? RequireInternalSlot(temporalTime, [[InitializedTemporalTime]]).
-        let object = this.as_object();
-        let time = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainTime object.")
-            })?;
+        require_internal_slot!(time = this, Self, "PlainTime");
 
         // 3. Return 𝔽(temporalTime.[[ISOHour]]).
         Ok(time.inner.hour().into())
@@ -292,13 +286,7 @@ impl PlainTime {
     fn get_minute(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Let temporalTime be the this value.
         // 2. Perform ? RequireInternalSlot(temporalTime, [[InitializedTemporalTime]]).
-        let object = this.as_object();
-        let time = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainTime object.")
-            })?;
+        require_internal_slot!(time = this, Self, "PlainTime");
 
         // 3. Return 𝔽(temporalTime.[[ISOMinute]]).
         Ok(time.inner.minute().into())
@@ -318,13 +306,7 @@ impl PlainTime {
     fn get_second(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Let temporalTime be the this value.
         // 2. Perform ? RequireInternalSlot(temporalTime, [[InitializedTemporalTime]]).
-        let object = this.as_object();
-        let time = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainTime object.")
-            })?;
+        require_internal_slot!(time = this, Self, "PlainTime");
 
         // 3. Return 𝔽(temporalTime.[[ISOSecond]]).
         Ok(time.inner.second().into())
@@ -344,13 +326,7 @@ impl PlainTime {
     fn get_millisecond(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Let temporalTime be the this value.
         // 2. Perform ? RequireInternalSlot(temporalTime, [[InitializedTemporalTime]]).
-        let object = this.as_object();
-        let time = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainTime object.")
-            })?;
+        require_internal_slot!(time = this, Self, "PlainTime");
 
         // 3. Return 𝔽(temporalTime.[[ISOMillisecond]]).
         Ok(time.inner.millisecond().into())
@@ -370,13 +346,7 @@ impl PlainTime {
     fn get_microsecond(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Let temporalTime be the this value.
         // 2. Perform ? RequireInternalSlot(temporalTime, [[InitializedTemporalTime]]).
-        let object = this.as_object();
-        let time = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainTime object.")
-            })?;
+        require_internal_slot!(time = this, Self, "PlainTime");
 
         // 3. Return 𝔽(temporalTime.[[ISOMicrosecond]]).
         Ok(time.inner.microsecond().into())
@@ -396,13 +366,7 @@ impl PlainTime {
     fn get_nanosecond(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Let temporalTime be the this value.
         // 2. Perform ? RequireInternalSlot(temporalTime, [[InitializedTemporalTime]]).
-        let object = this.as_object();
-        let time = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainTime object.")
-            })?;
+        require_internal_slot!(time = this, Self, "PlainTime");
 
         // 3. Return 𝔽(temporalTime.[[ISONanosecond]]).
         Ok(time.inner.nanosecond().into())
@@ -468,13 +432,7 @@ impl PlainTime {
     fn add(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let temporalTime be the this value.
         // 2. Perform ? RequireInternalSlot(temporalTime, [[InitializedTemporalTime]]).
-        let object = this.as_object();
-        let time = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainTime object.")
-            })?;
+        require_internal_slot!(time = this, Self, "PlainTime");
 
         let temporal_duration_like = args.get_or_undefined(0);
         let duration = to_temporal_duration_record(temporal_duration_like, context)?;
@@ -497,13 +455,7 @@ impl PlainTime {
     fn subtract(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let temporalTime be the this value.
         // 2. Perform ? RequireInternalSlot(temporalTime, [[InitializedTemporalTime]]).
-        let object = this.as_object();
-        let time = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainTime object.")
-            })?;
+        require_internal_slot!(time = this, Self, "PlainTime");
 
         let temporal_duration_like = args.get_or_undefined(0);
         let duration = to_temporal_duration_record(temporal_duration_like, context)?;
@@ -526,13 +478,7 @@ impl PlainTime {
     fn with(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1.Let temporalTime be the this value.
         // 2. Perform ? RequireInternalSlot(temporalTime, [[InitializedTemporalTime]]).
-        let object = this.as_object();
-        let time = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainTime object.")
-            })?;
+        require_internal_slot!(time = this, Self, "PlainTime");
 
         // 3. If ? IsPartialTemporalObject(temporalTimeLike) is false, throw a TypeError exception.
         // 4. Set options to ? GetOptionsObject(options).
@@ -572,13 +518,7 @@ impl PlainTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainTime/until
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainTime.html#method.until
     fn until(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let time = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainTime object.")
-            })?;
+        require_internal_slot!(time = this, Self, "PlainTime");
 
         let other = to_temporal_time(args.get_or_undefined(0), None, context)?;
 
@@ -602,13 +542,7 @@ impl PlainTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainTime/since
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainTime.html#method.since
     fn since(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let time = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainTime object.")
-            })?;
+        require_internal_slot!(time = this, Self, "PlainTime");
 
         let other = to_temporal_time(args.get_or_undefined(0), None, context)?;
 
@@ -634,13 +568,7 @@ impl PlainTime {
     fn round(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let temporalTime be the this value.
         // 2. Perform ? RequireInternalSlot(temporalTime, [[InitializedTemporalTime]]).
-        let object = this.as_object();
-        let time = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainTime object.")
-            })?;
+        require_internal_slot!(time = this, Self, "PlainTime");
 
         let round_to = match args.first().map(JsValue::variant) {
             // 3. If roundTo is undefined, then
@@ -713,13 +641,7 @@ impl PlainTime {
     fn equals(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let temporalTime be the this value.
         // 2. Perform ? RequireInternalSlot(temporalTime, [[InitializedTemporalTime]]).
-        let object = this.as_object();
-        let time = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainTime object.")
-            })?;
+        require_internal_slot!(time = this, Self, "PlainTime");
 
         // 3. Set other to ? ToTemporalTime(other).
         let other = to_temporal_time(args.get_or_undefined(0), None, context)?;
@@ -745,13 +667,7 @@ impl PlainTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainTime/toString
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainTime.html#method.to_ixdtf_string
     fn to_string(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let time = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainTime object.")
-            })?;
+        require_internal_slot!(time = this, Self, "PlainTime");
 
         let options = get_options_object(args.get_or_undefined(0))?;
 
@@ -782,13 +698,7 @@ impl PlainTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainTime/toLocaleString
     fn to_locale_string(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // TODO: Update for ECMA-402 compliance
-        let object = this.as_object();
-        let time = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainTime object.")
-            })?;
+        require_internal_slot!(time = this, Self, "PlainTime");
 
         let ixdtf = time
             .inner
@@ -806,13 +716,7 @@ impl PlainTime {
     /// [spec]: https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.tojson
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainTime/toJSON
     fn to_json(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let time = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainTime object.")
-            })?;
+        require_internal_slot!(time = this, Self, "PlainTime");
 
         let ixdtf = time
             .inner

--- a/core/engine/src/builtins/temporal/plain_year_month/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_year_month/mod.rs
@@ -297,8 +297,9 @@ impl PlainYearMonth {
 impl PlainYearMonth {
     // Helper for retrieving internal fields
     fn get_internal_field(this: &JsValue, field: &DateTimeValues) -> JsResult<JsValue> {
-        require_internal_slot!(year_month = this, Self, "PlainYearMonth");
-        let inner = &year_month.inner;
+        let year_month = require_internal_slot!(this, Self, "PlainYearMonth");
+        let year_month_data = year_month.borrow();
+        let inner = &year_month_data.data().inner;
         match field {
             DateTimeValues::Year => Ok(inner.year().into()),
             DateTimeValues::Month => Ok(inner.month().into()),
@@ -347,9 +348,11 @@ impl PlainYearMonth {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainYearMonth/era
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainYearMonth.html#method.era
     fn get_era(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(year_month = this, Self, "PlainYearMonth");
+        let year_month = require_internal_slot!(this, Self, "PlainYearMonth");
 
         Ok(year_month
+            .borrow()
+            .data()
             .inner
             .era()
             .map(|s| JsString::from(s.as_str()))
@@ -368,8 +371,13 @@ impl PlainYearMonth {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainYearMonth/eraYear
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainYearMonth.html#method.era_year
     fn get_era_year(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(year_month = this, Self, "PlainYearMonth");
-        Ok(year_month.inner.era_year().into_or_undefined())
+        let year_month = require_internal_slot!(this, Self, "PlainYearMonth");
+        Ok(year_month
+            .borrow()
+            .data()
+            .inner
+            .era_year()
+            .into_or_undefined())
     }
 
     /// 9.3.6 get `Temporal.PlainYearMonth.prototype.year`
@@ -429,8 +437,9 @@ impl PlainYearMonth {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainYearMonth/daysInYear
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainYearMonth.html#method.days_in_year
     fn get_days_in_year(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(year_month = this, Self, "PlainYearMonth");
-        let inner = &year_month.inner;
+        let year_month = require_internal_slot!(this, Self, "PlainYearMonth");
+        let year_month_data = year_month.borrow();
+        let inner = &year_month_data.data().inner;
         Ok(inner.days_in_year().into())
     }
 
@@ -446,8 +455,9 @@ impl PlainYearMonth {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainYearMonth/daysInMonth
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainYearMonth.html#method.days_in_month
     fn get_days_in_month(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(year_month = this, Self, "PlainYearMonth");
-        let inner = &year_month.inner;
+        let year_month = require_internal_slot!(this, Self, "PlainYearMonth");
+        let year_month_data = year_month.borrow();
+        let inner = &year_month_data.data().inner;
         Ok(inner.days_in_month().into())
     }
 
@@ -463,8 +473,9 @@ impl PlainYearMonth {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainYearMonth/monthsInYear
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainYearMonth.html#method.months_in_year
     fn get_months_in_year(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(year_month = this, Self, "PlainYearMonth");
-        let inner = &year_month.inner;
+        let year_month = require_internal_slot!(this, Self, "PlainYearMonth");
+        let year_month_data = year_month.borrow();
+        let inner = &year_month_data.data().inner;
         Ok(inner.months_in_year().into())
     }
 
@@ -480,9 +491,9 @@ impl PlainYearMonth {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainYearMonth/inLeapYear
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainYearMonth.html#method.in_leap_year
     fn get_in_leap_year(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(year_month = this, Self, "PlainYearMonth");
+        let year_month = require_internal_slot!(this, Self, "PlainYearMonth");
 
-        Ok(year_month.inner.in_leap_year().into())
+        Ok(year_month.borrow().data().inner.in_leap_year().into())
     }
 }
 
@@ -503,7 +514,7 @@ impl PlainYearMonth {
     fn with(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let yearMonth be the this value.
         // 2. Perform ? RequireInternalSlot(yearMonth, [[InitializedTemporalYearMonth]]).
-        require_internal_slot!(year_month = this, Self, "PlainYearMonth");
+        let year_month = require_internal_slot!(this, Self, "PlainYearMonth");
 
         // 3. If ? IsPartialTemporalObject(temporalYearMonthLike) is false, throw a TypeError exception.
         let Some(obj) = is_partial_temporal_object(args.get_or_undefined(0), context)? else {
@@ -515,7 +526,11 @@ impl PlainYearMonth {
         // 5. Let fields be ISODateToFields(calendar, yearMonth.[[ISODate]], year-month).
         // 6. Let partialYearMonth be ? PrepareCalendarFields(calendar, temporalYearMonthLike, « year, month, month-code », « », partial).
         // 7. Set fields to CalendarMergeFields(calendar, fields, partialYearMonth).
-        let fields = to_year_month_calendar_fields(&obj, year_month.inner.calendar(), context)?;
+        let fields = to_year_month_calendar_fields(
+            &obj,
+            year_month.borrow().data().inner.calendar(),
+            context,
+        )?;
         // NOTE: Update temporal_rs to handle this.
         if fields.is_empty() {
             return Err(JsNativeError::typ()
@@ -528,7 +543,11 @@ impl PlainYearMonth {
         let overflow = get_option::<Overflow>(&resolved_options, js_string!("overflow"), context)?
             .unwrap_or_default();
         // 10. Let isoDate be ? CalendarYearMonthFromFields(calendar, fields, overflow).
-        let result = year_month.inner.with(fields, Some(overflow))?;
+        let result = year_month
+            .borrow()
+            .data()
+            .inner
+            .with(fields, Some(overflow))?;
         // 11. Return ! CreateTemporalYearMonth(isoDate, calendar).
         create_temporal_year_month(result, None, context)
     }
@@ -581,11 +600,11 @@ impl PlainYearMonth {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainYearMonth/until
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainYearMonth.html#method.until
     fn until(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(year_month = this, Self, "PlainYearMonth");
+        let year_month = require_internal_slot!(this, Self, "PlainYearMonth");
 
         let other = to_temporal_year_month(args.get_or_undefined(0), None, context)?;
 
-        if year_month.inner.calendar() != other.calendar() {
+        if year_month.borrow().data().inner.calendar() != other.calendar() {
             return Err(JsNativeError::range()
                 .with_message("calendars are not the same.")
                 .into());
@@ -594,7 +613,7 @@ impl PlainYearMonth {
         let resolved_options = get_options_object(args.get_or_undefined(1))?;
         // TODO: Disallowed units must be rejected in `temporal_rs`.
         let settings = get_difference_settings(&resolved_options, context)?;
-        let result = year_month.inner.until(&other, settings)?;
+        let result = year_month.borrow().data().inner.until(&other, settings)?;
         create_temporal_duration(result, None, context).map(Into::into)
     }
 
@@ -610,11 +629,11 @@ impl PlainYearMonth {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainYearMonth/since
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainYearMonth.html#method.since
     fn since(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(year_month = this, Self, "PlainYearMonth");
+        let year_month = require_internal_slot!(this, Self, "PlainYearMonth");
 
         let other = to_temporal_year_month(args.get_or_undefined(0), None, context)?;
 
-        if year_month.inner.calendar() != other.calendar() {
+        if year_month.borrow().data().inner.calendar() != other.calendar() {
             return Err(JsNativeError::range()
                 .with_message("calendars are not the same.")
                 .into());
@@ -623,7 +642,7 @@ impl PlainYearMonth {
         let resolved_options = get_options_object(args.get_or_undefined(1))?;
         // TODO: Disallowed units must be rejected in `temporal_rs`.
         let settings = get_difference_settings(&resolved_options, context)?;
-        let result = year_month.inner.since(&other, settings)?;
+        let result = year_month.borrow().data().inner.since(&other, settings)?;
         create_temporal_duration(result, None, context).map(Into::into)
     }
 
@@ -639,11 +658,11 @@ impl PlainYearMonth {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainYearMonth/equals
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainYearMonth.html#impl-PartialEq-for-PlainYearMonth
     fn equals(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(year_month = this, Self, "PlainYearMonth");
+        let year_month = require_internal_slot!(this, Self, "PlainYearMonth");
 
         let other = to_temporal_year_month(args.get_or_undefined(0), None, context)?;
 
-        Ok((year_month.inner == other).into())
+        Ok((year_month.borrow().data().inner == other).into())
     }
 
     /// 9.3.19 `Temporal.PlainYearMonth.prototype.toString ( [ options ] )`
@@ -660,7 +679,7 @@ impl PlainYearMonth {
     fn to_string(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let YearMonth be the this value.
         // 2. Perform ? RequireInternalSlot(yearMonth, [[InitializedTemporalYearMonth]]).
-        require_internal_slot!(year_month = this, Self, "PlainYearMonth");
+        let year_month = require_internal_slot!(this, Self, "PlainYearMonth");
 
         // 3. Set options to ? NormalizeOptionsObject(options).
         let options = get_options_object(args.get_or_undefined(0))?;
@@ -670,7 +689,11 @@ impl PlainYearMonth {
             get_option::<DisplayCalendar>(&options, js_string!("calendarName"), context)?
                 .unwrap_or(DisplayCalendar::Auto);
 
-        let ixdtf = year_month.inner.to_ixdtf_string(show_calendar);
+        let ixdtf = year_month
+            .borrow()
+            .data()
+            .inner
+            .to_ixdtf_string(show_calendar);
         Ok(JsString::from(ixdtf).into())
     }
 
@@ -689,9 +712,9 @@ impl PlainYearMonth {
         _: &mut Context,
     ) -> JsResult<JsValue> {
         // TODO: Update for ECMA-402 compliance
-        require_internal_slot!(year_month = this, Self, "PlainYearMonth");
+        let year_month = require_internal_slot!(this, Self, "PlainYearMonth");
 
-        Ok(JsString::from(year_month.inner.to_string()).into())
+        Ok(JsString::from(year_month.borrow().data().inner.to_string()).into())
     }
 
     /// 9.3.21 `Temporal.PlainYearMonth.prototype.toJSON ( )`
@@ -704,9 +727,9 @@ impl PlainYearMonth {
     /// [spec]: https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.tojson
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainYearMonth/toJSON
     pub(crate) fn to_json(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(year_month = this, Self, "PlainYearMonth");
+        let year_month = require_internal_slot!(this, Self, "PlainYearMonth");
 
-        Ok(JsString::from(year_month.inner.to_string()).into())
+        Ok(JsString::from(year_month.borrow().data().inner.to_string()).into())
     }
 
     /// 9.3.22 `Temporal.PlainYearMonth.prototype.valueOf ( )`
@@ -738,7 +761,7 @@ impl PlainYearMonth {
     fn to_plain_date(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let yearMonth be the this value.
         // 2. Perform ? RequireInternalSlot(yearMonth, [[InitializedTemporalYearMonth]]).
-        require_internal_slot!(year_month = this, Self, "PlainYearMonth");
+        let year_month = require_internal_slot!(this, Self, "PlainYearMonth");
 
         // 3. If item is not an Object, then
         let Some(obj) = args.get_or_undefined(0).as_object() else {
@@ -764,7 +787,11 @@ impl PlainYearMonth {
 
         // 7. Let mergedFields be CalendarMergeFields(calendar, fields, inputFields).
         // 8. Let isoDate be ? CalendarDateFromFields(calendar, mergedFields, constrain).
-        let result = year_month.inner.to_plain_date(Some(fields))?;
+        let result = year_month
+            .borrow()
+            .data()
+            .inner
+            .to_plain_date(Some(fields))?;
         // 9. Return ! CreateTemporalDate(isoDate, calendar).
         create_temporal_date(result, None, context).map(Into::into)
     }

--- a/core/engine/src/builtins/temporal/plain_year_month/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_year_month/mod.rs
@@ -297,13 +297,7 @@ impl PlainYearMonth {
 impl PlainYearMonth {
     // Helper for retrieving internal fields
     fn get_internal_field(this: &JsValue, field: &DateTimeValues) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let year_month = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("this value must be a PlainYearMonth object.")
-            })?;
+        require_internal_slot!(year_month = this, Self, "PlainYearMonth");
         let inner = &year_month.inner;
         match field {
             DateTimeValues::Year => Ok(inner.year().into()),
@@ -353,13 +347,7 @@ impl PlainYearMonth {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainYearMonth/era
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainYearMonth.html#method.era
     fn get_era(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let year_month = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("this value must be a PlainYearMonth object.")
-            })?;
+        require_internal_slot!(year_month = this, Self, "PlainYearMonth");
 
         Ok(year_month
             .inner
@@ -380,13 +368,7 @@ impl PlainYearMonth {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainYearMonth/eraYear
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainYearMonth.html#method.era_year
     fn get_era_year(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let year_month = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("this value must be a PlainYearMonth object.")
-            })?;
+        require_internal_slot!(year_month = this, Self, "PlainYearMonth");
         Ok(year_month.inner.era_year().into_or_undefined())
     }
 
@@ -447,13 +429,7 @@ impl PlainYearMonth {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainYearMonth/daysInYear
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainYearMonth.html#method.days_in_year
     fn get_days_in_year(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let year_month = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("this value must be a PlainYearMonth object.")
-            })?;
+        require_internal_slot!(year_month = this, Self, "PlainYearMonth");
         let inner = &year_month.inner;
         Ok(inner.days_in_year().into())
     }
@@ -470,13 +446,7 @@ impl PlainYearMonth {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainYearMonth/daysInMonth
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainYearMonth.html#method.days_in_month
     fn get_days_in_month(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let year_month = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("this value must be a PlainYearMonth object.")
-            })?;
+        require_internal_slot!(year_month = this, Self, "PlainYearMonth");
         let inner = &year_month.inner;
         Ok(inner.days_in_month().into())
     }
@@ -493,13 +463,7 @@ impl PlainYearMonth {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainYearMonth/monthsInYear
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainYearMonth.html#method.months_in_year
     fn get_months_in_year(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let year_month = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("this value must be a PlainYearMonth object.")
-            })?;
+        require_internal_slot!(year_month = this, Self, "PlainYearMonth");
         let inner = &year_month.inner;
         Ok(inner.months_in_year().into())
     }
@@ -516,13 +480,7 @@ impl PlainYearMonth {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainYearMonth/inLeapYear
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainYearMonth.html#method.in_leap_year
     fn get_in_leap_year(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let year_month = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("this value must be a PlainYearMonth object.")
-            })?;
+        require_internal_slot!(year_month = this, Self, "PlainYearMonth");
 
         Ok(year_month.inner.in_leap_year().into())
     }
@@ -545,13 +503,7 @@ impl PlainYearMonth {
     fn with(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let yearMonth be the this value.
         // 2. Perform ? RequireInternalSlot(yearMonth, [[InitializedTemporalYearMonth]]).
-        let object = this.as_object();
-        let year_month = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("this value must be a PlainYearMonth object.")
-            })?;
+        require_internal_slot!(year_month = this, Self, "PlainYearMonth");
 
         // 3. If ? IsPartialTemporalObject(temporalYearMonthLike) is false, throw a TypeError exception.
         let Some(obj) = is_partial_temporal_object(args.get_or_undefined(0), context)? else {
@@ -629,13 +581,7 @@ impl PlainYearMonth {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainYearMonth/until
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainYearMonth.html#method.until
     fn until(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let year_month = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("this value must be a PlainYearMonth object.")
-            })?;
+        require_internal_slot!(year_month = this, Self, "PlainYearMonth");
 
         let other = to_temporal_year_month(args.get_or_undefined(0), None, context)?;
 
@@ -664,13 +610,7 @@ impl PlainYearMonth {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainYearMonth/since
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainYearMonth.html#method.since
     fn since(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let year_month = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("this value must be a PlainYearMonth object.")
-            })?;
+        require_internal_slot!(year_month = this, Self, "PlainYearMonth");
 
         let other = to_temporal_year_month(args.get_or_undefined(0), None, context)?;
 
@@ -699,13 +639,7 @@ impl PlainYearMonth {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainYearMonth/equals
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainYearMonth.html#impl-PartialEq-for-PlainYearMonth
     fn equals(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let year_month = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("this value must be a PlainYearMonth object.")
-            })?;
+        require_internal_slot!(year_month = this, Self, "PlainYearMonth");
 
         let other = to_temporal_year_month(args.get_or_undefined(0), None, context)?;
 
@@ -726,13 +660,7 @@ impl PlainYearMonth {
     fn to_string(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let YearMonth be the this value.
         // 2. Perform ? RequireInternalSlot(yearMonth, [[InitializedTemporalYearMonth]]).
-        let object = this.as_object();
-        let year_month = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("this value must be a PlainYearMonth object.")
-            })?;
+        require_internal_slot!(year_month = this, Self, "PlainYearMonth");
 
         // 3. Set options to ? NormalizeOptionsObject(options).
         let options = get_options_object(args.get_or_undefined(0))?;
@@ -761,13 +689,7 @@ impl PlainYearMonth {
         _: &mut Context,
     ) -> JsResult<JsValue> {
         // TODO: Update for ECMA-402 compliance
-        let object = this.as_object();
-        let year_month = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("this value must be a PlainYearMonth object.")
-            })?;
+        require_internal_slot!(year_month = this, Self, "PlainYearMonth");
 
         Ok(JsString::from(year_month.inner.to_string()).into())
     }
@@ -782,13 +704,7 @@ impl PlainYearMonth {
     /// [spec]: https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.tojson
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainYearMonth/toJSON
     pub(crate) fn to_json(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let year_month = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("this value must be a PlainYearMonth object.")
-            })?;
+        require_internal_slot!(year_month = this, Self, "PlainYearMonth");
 
         Ok(JsString::from(year_month.inner.to_string()).into())
     }
@@ -822,13 +738,7 @@ impl PlainYearMonth {
     fn to_plain_date(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let yearMonth be the this value.
         // 2. Perform ? RequireInternalSlot(yearMonth, [[InitializedTemporalYearMonth]]).
-        let object = this.as_object();
-        let year_month = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("this value must be a PlainYearMonth object.")
-            })?;
+        require_internal_slot!(year_month = this, Self, "PlainYearMonth");
 
         // 3. If item is not an Object, then
         let Some(obj) = args.get_or_undefined(0).as_object() else {

--- a/core/engine/src/builtins/temporal/zoneddatetime/mod.rs
+++ b/core/engine/src/builtins/temporal/zoneddatetime/mod.rs
@@ -478,9 +478,9 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/calendarId
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.calendar
     fn get_calendar_id(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
+        let zdt = require_internal_slot!(this, Self, "ZonedDateTime");
 
-        Ok(JsString::from(zdt.inner.calendar().identifier()).into())
+        Ok(JsString::from(zdt.borrow().data().inner.calendar().identifier()).into())
     }
 
     /// 6.3.4 get `Temporal.ZonedDateTime.prototype.timeZoneId`
@@ -495,10 +495,12 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/timeZoneId
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.timezone
     fn get_timezone_id(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
+        let zdt = require_internal_slot!(this, Self, "ZonedDateTime");
 
         Ok(JsString::from(
-            zdt.inner
+            zdt.borrow()
+                .data()
+                .inner
                 .time_zone()
                 .identifier_with_provider(context.timezone_provider())?,
         )
@@ -517,9 +519,9 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/era
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.era
     fn get_era(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
+        let zdt = require_internal_slot!(this, Self, "ZonedDateTime");
 
-        let era = zdt.inner.era();
+        let era = zdt.borrow().data().inner.era();
         Ok(era
             .map(|tinystr| JsString::from(tinystr.cow_to_lowercase()))
             .into_or_undefined())
@@ -537,9 +539,9 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/eraYear
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.era_year
     fn get_era_year(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
+        let zdt = require_internal_slot!(this, Self, "ZonedDateTime");
 
-        Ok(zdt.inner.era_year().into_or_undefined())
+        Ok(zdt.borrow().data().inner.era_year().into_or_undefined())
     }
 
     /// 6.3.7 get `Temporal.ZonedDateTime.prototype.year`
@@ -554,9 +556,9 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/year
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.year
     fn get_year(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
+        let zdt = require_internal_slot!(this, Self, "ZonedDateTime");
 
-        Ok(zdt.inner.year().into())
+        Ok(zdt.borrow().data().inner.year().into())
     }
 
     /// 6.3.8 get `Temporal.ZonedDateTime.prototype.month`
@@ -571,9 +573,9 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/month
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.month
     fn get_month(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
+        let zdt = require_internal_slot!(this, Self, "ZonedDateTime");
 
-        Ok(zdt.inner.month().into())
+        Ok(zdt.borrow().data().inner.month().into())
     }
 
     /// 6.3.9 get `Temporal.ZonedDateTime.prototype.monthCode`
@@ -588,9 +590,9 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/monthCode
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.month_code
     fn get_month_code(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
+        let zdt = require_internal_slot!(this, Self, "ZonedDateTime");
 
-        Ok(JsString::from(zdt.inner.month_code().as_str()).into())
+        Ok(JsString::from(zdt.borrow().data().inner.month_code().as_str()).into())
     }
 
     /// 6.3.10 get `Temporal.ZonedDateTime.prototype.day`
@@ -605,9 +607,9 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/day
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.day
     fn get_day(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
+        let zdt = require_internal_slot!(this, Self, "ZonedDateTime");
 
-        Ok(zdt.inner.day().into())
+        Ok(zdt.borrow().data().inner.day().into())
     }
 
     /// 6.3.11 get `Temporal.ZonedDateTime.prototype.hour`
@@ -622,9 +624,9 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/hour
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.hour
     fn get_hour(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
+        let zdt = require_internal_slot!(this, Self, "ZonedDateTime");
 
-        Ok(zdt.inner.hour().into())
+        Ok(zdt.borrow().data().inner.hour().into())
     }
 
     /// 6.3.12 get `Temporal.ZonedDateTime.prototype.minute`
@@ -639,9 +641,9 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/minute
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.minute
     fn get_minute(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
+        let zdt = require_internal_slot!(this, Self, "ZonedDateTime");
 
-        Ok(zdt.inner.minute().into())
+        Ok(zdt.borrow().data().inner.minute().into())
     }
 
     /// 6.3.13 get `Temporal.ZonedDateTime.prototype.second`
@@ -656,9 +658,9 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/second
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.second
     fn get_second(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
+        let zdt = require_internal_slot!(this, Self, "ZonedDateTime");
 
-        Ok(zdt.inner.second().into())
+        Ok(zdt.borrow().data().inner.second().into())
     }
 
     /// 6.3.14 get `Temporal.ZonedDateTime.prototype.millisecond`
@@ -673,9 +675,9 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/millisecond
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.millisecond
     fn get_millisecond(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
+        let zdt = require_internal_slot!(this, Self, "ZonedDateTime");
 
-        Ok(zdt.inner.millisecond().into())
+        Ok(zdt.borrow().data().inner.millisecond().into())
     }
 
     /// 6.3.15 get `Temporal.ZonedDateTime.prototype.microsecond`
@@ -690,9 +692,9 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/microsecond
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.microsecond
     fn get_microsecond(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
+        let zdt = require_internal_slot!(this, Self, "ZonedDateTime");
 
-        Ok(zdt.inner.microsecond().into())
+        Ok(zdt.borrow().data().inner.microsecond().into())
     }
 
     /// 6.3.16 get `Temporal.ZonedDateTime.prototype.nanosecond`
@@ -707,9 +709,9 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/nanosecond
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.nanosecond
     fn get_nanosecond(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
+        let zdt = require_internal_slot!(this, Self, "ZonedDateTime");
 
-        Ok(zdt.inner.nanosecond().into())
+        Ok(zdt.borrow().data().inner.nanosecond().into())
     }
 
     /// 6.3.17 get `Temporal.ZonedDateTime.prototype.epochMilliseconds`
@@ -724,9 +726,9 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/epochMilliseconds
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.epoch_milliseconds
     fn get_epoch_milliseconds(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
+        let zdt = require_internal_slot!(this, Self, "ZonedDateTime");
 
-        Ok(zdt.inner.epoch_milliseconds().into())
+        Ok(zdt.borrow().data().inner.epoch_milliseconds().into())
     }
 
     /// 6.3.18 get `Temporal.ZonedDateTime.prototype.epochNanoseconds`
@@ -741,9 +743,9 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/epochNanoseconds
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.epoch_nanoseconds
     fn get_epoch_nanoseconds(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
+        let zdt = require_internal_slot!(this, Self, "ZonedDateTime");
 
-        Ok(JsBigInt::from(zdt.inner.epoch_nanoseconds().as_i128()).into())
+        Ok(JsBigInt::from(zdt.borrow().data().inner.epoch_nanoseconds().as_i128()).into())
     }
 
     /// 6.3.19 get `Temporal.ZonedDateTime.prototype.dayOfWeek`
@@ -758,9 +760,9 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/dayOfWeek
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.day_of_week
     fn get_day_of_week(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
+        let zdt = require_internal_slot!(this, Self, "ZonedDateTime");
 
-        Ok(zdt.inner.day_of_week().into())
+        Ok(zdt.borrow().data().inner.day_of_week().into())
     }
 
     /// 6.3.20 get `Temporal.ZonedDateTime.prototype.dayOfYear`
@@ -775,9 +777,9 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/dayOfYear
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.day_of_year
     fn get_day_of_year(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
+        let zdt = require_internal_slot!(this, Self, "ZonedDateTime");
 
-        Ok(zdt.inner.day_of_year().into())
+        Ok(zdt.borrow().data().inner.day_of_year().into())
     }
 
     /// 6.3.21 get `Temporal.ZonedDateTime.prototype.weekOfYear`
@@ -792,9 +794,9 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/weekOfYear
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.week_of_year
     fn get_week_of_year(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
+        let zdt = require_internal_slot!(this, Self, "ZonedDateTime");
 
-        Ok(zdt.inner.week_of_year().into_or_undefined())
+        Ok(zdt.borrow().data().inner.week_of_year().into_or_undefined())
     }
 
     /// 6.3.22 get `Temporal.ZonedDateTime.prototype.yearOfWeek`
@@ -809,9 +811,9 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/yearOfWeek
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.year_of_week
     fn get_year_of_week(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
+        let zdt = require_internal_slot!(this, Self, "ZonedDateTime");
 
-        Ok(zdt.inner.year_of_week().into_or_undefined())
+        Ok(zdt.borrow().data().inner.year_of_week().into_or_undefined())
     }
 
     /// 6.3.23 get `Temporal.ZonedDateTime.prototype.hoursInDay`
@@ -826,9 +828,11 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/hoursInDay
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.hours_in_day
     fn get_hours_in_day(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
+        let zdt = require_internal_slot!(this, Self, "ZonedDateTime");
 
         Ok(zdt
+            .borrow()
+            .data()
             .inner
             .hours_in_day_with_provider(context.timezone_provider())?
             .into())
@@ -846,9 +850,9 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/daysInWeek
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.days_in_week
     fn get_days_in_week(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
+        let zdt = require_internal_slot!(this, Self, "ZonedDateTime");
 
-        Ok(zdt.inner.days_in_week().into())
+        Ok(zdt.borrow().data().inner.days_in_week().into())
     }
 
     /// 6.3.25 get `Temporal.ZonedDateTime.prototype.daysInMonth`
@@ -863,9 +867,9 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/daysInMonth
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.days_in_month
     fn get_days_in_month(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
+        let zdt = require_internal_slot!(this, Self, "ZonedDateTime");
 
-        Ok(zdt.inner.days_in_month().into())
+        Ok(zdt.borrow().data().inner.days_in_month().into())
     }
 
     /// 6.3.26 get `Temporal.ZonedDateTime.prototype.daysInYear`
@@ -880,9 +884,9 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/daysInYear
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.days_in_year
     fn get_days_in_year(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
+        let zdt = require_internal_slot!(this, Self, "ZonedDateTime");
 
-        Ok(zdt.inner.days_in_year().into())
+        Ok(zdt.borrow().data().inner.days_in_year().into())
     }
 
     /// 6.3.27 get `Temporal.ZonedDateTime.prototype.monthsInYear`
@@ -897,9 +901,9 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/monthsInYear
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.months_in_year
     fn get_months_in_year(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
+        let zdt = require_internal_slot!(this, Self, "ZonedDateTime");
 
-        Ok(zdt.inner.months_in_year().into())
+        Ok(zdt.borrow().data().inner.months_in_year().into())
     }
 
     /// 6.3.28 get `Temporal.ZonedDateTime.prototype.inLeapYear`
@@ -914,9 +918,9 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/inLeapYear
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.in_leap_year
     fn get_in_leap_year(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
+        let zdt = require_internal_slot!(this, Self, "ZonedDateTime");
 
-        Ok(zdt.inner.in_leap_year().into())
+        Ok(zdt.borrow().data().inner.in_leap_year().into())
     }
 
     /// 6.3.29 get Temporal.ZonedDateTime.prototype.offsetNanoseconds
@@ -931,9 +935,9 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/offsetNanoseconds
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.offset_nanoseconds
     fn get_offset_nanoseconds(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
+        let zdt = require_internal_slot!(this, Self, "ZonedDateTime");
 
-        Ok(zdt.inner.offset_nanoseconds().into())
+        Ok(zdt.borrow().data().inner.offset_nanoseconds().into())
     }
 
     /// 6.3.30 get Temporal.ZonedDateTime.prototype.offset
@@ -948,9 +952,9 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/offset
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.offset
     fn get_offset(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
+        let zdt = require_internal_slot!(this, Self, "ZonedDateTime");
 
-        Ok(JsString::from(zdt.inner.offset()).into())
+        Ok(JsString::from(zdt.borrow().data().inner.offset()).into())
     }
 }
 
@@ -1010,7 +1014,7 @@ impl ZonedDateTime {
     fn with(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let zonedDateTime be the this value.
         // 2. Perform ? RequireInternalSlot(zonedDateTime, [[InitializedTemporalZonedDateTime]]).
-        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
+        let zdt = require_internal_slot!(this, Self, "ZonedDateTime");
         // 3. If ? IsPartialTemporalObject(temporalZonedDateTimeLike) is false, throw a TypeError exception.
         let Some(obj) = is_partial_temporal_object(args.get_or_undefined(0), context)? else {
             return Err(JsNativeError::typ()
@@ -1034,7 +1038,7 @@ impl ZonedDateTime {
         // 18. Set fields to CalendarMergeFields(calendar, fields, partialZonedDateTime).
         let (fields, _) = to_zoned_date_time_fields(
             &obj,
-            zdt.inner.calendar(),
+            zdt.borrow().data().inner.calendar(),
             ZdtFieldsType::NoTimeZone,
             context,
         )?;
@@ -1050,7 +1054,7 @@ impl ZonedDateTime {
         // 22. Let overflow be ? GetTemporalOverflowOption(resolvedOptions).
         let overflow = get_option::<Overflow>(&resolved_options, js_string!("overflow"), context)?;
 
-        let result = zdt.inner.with_with_provider(
+        let result = zdt.borrow().data().inner.with_with_provider(
             fields,
             disambiguation,
             offset,
@@ -1076,7 +1080,7 @@ impl ZonedDateTime {
         args: &[JsValue],
         context: &mut Context,
     ) -> JsResult<JsValue> {
-        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
+        let zdt = require_internal_slot!(this, Self, "ZonedDateTime");
 
         let time = args
             .get_or_undefined(0)
@@ -1084,6 +1088,8 @@ impl ZonedDateTime {
             .transpose()?;
 
         let inner = zdt
+            .borrow()
+            .data()
             .inner
             .with_plain_time_and_provider(time, context.timezone_provider())?;
         create_temporal_zoneddatetime(inner, None, context).map(Into::into)
@@ -1101,11 +1107,13 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/withTimeZone
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.with_timezone
     fn with_timezone(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
+        let zdt = require_internal_slot!(this, Self, "ZonedDateTime");
 
         let timezone = to_temporal_timezone_identifier(args.get_or_undefined(0), context)?;
 
         let inner = zdt
+            .borrow()
+            .data()
             .inner
             .with_time_zone_with_provider(timezone, context.timezone_provider())?;
         create_temporal_zoneddatetime(inner, None, context).map(Into::into)
@@ -1123,11 +1131,11 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/withCalendar
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.with_calendar
     fn with_calendar(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
+        let zdt = require_internal_slot!(this, Self, "ZonedDateTime");
 
         let calendar = to_temporal_calendar_identifier(args.get_or_undefined(0))?;
 
-        let inner = zdt.inner.with_calendar(calendar);
+        let inner = zdt.borrow().data().inner.with_calendar(calendar);
         create_temporal_zoneddatetime(inner, None, context).map(Into::into)
     }
 
@@ -1143,16 +1151,18 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/add
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.add
     fn add(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
+        let zdt = require_internal_slot!(this, Self, "ZonedDateTime");
 
         let duration = to_temporal_duration(args.get_or_undefined(0), context)?;
 
         let options = get_options_object(args.get_or_undefined(1))?;
         let overflow = get_option::<Overflow>(&options, js_string!("overflow"), context)?;
 
-        let result =
-            zdt.inner
-                .add_with_provider(&duration, overflow, context.timezone_provider())?;
+        let result = zdt.borrow().data().inner.add_with_provider(
+            &duration,
+            overflow,
+            context.timezone_provider(),
+        )?;
         create_temporal_zoneddatetime(result, None, context).map(Into::into)
     }
 
@@ -1168,16 +1178,18 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/subtract
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.subtract
     fn subtract(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
+        let zdt = require_internal_slot!(this, Self, "ZonedDateTime");
 
         let duration = to_temporal_duration(args.get_or_undefined(0), context)?;
 
         let options = get_options_object(args.get_or_undefined(1))?;
         let overflow = get_option::<Overflow>(&options, js_string!("overflow"), context)?;
 
-        let result =
-            zdt.inner
-                .subtract_with_provider(&duration, overflow, context.timezone_provider())?;
+        let result = zdt.borrow().data().inner.subtract_with_provider(
+            &duration,
+            overflow,
+            context.timezone_provider(),
+        )?;
         create_temporal_zoneddatetime(result, None, context).map(Into::into)
     }
 
@@ -1193,16 +1205,18 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/until
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.until
     fn until(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
+        let zdt = require_internal_slot!(this, Self, "ZonedDateTime");
 
         let other = to_temporal_zoneddatetime(args.get_or_undefined(0), None, context)?;
 
         let options = get_options_object(args.get_or_undefined(1))?;
         let settings = get_difference_settings(&options, context)?;
 
-        let result =
-            zdt.inner
-                .until_with_provider(&other, settings, context.timezone_provider())?;
+        let result = zdt.borrow().data().inner.until_with_provider(
+            &other,
+            settings,
+            context.timezone_provider(),
+        )?;
         create_temporal_duration(result, None, context).map(Into::into)
     }
 
@@ -1218,16 +1232,18 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/since
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.since
     fn since(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
+        let zdt = require_internal_slot!(this, Self, "ZonedDateTime");
 
         let other = to_temporal_zoneddatetime(args.get_or_undefined(0), None, context)?;
 
         let options = get_options_object(args.get_or_undefined(1))?;
         let settings = get_difference_settings(&options, context)?;
 
-        let result =
-            zdt.inner
-                .since_with_provider(&other, settings, context.timezone_provider())?;
+        let result = zdt.borrow().data().inner.since_with_provider(
+            &other,
+            settings,
+            context.timezone_provider(),
+        )?;
         create_temporal_duration(result, None, context).map(Into::into)
     }
 
@@ -1245,7 +1261,7 @@ impl ZonedDateTime {
     fn round(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let zonedDateTime be the this value.
         // 2. Perform ? RequireInternalSlot(zonedDateTime, [[InitializedTemporalZonedDateTime]]).
-        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
+        let zdt = require_internal_slot!(this, Self, "ZonedDateTime");
 
         let round_to = match args.first().map(JsValue::variant) {
             // 3. If roundTo is undefined, then
@@ -1299,6 +1315,8 @@ impl ZonedDateTime {
         )?;
 
         let result = zdt
+            .borrow()
+            .data()
             .inner
             .round_with_provider(options, context.timezone_provider())?;
         create_temporal_zoneddatetime(result, None, context).map(Into::into)
@@ -1316,10 +1334,12 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/equals
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#impl-PartialEq-for-ZonedDateTime
     fn equals(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
+        let zdt = require_internal_slot!(this, Self, "ZonedDateTime");
 
         let other = to_temporal_zoneddatetime(args.get_or_undefined(0), None, context)?;
         Ok(zdt
+            .borrow()
+            .data()
             .inner
             .equals_with_provider(&other, context.timezone_provider())?
             .into())
@@ -1337,7 +1357,7 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/toString
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.to_ixdtf_string
     fn to_string(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
+        let zdt = require_internal_slot!(this, Self, "ZonedDateTime");
 
         let options = get_options_object(args.get_or_undefined(0))?;
 
@@ -1360,7 +1380,7 @@ impl ZonedDateTime {
             smallest_unit,
             rounding_mode,
         };
-        let ixdtf = zdt.inner.to_ixdtf_string_with_provider(
+        let ixdtf = zdt.borrow().data().inner.to_ixdtf_string_with_provider(
             show_offset,
             display_timezone,
             show_calendar,
@@ -1382,9 +1402,9 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/toLocaleString
     fn to_locale_string(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // TODO: Update for ECMA-402 compliance
-        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
+        let zdt = require_internal_slot!(this, Self, "ZonedDateTime");
 
-        let ixdtf = zdt.inner.to_ixdtf_string_with_provider(
+        let ixdtf = zdt.borrow().data().inner.to_ixdtf_string_with_provider(
             DisplayOffset::Auto,
             DisplayTimeZone::Auto,
             DisplayCalendar::Auto,
@@ -1405,9 +1425,9 @@ impl ZonedDateTime {
     /// [spec]: https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.tojson
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/toJSON
     fn to_json(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
+        let zdt = require_internal_slot!(this, Self, "ZonedDateTime");
 
-        let ixdtf = zdt.inner.to_ixdtf_string_with_provider(
+        let ixdtf = zdt.borrow().data().inner.to_ixdtf_string_with_provider(
             DisplayOffset::Auto,
             DisplayTimeZone::Auto,
             DisplayCalendar::Auto,
@@ -1445,9 +1465,11 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/startOfDay
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.start_of_day
     fn start_of_day(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
+        let zdt = require_internal_slot!(this, Self, "ZonedDateTime");
 
         let new = zdt
+            .borrow()
+            .data()
             .inner
             .start_of_day_with_provider(context.timezone_provider())?;
         create_temporal_zoneddatetime(new, None, context).map(Into::into)
@@ -1472,7 +1494,7 @@ impl ZonedDateTime {
         // 1. Let zonedDateTime be the this value.
         // 2. Perform ? RequireInternalSlot(zonedDateTime, [[InitializedTemporalZonedDateTime]]).
         // 3. Let timeZone be zonedDateTime.[[TimeZone]].
-        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
+        let zdt = require_internal_slot!(this, Self, "ZonedDateTime");
 
         let direction_param = args.get_or_undefined(0);
         // 4. If directionParam is undefined, throw a TypeError exception.
@@ -1509,6 +1531,8 @@ impl ZonedDateTime {
 
         // Step 8-12
         let result = zdt
+            .borrow()
+            .data()
             .inner
             .get_time_zone_transition_with_provider(direction, context.timezone_provider())?;
 
@@ -1530,9 +1554,9 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/toInstant
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.to_instant
     fn to_instant(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
+        let zdt = require_internal_slot!(this, Self, "ZonedDateTime");
 
-        create_temporal_instant(zdt.inner.to_instant(), None, context)
+        create_temporal_instant(zdt.borrow().data().inner.to_instant(), None, context)
     }
 
     /// 6.3.48 `Temporal.ZonedDateTime.prototype.toPlainDate ( )`
@@ -1547,9 +1571,9 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/toPlainDate
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.to_plain_date
     fn to_plain_date(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
+        let zdt = require_internal_slot!(this, Self, "ZonedDateTime");
 
-        let inner = zdt.inner.to_plain_date();
+        let inner = zdt.borrow().data().inner.to_plain_date();
         create_temporal_date(inner, None, context).map(Into::into)
     }
 
@@ -1565,9 +1589,9 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/toPlainTime
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.to_plain_time
     fn to_plain_time(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
+        let zdt = require_internal_slot!(this, Self, "ZonedDateTime");
 
-        let new = zdt.inner.to_plain_time();
+        let new = zdt.borrow().data().inner.to_plain_time();
         create_temporal_time(new, None, context).map(Into::into)
     }
 
@@ -1587,9 +1611,9 @@ impl ZonedDateTime {
         _: &[JsValue],
         context: &mut Context,
     ) -> JsResult<JsValue> {
-        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
+        let zdt = require_internal_slot!(this, Self, "ZonedDateTime");
 
-        let new = zdt.inner.to_plain_date_time();
+        let new = zdt.borrow().data().inner.to_plain_date_time();
         create_temporal_datetime(new, None, context).map(Into::into)
     }
 }

--- a/core/engine/src/builtins/temporal/zoneddatetime/mod.rs
+++ b/core/engine/src/builtins/temporal/zoneddatetime/mod.rs
@@ -478,13 +478,7 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/calendarId
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.calendar
     fn get_calendar_id(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let zdt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
-            })?;
+        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
 
         Ok(JsString::from(zdt.inner.calendar().identifier()).into())
     }
@@ -501,13 +495,7 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/timeZoneId
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.timezone
     fn get_timezone_id(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let zdt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
-            })?;
+        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
 
         Ok(JsString::from(
             zdt.inner
@@ -529,13 +517,7 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/era
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.era
     fn get_era(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let zdt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
-            })?;
+        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
 
         let era = zdt.inner.era();
         Ok(era
@@ -555,13 +537,7 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/eraYear
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.era_year
     fn get_era_year(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let zdt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
-            })?;
+        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
 
         Ok(zdt.inner.era_year().into_or_undefined())
     }
@@ -578,13 +554,7 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/year
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.year
     fn get_year(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let zdt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
-            })?;
+        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
 
         Ok(zdt.inner.year().into())
     }
@@ -601,13 +571,7 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/month
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.month
     fn get_month(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let zdt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
-            })?;
+        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
 
         Ok(zdt.inner.month().into())
     }
@@ -624,13 +588,7 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/monthCode
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.month_code
     fn get_month_code(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let zdt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
-            })?;
+        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
 
         Ok(JsString::from(zdt.inner.month_code().as_str()).into())
     }
@@ -647,13 +605,7 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/day
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.day
     fn get_day(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let zdt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
-            })?;
+        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
 
         Ok(zdt.inner.day().into())
     }
@@ -670,13 +622,7 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/hour
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.hour
     fn get_hour(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let zdt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
-            })?;
+        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
 
         Ok(zdt.inner.hour().into())
     }
@@ -693,13 +639,7 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/minute
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.minute
     fn get_minute(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let zdt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
-            })?;
+        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
 
         Ok(zdt.inner.minute().into())
     }
@@ -716,13 +656,7 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/second
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.second
     fn get_second(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let zdt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
-            })?;
+        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
 
         Ok(zdt.inner.second().into())
     }
@@ -739,13 +673,7 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/millisecond
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.millisecond
     fn get_millisecond(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let zdt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
-            })?;
+        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
 
         Ok(zdt.inner.millisecond().into())
     }
@@ -762,13 +690,7 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/microsecond
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.microsecond
     fn get_microsecond(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let zdt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
-            })?;
+        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
 
         Ok(zdt.inner.microsecond().into())
     }
@@ -785,13 +707,7 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/nanosecond
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.nanosecond
     fn get_nanosecond(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let zdt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
-            })?;
+        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
 
         Ok(zdt.inner.nanosecond().into())
     }
@@ -808,13 +724,7 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/epochMilliseconds
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.epoch_milliseconds
     fn get_epoch_milliseconds(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let zdt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
-            })?;
+        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
 
         Ok(zdt.inner.epoch_milliseconds().into())
     }
@@ -831,13 +741,7 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/epochNanoseconds
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.epoch_nanoseconds
     fn get_epoch_nanoseconds(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let zdt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
-            })?;
+        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
 
         Ok(JsBigInt::from(zdt.inner.epoch_nanoseconds().as_i128()).into())
     }
@@ -854,13 +758,7 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/dayOfWeek
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.day_of_week
     fn get_day_of_week(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let zdt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
-            })?;
+        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
 
         Ok(zdt.inner.day_of_week().into())
     }
@@ -877,13 +775,7 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/dayOfYear
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.day_of_year
     fn get_day_of_year(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let zdt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
-            })?;
+        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
 
         Ok(zdt.inner.day_of_year().into())
     }
@@ -900,13 +792,7 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/weekOfYear
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.week_of_year
     fn get_week_of_year(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let zdt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
-            })?;
+        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
 
         Ok(zdt.inner.week_of_year().into_or_undefined())
     }
@@ -923,13 +809,7 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/yearOfWeek
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.year_of_week
     fn get_year_of_week(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let zdt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
-            })?;
+        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
 
         Ok(zdt.inner.year_of_week().into_or_undefined())
     }
@@ -946,13 +826,7 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/hoursInDay
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.hours_in_day
     fn get_hours_in_day(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let zdt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
-            })?;
+        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
 
         Ok(zdt
             .inner
@@ -972,13 +846,7 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/daysInWeek
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.days_in_week
     fn get_days_in_week(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let zdt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
-            })?;
+        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
 
         Ok(zdt.inner.days_in_week().into())
     }
@@ -995,13 +863,7 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/daysInMonth
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.days_in_month
     fn get_days_in_month(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let zdt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
-            })?;
+        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
 
         Ok(zdt.inner.days_in_month().into())
     }
@@ -1018,13 +880,7 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/daysInYear
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.days_in_year
     fn get_days_in_year(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let zdt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
-            })?;
+        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
 
         Ok(zdt.inner.days_in_year().into())
     }
@@ -1041,13 +897,7 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/monthsInYear
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.months_in_year
     fn get_months_in_year(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let zdt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
-            })?;
+        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
 
         Ok(zdt.inner.months_in_year().into())
     }
@@ -1064,13 +914,7 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/inLeapYear
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.in_leap_year
     fn get_in_leap_year(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let zdt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
-            })?;
+        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
 
         Ok(zdt.inner.in_leap_year().into())
     }
@@ -1087,13 +931,7 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/offsetNanoseconds
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.offset_nanoseconds
     fn get_offset_nanoseconds(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let zdt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
-            })?;
+        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
 
         Ok(zdt.inner.offset_nanoseconds().into())
     }
@@ -1110,13 +948,7 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/offset
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.offset
     fn get_offset(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let zdt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
-            })?;
+        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
 
         Ok(JsString::from(zdt.inner.offset()).into())
     }
@@ -1178,13 +1010,7 @@ impl ZonedDateTime {
     fn with(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let zonedDateTime be the this value.
         // 2. Perform ? RequireInternalSlot(zonedDateTime, [[InitializedTemporalZonedDateTime]]).
-        let object = this.as_object();
-        let zdt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
-            })?;
+        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
         // 3. If ? IsPartialTemporalObject(temporalZonedDateTimeLike) is false, throw a TypeError exception.
         let Some(obj) = is_partial_temporal_object(args.get_or_undefined(0), context)? else {
             return Err(JsNativeError::typ()
@@ -1250,13 +1076,7 @@ impl ZonedDateTime {
         args: &[JsValue],
         context: &mut Context,
     ) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let zdt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
-            })?;
+        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
 
         let time = args
             .get_or_undefined(0)
@@ -1281,13 +1101,7 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/withTimeZone
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.with_timezone
     fn with_timezone(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let zdt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
-            })?;
+        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
 
         let timezone = to_temporal_timezone_identifier(args.get_or_undefined(0), context)?;
 
@@ -1309,13 +1123,7 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/withCalendar
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.with_calendar
     fn with_calendar(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let zdt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
-            })?;
+        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
 
         let calendar = to_temporal_calendar_identifier(args.get_or_undefined(0))?;
 
@@ -1335,13 +1143,7 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/add
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.add
     fn add(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let zdt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
-            })?;
+        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
 
         let duration = to_temporal_duration(args.get_or_undefined(0), context)?;
 
@@ -1366,13 +1168,7 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/subtract
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.subtract
     fn subtract(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let zdt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
-            })?;
+        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
 
         let duration = to_temporal_duration(args.get_or_undefined(0), context)?;
 
@@ -1397,13 +1193,7 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/until
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.until
     fn until(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let zdt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
-            })?;
+        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
 
         let other = to_temporal_zoneddatetime(args.get_or_undefined(0), None, context)?;
 
@@ -1428,13 +1218,7 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/since
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.since
     fn since(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let zdt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
-            })?;
+        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
 
         let other = to_temporal_zoneddatetime(args.get_or_undefined(0), None, context)?;
 
@@ -1461,13 +1245,7 @@ impl ZonedDateTime {
     fn round(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let zonedDateTime be the this value.
         // 2. Perform ? RequireInternalSlot(zonedDateTime, [[InitializedTemporalZonedDateTime]]).
-        let object = this.as_object();
-        let zdt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
-            })?;
+        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
 
         let round_to = match args.first().map(JsValue::variant) {
             // 3. If roundTo is undefined, then
@@ -1538,13 +1316,7 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/equals
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#impl-PartialEq-for-ZonedDateTime
     fn equals(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let zdt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
-            })?;
+        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
 
         let other = to_temporal_zoneddatetime(args.get_or_undefined(0), None, context)?;
         Ok(zdt
@@ -1565,13 +1337,7 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/toString
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.to_ixdtf_string
     fn to_string(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let zdt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
-            })?;
+        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
 
         let options = get_options_object(args.get_or_undefined(0))?;
 
@@ -1616,13 +1382,7 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/toLocaleString
     fn to_locale_string(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // TODO: Update for ECMA-402 compliance
-        let object = this.as_object();
-        let zdt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
-            })?;
+        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
 
         let ixdtf = zdt.inner.to_ixdtf_string_with_provider(
             DisplayOffset::Auto,
@@ -1645,13 +1405,7 @@ impl ZonedDateTime {
     /// [spec]: https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.tojson
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/toJSON
     fn to_json(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let zdt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
-            })?;
+        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
 
         let ixdtf = zdt.inner.to_ixdtf_string_with_provider(
             DisplayOffset::Auto,
@@ -1691,13 +1445,7 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/startOfDay
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.start_of_day
     fn start_of_day(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let zdt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
-            })?;
+        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
 
         let new = zdt
             .inner
@@ -1724,13 +1472,7 @@ impl ZonedDateTime {
         // 1. Let zonedDateTime be the this value.
         // 2. Perform ? RequireInternalSlot(zonedDateTime, [[InitializedTemporalZonedDateTime]]).
         // 3. Let timeZone be zonedDateTime.[[TimeZone]].
-        let object = this.as_object();
-        let zdt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
-            })?;
+        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
 
         let direction_param = args.get_or_undefined(0);
         // 4. If directionParam is undefined, throw a TypeError exception.
@@ -1788,13 +1530,7 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/toInstant
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.to_instant
     fn to_instant(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let zdt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
-            })?;
+        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
 
         create_temporal_instant(zdt.inner.to_instant(), None, context)
     }
@@ -1811,13 +1547,7 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/toPlainDate
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.to_plain_date
     fn to_plain_date(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let zdt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
-            })?;
+        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
 
         let inner = zdt.inner.to_plain_date();
         create_temporal_date(inner, None, context).map(Into::into)
@@ -1835,13 +1565,7 @@ impl ZonedDateTime {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/toPlainTime
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.ZonedDateTime.html#method.to_plain_time
     fn to_plain_time(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let zdt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
-            })?;
+        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
 
         let new = zdt.inner.to_plain_time();
         create_temporal_time(new, None, context).map(Into::into)
@@ -1863,13 +1587,7 @@ impl ZonedDateTime {
         _: &[JsValue],
         context: &mut Context,
     ) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let zdt = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
-            })?;
+        require_internal_slot!(zdt = this, Self, "ZonedDateTime");
 
         let new = zdt.inner.to_plain_date_time();
         create_temporal_datetime(new, None, context).map(Into::into)

--- a/core/engine/src/builtins/typed_array/builtin.rs
+++ b/core/engine/src/builtins/typed_array/builtin.rs
@@ -409,13 +409,7 @@ impl BuiltinTypedArray {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[TypedArrayName]]).
         // 3. Assert: O has a [[ViewedArrayBuffer]] internal slot.
-        let object = this.as_object();
-        let ta = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<TypedArray>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("`this` is not a typed array object")
-            })?;
+        require_internal_slot!(ta = this, TypedArray, "TypedArray");
 
         // 4. Let buffer be O.[[ViewedArrayBuffer]].
         // 5. Return buffer.
@@ -432,13 +426,7 @@ impl BuiltinTypedArray {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[TypedArrayName]]).
         // 3. Assert: O has a [[ViewedArrayBuffer]] internal slot.
-        let object = this.as_object();
-        let ta = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<TypedArray>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("`this` is not a typed array object")
-            })?;
+        require_internal_slot!(ta = this, TypedArray, "TypedArray");
 
         // 4. Let taRecord be MakeTypedArrayWithBufferWitnessRecord(O, seq-cst).
         let buf_len = ta
@@ -463,13 +451,7 @@ impl BuiltinTypedArray {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[TypedArrayName]]).
         // 3. Assert: O has a [[ViewedArrayBuffer]] internal slot.
-        let object = this.as_object();
-        let ta = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<TypedArray>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("Value is not a typed array object")
-            })?;
+        require_internal_slot!(ta = this, TypedArray, "TypedArray");
 
         // 4. Let taRecord be MakeTypedArrayWithBufferWitnessRecord(O, seq-cst).
         // 5. If IsTypedArrayOutOfBounds(taRecord) is true, return +0𝔽.
@@ -1327,13 +1309,7 @@ impl BuiltinTypedArray {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[TypedArrayName]]).
         // 3. Assert: O has [[ViewedArrayBuffer]] and [[ArrayLength]] internal slots.
-        let object = this.as_object();
-        let ta = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<TypedArray>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("`this` is not a typed array object")
-            })?;
+        require_internal_slot!(ta = this, TypedArray, "TypedArray");
 
         // 4. Let taRecord be MakeTypedArrayWithBufferWitnessRecord(O, seq-cst).
         // 5. If IsTypedArrayOutOfBounds(taRecord) is true, return +0𝔽.

--- a/core/engine/src/builtins/typed_array/builtin.rs
+++ b/core/engine/src/builtins/typed_array/builtin.rs
@@ -409,11 +409,11 @@ impl BuiltinTypedArray {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[TypedArrayName]]).
         // 3. Assert: O has a [[ViewedArrayBuffer]] internal slot.
-        require_internal_slot!(ta = this, TypedArray, "TypedArray");
+        let ta = require_internal_slot!(this, TypedArray, "TypedArray");
 
         // 4. Let buffer be O.[[ViewedArrayBuffer]].
         // 5. Return buffer.
-        Ok(ta.viewed_array_buffer().clone().into())
+        Ok(ta.borrow().data().viewed_array_buffer().clone().into())
     }
 
     /// `get %TypedArray%.prototype.byteLength`
@@ -426,10 +426,12 @@ impl BuiltinTypedArray {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[TypedArrayName]]).
         // 3. Assert: O has a [[ViewedArrayBuffer]] internal slot.
-        require_internal_slot!(ta = this, TypedArray, "TypedArray");
+        let ta = require_internal_slot!(this, TypedArray, "TypedArray");
 
         // 4. Let taRecord be MakeTypedArrayWithBufferWitnessRecord(O, seq-cst).
-        let buf_len = ta
+        let ta_data = ta.borrow();
+        let ta_data = ta_data.data();
+        let buf_len = ta_data
             .viewed_array_buffer()
             .as_buffer()
             .bytes(Ordering::SeqCst)
@@ -438,7 +440,7 @@ impl BuiltinTypedArray {
 
         // 5. Let size be TypedArrayByteLength(taRecord).
         // 6. Return 𝔽(size).
-        Ok(ta.byte_length(buf_len).into())
+        Ok(ta_data.byte_length(buf_len).into())
     }
 
     /// `get %TypedArray%.prototype.byteOffset`
@@ -451,23 +453,27 @@ impl BuiltinTypedArray {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[TypedArrayName]]).
         // 3. Assert: O has a [[ViewedArrayBuffer]] internal slot.
-        require_internal_slot!(ta = this, TypedArray, "TypedArray");
+        let ta = require_internal_slot!(this, TypedArray, "TypedArray");
 
         // 4. Let taRecord be MakeTypedArrayWithBufferWitnessRecord(O, seq-cst).
         // 5. If IsTypedArrayOutOfBounds(taRecord) is true, return +0𝔽.
-        if ta
-            .viewed_array_buffer()
-            .as_buffer()
-            .bytes(Ordering::SeqCst)
-            .filter(|s| !ta.is_out_of_bounds(s.len()))
-            .is_none()
         {
-            return Ok(0.into());
+            let ta_data = ta.borrow();
+            let ta_data = ta_data.data();
+            if ta_data
+                .viewed_array_buffer()
+                .as_buffer()
+                .bytes(Ordering::SeqCst)
+                .filter(|s| !ta_data.is_out_of_bounds(s.len()))
+                .is_none()
+            {
+                return Ok(0.into());
+            }
         }
 
         // 6. Let offset be O.[[ByteOffset]].
         // 7. Return 𝔽(offset).
-        Ok(ta.byte_offset().into())
+        Ok(ta.borrow().data().byte_offset().into())
     }
 
     /// `%TypedArray%.prototype.copyWithin ( target, start [ , end ] )`
@@ -1309,21 +1315,23 @@ impl BuiltinTypedArray {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[TypedArrayName]]).
         // 3. Assert: O has [[ViewedArrayBuffer]] and [[ArrayLength]] internal slots.
-        require_internal_slot!(ta = this, TypedArray, "TypedArray");
+        let ta = require_internal_slot!(this, TypedArray, "TypedArray");
 
         // 4. Let taRecord be MakeTypedArrayWithBufferWitnessRecord(O, seq-cst).
         // 5. If IsTypedArrayOutOfBounds(taRecord) is true, return +0𝔽.
-        let buf = ta.viewed_array_buffer().as_buffer();
+        let ta_data = ta.borrow();
+        let ta_data = ta_data.data();
+        let buf = ta_data.viewed_array_buffer().as_buffer();
         let Some(buf) = buf
             .bytes(Ordering::SeqCst)
-            .filter(|s| !ta.is_out_of_bounds(s.len()))
+            .filter(|s| !ta_data.is_out_of_bounds(s.len()))
         else {
             return Ok(0.into());
         };
 
         // 6. Let length be TypedArrayLength(taRecord).
         // 7. Return 𝔽(length).
-        Ok(ta.array_length(buf.len()).into())
+        Ok(ta.borrow().data().array_length(buf.len()).into())
     }
 
     /// `%TypedArray%.prototype.map ( callbackfn [ , thisArg ] )`

--- a/core/engine/src/builtins/weak/weak_ref.rs
+++ b/core/engine/src/builtins/weak/weak_ref.rs
@@ -108,15 +108,7 @@ impl WeakRef {
     pub(crate) fn deref(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let weakRef be the this value.
         // 2. Perform ? RequireInternalSlot(weakRef, [[WeakRefTarget]]).
-        let object = this.as_object();
-        let weak_ref = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<WeakGc<ErasedVTableObject>>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message(
-                    "WeakRef.prototype.deref: expected `this` to be a `WeakRef` object",
-                )
-            })?;
+        require_internal_slot!(weak_ref = this, WeakGc<ErasedVTableObject>, "WeakRef");
 
         // 3. Return WeakRefDeref(weakRef).
 
@@ -229,7 +221,7 @@ mod tests {
         run_test_actions([TestAction::assert_native_error(
             "WeakRef.prototype.deref.call({})",
             JsNativeErrorKind::Type,
-            "WeakRef.prototype.deref: expected `this` to be a `WeakRef` object",
+            "the this object must be a WeakRef object.",
         )]);
     }
 

--- a/core/engine/src/builtins/weak/weak_ref.rs
+++ b/core/engine/src/builtins/weak/weak_ref.rs
@@ -108,7 +108,7 @@ impl WeakRef {
     pub(crate) fn deref(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let weakRef be the this value.
         // 2. Perform ? RequireInternalSlot(weakRef, [[WeakRefTarget]]).
-        require_internal_slot!(weak_ref = this, WeakGc<ErasedVTableObject>, "WeakRef");
+        let weak_ref = require_internal_slot!(this, WeakGc<ErasedVTableObject>, "WeakRef");
 
         // 3. Return WeakRefDeref(weakRef).
 
@@ -116,7 +116,7 @@ impl WeakRef {
         // https://tc39.es/ecma262/multipage/managing-memory.html#sec-weakrefderef
         // 1. Let target be weakRef.[[WeakRefTarget]].
         // 2. If target is not empty, then
-        if let Some(object) = weak_ref.upgrade() {
+        if let Some(object) = weak_ref.borrow().data().upgrade() {
             let object = JsObject::from(object);
 
             // a. Perform AddToKeptObjects(target).

--- a/core/engine/src/builtins/weak_map/mod.rs
+++ b/core/engine/src/builtins/weak_map/mod.rs
@@ -175,14 +175,7 @@ impl WeakMap {
     ) -> JsResult<JsValue> {
         // 1. Let M be the this value.
         // 2. Perform ? RequireInternalSlot(M, [[WeakMapData]]).
-        let object = this.as_object();
-        let map = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<NativeWeakMap>)
-            .ok_or_else(|| {
-                js_error!(TypeError:
-                    "WeakMap.prototype.get: expected 'this' to be a WeakMap object")
-            })?;
+        require_internal_slot!(map = this, NativeWeakMap, "WeakMap");
 
         // 3. Let entries be M.[[WeakMapData]].
         // 4. If key is not an Object, return undefined.
@@ -217,14 +210,7 @@ impl WeakMap {
     ) -> JsResult<JsValue> {
         // 1. Let M be the this value.
         // 2. Perform ? RequireInternalSlot(M, [[WeakMapData]]).
-        let object = this.as_object();
-        let map = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<NativeWeakMap>)
-            .ok_or_else(|| {
-                js_error!(TypeError:
-                    "WeakMap.prototype.has: expected 'this' to be a WeakMap object")
-            })?;
+        require_internal_slot!(map = this, NativeWeakMap, "WeakMap");
 
         // 3. Let entries be M.[[WeakMapData]].
         // 4. If key is not an Object, return false.

--- a/core/engine/src/builtins/weak_map/mod.rs
+++ b/core/engine/src/builtins/weak_map/mod.rs
@@ -175,7 +175,7 @@ impl WeakMap {
     ) -> JsResult<JsValue> {
         // 1. Let M be the this value.
         // 2. Perform ? RequireInternalSlot(M, [[WeakMapData]]).
-        require_internal_slot!(map = this, NativeWeakMap, "WeakMap");
+        let map = require_internal_slot!(this, NativeWeakMap, "WeakMap");
 
         // 3. Let entries be M.[[WeakMapData]].
         // 4. If key is not an Object, return undefined.
@@ -186,7 +186,7 @@ impl WeakMap {
         // 5. For each Record { [[Key]], [[Value]] } p of entries, do
         // a. If p.[[Key]] is not empty and SameValue(p.[[Key]], key) is true, return p.[[Value]].
         // 6. Return undefined.
-        if let Some(entry) = map.get(key.inner())
+        if let Some(entry) = map.borrow().data().get(key.inner())
             && let Some(val) = entry.value()
         {
             Ok(val.clone())
@@ -210,7 +210,7 @@ impl WeakMap {
     ) -> JsResult<JsValue> {
         // 1. Let M be the this value.
         // 2. Perform ? RequireInternalSlot(M, [[WeakMapData]]).
-        require_internal_slot!(map = this, NativeWeakMap, "WeakMap");
+        let map = require_internal_slot!(this, NativeWeakMap, "WeakMap");
 
         // 3. Let entries be M.[[WeakMapData]].
         // 4. If key is not an Object, return false.
@@ -221,7 +221,7 @@ impl WeakMap {
         // 5. For each Record { [[Key]], [[Value]] } p of entries, do
         // a. If p.[[Key]] is not empty and SameValue(p.[[Key]], key) is true, return true.
         // 6. Return false.
-        Ok(map.contains_key(key.inner()).into())
+        Ok(map.borrow().data().contains_key(key.inner()).into())
     }
 
     /// `WeakMap.prototype.set ( key, value )`

--- a/core/engine/src/builtins/weak_set/mod.rs
+++ b/core/engine/src/builtins/weak_set/mod.rs
@@ -232,7 +232,7 @@ impl WeakSet {
     ) -> JsResult<JsValue> {
         // 1. Let S be the this value.
         // 2. Perform ? RequireInternalSlot(S, [[WeakSetData]]).
-        require_internal_slot!(set = this, NativeWeakSet, "WeakSet");
+        let set = require_internal_slot!(this, NativeWeakSet, "WeakSet");
 
         // 3. Let entries be the List that is S.[[WeakSetData]].
         // 4. If Type(value) is not Object, return false.
@@ -244,7 +244,7 @@ impl WeakSet {
         // 5. For each element e of entries, do
         // a. If e is not empty and SameValue(e, value) is true, return true.
         // 6. Return false.
-        Ok(set.contains_key(value.inner()).into())
+        Ok(set.borrow().data().contains_key(value.inner()).into())
     }
 }
 

--- a/core/engine/src/builtins/weak_set/mod.rs
+++ b/core/engine/src/builtins/weak_set/mod.rs
@@ -232,14 +232,7 @@ impl WeakSet {
     ) -> JsResult<JsValue> {
         // 1. Let S be the this value.
         // 2. Perform ? RequireInternalSlot(S, [[WeakSetData]]).
-        let object = this.as_object();
-        let set = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<NativeWeakSet>)
-            .ok_or_else(|| {
-                js_error!(TypeError:
-                    "WeakSet.prototype.has: expected 'this' to be a WeakSet object")
-            })?;
+        require_internal_slot!(set = this, NativeWeakSet, "WeakSet");
 
         // 3. Let entries be the List that is S.[[WeakSetData]].
         // 4. If Type(value) is not Object, return false.


### PR DESCRIPTION
### Summary

This PR introduces a new `require_internal_slot!` macro to replace the repetitive 5-line [this](cci:1://file:///Users/nakshatrasharma/Desktop/boa/core/engine/src/builtins/date/tests.rs:100:0-107:1)-type-checking boilerplate found across the engine's built-in prototype methods. 

Previously, almost every prototype method (across Temporal, Date, TypedArrays, etc.) manually downcasted `this` and returned a `TypeError` if the internal slot was missing:

```rust
let object = this.as_object();
let date = object
    .as_ref()
    .and_then(JsObject::downcast_ref::<Self>)
    .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?;
```

This PR refactors those occurrences into a single, much cleaner macro call that correctly handles the necessary borrowing and lifetime scoping:

`require_internal_slot!(date = this, Date, "Date");`

### Scope of changes
While originally intended for just the Temporal built-ins, I realized this boilerplate is heavily duplicated across the entire engine. Therefore, I've broadened the scope and applied the macro to all affected built-ins, including:

- Temporal (all modules)
- Date
- ArrayBuffer & SharedArrayBuffer
- DataView
- TypedArray
- WeakRef, WeakMap, WeakSet
- Intl (Collator, Segmenter, Segments)

### Error Messages & Testing
As part of standardizing this pattern, all error messages across the engine for missing internal slots have been unified to use the generic format: TypeError: "the this object must be a {Type} object.".

All existing tests (specifically in Builtin::Date) that previously relied on custom error strings like "'this' is not a Date" have been updated to expect the new standardized message. CI tests now pass cleanly with these updates.
