### PR TITLE
fix(math): avoid overflow in Math.asinh for very large finite inputs

### DIFF
--- a/core/engine/src/builtins/math/mod.rs
+++ b/core/engine/src/builtins/math/mod.rs
@@ -20,14 +20,17 @@ use crate::{
 use super::{BuiltInBuilder, IntrinsicObject};
 
 /// For very large finite `|x|`, `f64::asinh` can overflow internally when forming `x²`.
-/// In that regime `asinh(x)` is well approximated by `sign(x) · (ln|x| + ln 2)`.
+/// In that regime `asinh(x) ≈ ln(2|x|) + 1/(4x²)`; the correction is computed as `(1/(2x))²`
+/// so we never square `x` (which would overflow).
 fn asinh_f64(n: f64) -> f64 {
     if n.is_nan() || n == 0.0 || n.is_infinite() {
         return n;
     }
     let ax = n.abs();
     if (ax * ax).is_infinite() {
-        n.signum() * (ax.ln() + std::f64::consts::LN_2)
+        let ln_2x = ax.ln() + std::f64::consts::LN_2;
+        let inv_2x = 0.5 / ax;
+        n.signum() * (ln_2x + inv_2x * inv_2x)
     } else {
         n.asinh()
     }

--- a/core/engine/src/builtins/math/mod.rs
+++ b/core/engine/src/builtins/math/mod.rs
@@ -19,6 +19,20 @@ use crate::{
 
 use super::{BuiltInBuilder, IntrinsicObject};
 
+/// For very large finite `|x|`, `f64::asinh` can overflow internally when forming `x²`.
+/// In that regime `asinh(x)` is well approximated by `sign(x) · (ln|x| + ln 2)`.
+fn asinh_f64(n: f64) -> f64 {
+    if n.is_nan() || n == 0.0 || n.is_infinite() {
+        return n;
+    }
+    let ax = n.abs();
+    if (ax * ax).is_infinite() {
+        n.signum() * (ax.ln() + std::f64::consts::LN_2)
+    } else {
+        n.asinh()
+    }
+}
+
 #[cfg(test)]
 mod tests;
 
@@ -198,14 +212,13 @@ impl Math {
     /// [spec]: https://tc39.es/ecma262/#sec-math.asinh
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/asinh
     pub(crate) fn asinh(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        Ok(args
+        let n = args
             .get_or_undefined(0)
             // 1. Let n be ? ToNumber(x).
-            .to_number(context)?
-            // 2. If n is NaN, n is +0𝔽, n is -0𝔽, n is +∞𝔽, or n is -∞𝔽, return n.
-            // 3. Return an implementation-approximated value representing the result of the inverse hyperbolic sine of ℝ(n).
-            .asinh()
-            .into())
+            .to_number(context)?;
+        // 2. If n is NaN, n is +0𝔽, n is -0𝔽, n is +∞𝔽, or n is -∞𝔽, return n.
+        // 3. Return an implementation-approximated value representing the result of the inverse hyperbolic sine of ℝ(n).
+        Ok(asinh_f64(n).into())
     }
 
     /// Get the arctangent of a number.

--- a/core/engine/src/builtins/math/tests.rs
+++ b/core/engine/src/builtins/math/tests.rs
@@ -42,6 +42,9 @@ fn asinh() {
     run_test_actions([
         TestAction::assert_eq("Math.asinh(1)", 0.881_373_587_019_543),
         TestAction::assert_eq("Math.asinh(0)", 0.0),
+        TestAction::assert_eq("Math.asinh(1e308)", 709.889_355_822_726_f64),
+        TestAction::assert_eq("Math.asinh(Number.MAX_VALUE)", 710.475_860_073_943_9_f64),
+        TestAction::assert_eq("Math.asinh(-1e308)", -709.889_355_822_726_f64),
     ]);
 }
 


### PR DESCRIPTION
Fixes #5239

<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request fixes/closes #5239.

It changes the following:

- **Cause:** For very large finite `x`, Rust’s `f64::asinh` can overflow internally (e.g. when forming `x²`), so `Math.asinh` returned `±Infinity` instead of a finite value (e.g. `1e308`, `Number.MAX_VALUE`).
- **Fix:** When `|x|²` would overflow, use the large-magnitude approximation `sign(x) · (ln(2|x|) + 1/(4x²))`, with the correction computed as `(1/(2x))²` so `x²` is never formed. Otherwise delegate to `f64::asinh`. Implemented in `core/engine/src/builtins/math/mod.rs`.
- **Tests:** Extended `asinh` tests in `core/engine/src/builtins/math/tests.rs` for `1e308`, `Number.MAX_VALUE`, and `-1e308`.

**How to verify**

- `cargo test -p boa_engine builtins::math::tests::asinh`
- `cargo run --bin boa -- -e 'console.log(Math.asinh(1e308)); console.log(Math.asinh(Number.MAX_VALUE)); console.log(Math.asinh(-1e308))'` — expect finite values (~709.89, ~710.48, ~-709.89), not `Infinity`.