### PR TITLE
Veercodeprog/feat/5144 boa class plain properties

### DIFF
--- a/core/engine/src/builtins/math/mod.rs
+++ b/core/engine/src/builtins/math/mod.rs
@@ -20,14 +20,17 @@ use crate::{
 use super::{BuiltInBuilder, IntrinsicObject};
 
 /// For very large finite `|x|`, `f64::asinh` can overflow internally when forming `x²`.
-/// In that regime `asinh(x)` is well approximated by `sign(x) · (ln|x| + ln 2)`.
+/// In that regime `asinh(x) ≈ ln(2|x|) + 1/(4x²)`; the correction is computed as `(1/(2x))²`
+/// so we never square `x` (which would overflow).
 fn asinh_f64(n: f64) -> f64 {
     if n.is_nan() || n == 0.0 || n.is_infinite() {
         return n;
     }
     let ax = n.abs();
     if (ax * ax).is_infinite() {
-        n.signum() * (ax.ln() + std::f64::consts::LN_2)
+        let ln_2x = ax.ln() + std::f64::consts::LN_2;
+        let inv_2x = 0.5 / ax;
+        n.signum() * (ln_2x + inv_2x * inv_2x)
     } else {
         n.asinh()
     }

--- a/core/engine/src/builtins/math/mod.rs
+++ b/core/engine/src/builtins/math/mod.rs
@@ -19,6 +19,20 @@ use crate::{
 
 use super::{BuiltInBuilder, IntrinsicObject};
 
+/// For very large finite `|x|`, `f64::asinh` can overflow internally when forming `x²`.
+/// In that regime `asinh(x)` is well approximated by `sign(x) · (ln|x| + ln 2)`.
+fn asinh_f64(n: f64) -> f64 {
+    if n.is_nan() || n == 0.0 || n.is_infinite() {
+        return n;
+    }
+    let ax = n.abs();
+    if (ax * ax).is_infinite() {
+        n.signum() * (ax.ln() + std::f64::consts::LN_2)
+    } else {
+        n.asinh()
+    }
+}
+
 #[cfg(test)]
 mod tests;
 
@@ -198,14 +212,13 @@ impl Math {
     /// [spec]: https://tc39.es/ecma262/#sec-math.asinh
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/asinh
     pub(crate) fn asinh(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        Ok(args
+        let n = args
             .get_or_undefined(0)
             // 1. Let n be ? ToNumber(x).
-            .to_number(context)?
-            // 2. If n is NaN, n is +0𝔽, n is -0𝔽, n is +∞𝔽, or n is -∞𝔽, return n.
-            // 3. Return an implementation-approximated value representing the result of the inverse hyperbolic sine of ℝ(n).
-            .asinh()
-            .into())
+            .to_number(context)?;
+        // 2. If n is NaN, n is +0𝔽, n is -0𝔽, n is +∞𝔽, or n is -∞𝔽, return n.
+        // 3. Return an implementation-approximated value representing the result of the inverse hyperbolic sine of ℝ(n).
+        Ok(asinh_f64(n).into())
     }
 
     /// Get the arctangent of a number.

--- a/core/engine/src/builtins/math/tests.rs
+++ b/core/engine/src/builtins/math/tests.rs
@@ -42,6 +42,9 @@ fn asinh() {
     run_test_actions([
         TestAction::assert_eq("Math.asinh(1)", 0.881_373_587_019_543),
         TestAction::assert_eq("Math.asinh(0)", 0.0),
+        TestAction::assert_eq("Math.asinh(1e308)", 709.889_355_822_726_f64),
+        TestAction::assert_eq("Math.asinh(Number.MAX_VALUE)", 710.475_860_073_943_9_f64),
+        TestAction::assert_eq("Math.asinh(-1e308)", -709.889_355_822_726_f64),
     ]);
 }
 

--- a/core/macros/src/class.rs
+++ b/core/macros/src/class.rs
@@ -783,10 +783,7 @@ impl VisitMut for ClassVisitor {
         // method-type related attributes.
         if (has_static_attr
             || has_method_attr
-            || !(has_getter_attr
-                || has_ctor_attr
-                || has_setter_attr
-                || has_js_init_attr))
+            || !(has_getter_attr || has_ctor_attr || has_setter_attr || has_js_init_attr))
             && let Err((span, msg)) = self.method(has_method_attr, has_static_attr, item)
         {
             self.error(span, msg);

--- a/core/macros/src/class.rs
+++ b/core/macros/src/class.rs
@@ -352,9 +352,90 @@ impl Function {
         })
     }
 
+    /// Builds the body of [`boa_engine::class::Class::object_constructor`] from a
+    /// `#[boa(js_init)]` function.
+    ///
+    /// The attributed function must have exactly three parameters:
+    /// `instance: &JsObject<Self>`, `args: &[JsValue]`, and `context: &mut Context` (paths may be
+    /// qualified). It must not take `self`. The return type must be `()`, `JsResult<()>` or
+    /// omitted (treated as `()`).
+    fn js_init(fn_: &mut ImplItemFn) -> SpannedResult<TokenStream2> {
+        if fn_.sig.asyncness.is_some() {
+            error(&fn_.sig.asyncness, "Async functions are not supported.")?;
+        }
+
+        if !fn_.sig.generics.params.is_empty() {
+            error(&fn_.sig.generics, "Generic functions are not supported.")?;
+        }
+
+        if fn_.sig.inputs.len() != 3 {
+            return error(
+                &fn_.sig.inputs,
+                "js_init must have exactly 3 parameters: \
+                 instance: &JsObject<Self>, args: &[JsValue], context: &mut Context",
+            );
+        }
+
+        for input in &fn_.sig.inputs {
+            if let FnArg::Receiver(r) = input {
+                return error(r, "js_init cannot use `self`");
+            }
+        }
+
+        let fn_name = &fn_.sig.ident;
+
+        let invoke = quote! {
+            Self:: #fn_name ( instance, args, context )
+        };
+
+        let body_tail = match &fn_.sig.output {
+            ReturnType::Default => quote! {
+                #invoke;
+                Ok(())
+            },
+            ReturnType::Type(_, ty) => {
+                if type_is_empty_tuple(ty) {
+                    quote! {
+                        #invoke;
+                        Ok(())
+                    }
+                } else if type_is_js_result(ty) {
+                    quote! {
+                        #invoke
+                    }
+                } else {
+                    return error(
+                        &fn_.sig.output,
+                        "js_init return type must be `()`, `JsResult<()>` or omitted",
+                    );
+                }
+            }
+        };
+
+        Ok(quote! {
+            #body_tail
+        })
+    }
+
     pub(crate) fn body(&self) -> &TokenStream2 {
         &self.body
     }
+}
+
+/// Returns `true` if `ty` is the unit type `()`.
+fn type_is_empty_tuple(ty: &Type) -> bool {
+    matches!(ty, Type::Tuple(t) if t.elems.is_empty())
+}
+
+/// Returns `true` if `ty` is `JsResult<...>` (any `T`).
+fn type_is_js_result(ty: &Type) -> bool {
+    let Type::Path(tp) = ty else {
+        return false;
+    };
+    tp.path
+        .segments
+        .last()
+        .is_some_and(|s| s.ident == "JsResult")
 }
 
 #[derive(Debug, Default)]
@@ -454,6 +535,9 @@ struct ClassVisitor {
     // Whether we detected a constructor while visiting.
     constructor: Option<Function>,
 
+    /// Body for `Class::object_constructor`, from at most one `#[boa(js_init)]`.
+    js_init: Option<TokenStream2>,
+
     // All static functions recorded.
     statics: Vec<Function>,
 
@@ -473,6 +557,7 @@ impl ClassVisitor {
             renaming,
             type_,
             constructor: None,
+            js_init: None,
             statics: Vec::new(),
             methods: Vec::new(),
             accessors: BTreeMap::default(),
@@ -546,6 +631,17 @@ impl ClassVisitor {
         Ok(())
     }
 
+    fn js_init(&mut self, fn_: &mut ImplItemFn) -> SpannedResult<()> {
+        if self.js_init.is_some() {
+            return error(
+                fn_,
+                "Only one #[boa(js_init)] function is allowed per #[boa_class] impl.",
+            );
+        }
+        self.js_init = Some(Function::js_init(fn_)?);
+        Ok(())
+    }
+
     /// Add an error to list of errors we are recording along the way. Errors are handled
     /// at the end of the process, so this combines all errors.
     #[allow(clippy::needless_pass_by_value)]
@@ -609,6 +705,20 @@ impl ClassVisitor {
             |c| c.body.clone(),
         );
 
+        let object_constructor_impl = if let Some(body) = &self.js_init {
+            quote! {
+                fn object_constructor(
+                    instance: &boa_engine::object::JsObject<Self>,
+                    args: &[boa_engine::JsValue],
+                    context: &mut boa_engine::Context,
+                ) -> boa_engine::JsResult<()> {
+                    #body
+                }
+            }
+        } else {
+            quote! {}
+        };
+
         quote! {
             impl boa_engine::class::Class for #class_ty {
                 const NAME: &'static str = #class_name;
@@ -621,6 +731,8 @@ impl ClassVisitor {
                 ) -> boa_engine::JsResult<Self> {
                     #constructor_body
                 }
+
+                #object_constructor_impl
 
                 fn init(builder: &mut boa_engine::class::ClassBuilder) -> boa_engine::JsResult<()> {
                     // Add all statics.
@@ -645,6 +757,7 @@ impl VisitMut for ClassVisitor {
     fn visit_impl_item_fn_mut(&mut self, item: &mut ImplItemFn) {
         // If there's a `boa` argument, parse it.
         let has_ctor_attr = take_path_attr(&mut item.attrs, "constructor");
+        let has_js_init_attr = take_path_attr(&mut item.attrs, "js_init");
         let has_getter_attr = take_path_attr(&mut item.attrs, "getter");
         let has_setter_attr = take_path_attr(&mut item.attrs, "setter");
         let has_method_attr = take_path_attr(&mut item.attrs, "method");
@@ -662,11 +775,18 @@ impl VisitMut for ClassVisitor {
             self.error(span, msg);
         }
 
+        if has_js_init_attr && let Err((span, msg)) = self.js_init(item) {
+            self.error(span, msg);
+        }
+
         // A function is a method if it has a `#[boa(method)]` attribute or has no
         // method-type related attributes.
         if (has_static_attr
             || has_method_attr
-            || !(has_getter_attr || has_ctor_attr || has_setter_attr))
+            || !(has_getter_attr
+                || has_ctor_attr
+                || has_setter_attr
+                || has_js_init_attr))
             && let Err((span, msg)) = self.method(has_method_attr, has_static_attr, item)
         {
             self.error(span, msg);

--- a/core/macros/src/lib.rs
+++ b/core/macros/src/lib.rs
@@ -76,7 +76,11 @@ pub fn embed_module_inner(input: TokenStream) -> TokenStream {
 /// 3. `#[boa(static)]` will declare a static method.
 /// 4. `#[boa(method)]` will declare a method.
 /// 5. `#[boa(constructor)]` will declare a constructor.
-/// 6. `#[boa(length = 123)]` sets the length of the function in JavaScript (ie. its
+/// 6. `#[boa(js_init)]` declares `Class::object_constructor`: run after the instance object
+///    exists to set plain JS properties on `instance` (or similar). The function must have
+///    exactly `instance: &JsObject<Self>`, `args: &[JsValue]`, and `context: &mut Context`, and
+///    return `()` or `JsResult<()>`. At most one per `impl` block.
+/// 7. `#[boa(length = 123)]` sets the length of the function in JavaScript (ie. its
 ///    number of arguments accepted).
 ///
 /// Multiple of those attributes can be added to a single method.

--- a/tests/macros/tests/class.rs
+++ b/tests/macros/tests/class.rs
@@ -2,7 +2,8 @@
 #![allow(unused_crate_dependencies)]
 
 use boa_engine::{
-    Context, Finalize, JsData, JsObject, JsString, JsValue, Source, Trace, boa_class, js_string,
+    Context, Finalize, JsArgs, JsData, JsObject, JsResult, JsString, JsValue, Source, Trace,
+    boa_class, js_string,
 };
 
 #[derive(Clone, Trace, Finalize, JsData)]
@@ -69,6 +70,39 @@ impl Animal {
             AnimalType::Dog => js_string!("woof"),
             AnimalType::Other => js_string!(r"¯\_(ツ)_/¯"),
         }
+    }
+}
+
+/// Class with `#[boa(js_init)]` setting an own data property on the JS object.
+#[derive(Clone, Trace, Finalize, JsData)]
+struct Widget {
+    id: i32,
+}
+
+#[boa_class]
+impl Widget {
+    #[boa(constructor)]
+    fn new(id: i32) -> Self {
+        Self { id }
+    }
+
+    #[boa(js_init)]
+    fn init_js_object(
+        instance: &JsObject<Self>,
+        args: &[JsValue],
+        context: &mut Context,
+    ) -> JsResult<()> {
+        let label = args.get_or_undefined(1).to_string(context)?;
+        instance
+            .clone()
+            .upcast()
+            .set(js_string!("label"), JsValue::from(label), true, context)?;
+        Ok(())
+    }
+
+    #[boa(rename = "getId")]
+    fn get_id(&self) -> i32 {
+        self.id
     }
 }
 
@@ -146,6 +180,27 @@ fn boa_class() {
             assertEq(Animal.prototype.method.length, 11, "Method.length");
             assertEq(Animal.prototype.speak.length, 0, "speak.length");
             assertEq(Animal.prototype.setAge.length, 1, "setAge.length");
+     "#,
+        ))
+        .expect("Could not evaluate script");
+}
+
+#[test]
+fn boa_class_js_init_sets_own_property() {
+    let mut context = Context::default();
+
+    context.register_global_class::<Widget>().unwrap();
+
+    context
+        .eval(Source::from_bytes(ASSERT_DECL))
+        .expect("Unreachable.");
+
+    context
+        .eval(Source::from_bytes(
+            r#"
+            let w = new Widget(7, "hello");
+            assertEq(w.getId(), 7, "native id from constructor");
+            assertEq(w.label, "hello", "own property from js_init");
      "#,
         ))
         .expect("Could not evaluate script");


### PR DESCRIPTION
# feat(macros): add `#[boa(js_init)]` support to `#[boa_class]`

Closes #5144 (partial — instance-side initialization only)

## Summary

Introduces the `#[boa(js_init)]` attribute to the `#[boa_class]` macro,
allowing embedders to hook into `object_constructor` without having to
hand-write a full `impl Class` block. This enables setting own data
properties on a freshly constructed `JsObject` instance — the first
concrete step toward the plain-property support discussed in #5144.

## Motivation

Currently, `#[boa_class]` only exposes `data_constructor` via
`#[boa(constructor)]`. If you want to set own JS properties after the
object exists (e.g. `instance.upcast().set("label", ...)`), you have to
drop out of the macro entirely and write `impl Class` manually. The
`object_constructor` hook already exists on the `Class` trait for
exactly this purpose — this PR just wires it up through the macro.

## Changes

### `core/macros/src/class.rs`
- Parse `#[boa(js_init)]` on at most one function per `#[boa_class] impl` block.
- Validate the expected shape: no `self`, no generics or `async`, exactly
  three parameters (`instance`, `args`, `context`), return type must be
  `()`, `JsResult<()>`, or omitted (normalized to `()`).
- Emit `fn object_constructor(...)` in the generated `impl Class` when a
  `js_init` function is present; otherwise fall back to the no-op trait
  default.
- Exclude `js_init`-annotated functions from method/static registration
  so they are not accidentally exposed as JS-callable methods.

### `core/macros/src/lib.rs`
- Add `#[boa(js_init)]` to the `boa_class` attribute documentation with
  a brief usage example.

### `tests/macros/tests/class.rs`
- New `Widget` class and `boa_class_js_init_sets_own_property` test:
  `#[boa(constructor)]` stores the native `id` field; `#[boa(js_init)]`
  sets an own data property `label` from a second constructor argument,
  verifying end-to-end that instance-side initialization works.

## Scope

**Covered by this PR:**
- Instance-side property initialization via the existing
  `object_constructor` trait hook.

**Out of scope / follow-up work for #5144:**
- Prototype and static property declarations
  (`#[boa(property)]` / `#[boa(static_property)]` → `ClassBuilder::property`).
- Declarative `const`-style properties, particularly where values involve
  non-`const` types such as `JsValue`.
- Unifying `data_constructor` and `object_constructor` into a single
  constructor model (if the project pursues that direction).
- Proc-macro-level type validation for `js_init` parameters — wrong types
  still produce a compile error at the forwarded `Self::…` call site.

## Testing

```bash
# Run the new macro integration test
cargo test -p boa_macros_tests --test class

# Lint check
cargo clippy -p boa_macros --all-targets -- -D warnings
