### PR TITLE
Fix IteratorClose omission in IteratorRecord (IteratorStep / IteratorStepValue)

### DIFF
--- a/core/engine/src/builtins/iterable/mod.rs
+++ b/core/engine/src/builtins/iterable/mod.rs
@@ -557,7 +557,14 @@ impl IteratorRecord {
             // 5. If done is true, then
             //     a. Set iteratorRecord.[[Done]] to true.
             //     b. Return done.
-            iter.done = result.complete(context)?;
+            let done = match result.complete(context) {
+                Ok(done) => done,
+                Err(err) => {
+                    drop(iter.close(Err(err.clone()), context));
+                    return Err(err);
+                }
+            };
+            iter.done = done;
 
             iter.last_result = result;
 
@@ -586,7 +593,14 @@ impl IteratorRecord {
             // 4. If value is a throw completion, then
             //     a. Set iteratorRecord.[[Done]] to true.
             // 5. Return ? value.
-            self.value(context).map(Some)
+            let value = match self.value(context) {
+                Ok(val) => val,
+                Err(err) => {
+                    drop(self.close(Err(err.clone()), context));
+                    return Err(err);
+                }
+            };
+            Ok(Some(value))
         }
     }
 


### PR DESCRIPTION
## Fix IteratorClose omission in IteratorRecord (IteratorStep / IteratorStepValue)

### Background

ECMA-262 requires that iterators are properly closed when an abrupt completion occurs during iteration.

Specifically:

- §7.4.6 IteratorStep
- §7.4.7 IteratorStepValue

Both require the use of **IfAbruptCloseIterator**, which ensures that the iterator’s `return` method is invoked if accessing:

- **`done` (IteratorComplete)**
- **`value` (IteratorValue)**

throws an exception.

---

### Problem

The current implementation of:

- `IteratorRecord::step`
- `IteratorRecord::step_value`

propagates errors using `?` without invoking `IteratorClose`, which can leave iterators in an unclosed state when:

- `done` getter throws
- `value` getter throws

This violates ECMAScript semantics and may lead to incorrect iterator behavior.

---

### Changes

- Replaced `?` with explicit error handling in both methods
- On abrupt completion:
  - Call `iterator.close(Err(err.clone()), context)`
  - Explicitly drop the result using `drop(...)`
  - Return the original error (preserving completion semantics)

---

### Example Scenario

```js
let closed = false;

let iter = {
  next() {
    return {
      get done() {
        throw new Error("boom");
      }
    };
  },
  return() {
    closed = true;
    return {};
  }
};

try {
  iter.next();
} catch {}

console.log(closed); // should be true