### PR TITLE
fix(temporal): align Duration toLocaleString with spec fallback and i…

### DIFF
--- a/core/engine/src/builtins/temporal/duration/mod.rs
+++ b/core/engine/src/builtins/temporal/duration/mod.rs
@@ -1115,7 +1115,15 @@ impl Duration {
         Ok(JsString::from(result).into())
     }
 
-    /// 7.3.24 `Temporal.Duration.prototype.toLocaleString ( )`
+    /// 7.3.24 `Temporal.Duration.prototype.toLocaleString ( [ locales [ , options ] ] )`
+    ///
+    /// When the implementation includes ECMA-402, this method is defined by the Intl specification
+    /// (typically via `Intl.DurationFormat`). Boa does not implement `Intl.DurationFormat` yet, so
+    /// we use the Temporal proposal **non-ECMA-402** fallback: `TemporalDurationToString(duration, auto)`
+    /// — the same string as [`Self::to_json`].
+    ///
+    /// The `locales` and `options` arguments are accepted for API compatibility but are ignored
+    /// until locale-sensitive duration formatting is implemented.
     ///
     /// More information:
     ///
@@ -1126,23 +1134,10 @@ impl Duration {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Duration/toLocaleString
     pub(crate) fn to_locale_string(
         this: &JsValue,
-        _: &[JsValue],
-        _: &mut Context,
+        _args: &[JsValue],
+        context: &mut Context,
     ) -> JsResult<JsValue> {
-        // TODO: Update for ECMA-402 compliance
-        let object = this.as_object();
-        let duration = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("this value must be a Duration object.")
-            })?;
-
-        let result = duration
-            .inner
-            .as_temporal_string(ToStringRoundingOptions::default())?;
-
-        Ok(JsString::from(result).into())
+        Self::to_json(this, &[], context)
     }
 
     /// 7.3.25 `Temporal.Duration.prototype.valueOf ( )`
@@ -1156,7 +1151,11 @@ impl Duration {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Duration/valueOf
     pub(crate) fn value_of(_this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         Err(JsNativeError::typ()
-            .with_message("`valueOf` not supported by Temporal built-ins. See 'compare', 'equals', or `toString`")
+            .with_message(
+                "Cannot convert a Temporal.Duration to a primitive value. \
+                 Use Temporal.Duration.compare() for comparison or \
+                 Temporal.Duration.prototype.toString() for a string representation.",
+            )
             .into())
     }
 }

--- a/core/engine/src/builtins/temporal/duration/tests.rs
+++ b/core/engine/src/builtins/temporal/duration/tests.rs
@@ -1,4 +1,4 @@
-use crate::{TestAction, run_test_actions};
+use crate::{JsNativeErrorKind, TestAction, run_test_actions};
 
 #[test]
 fn duration_constructor() {
@@ -69,4 +69,24 @@ fn basic() {
         TestAction::assert_eq("dur.microseconds", 0),
         TestAction::assert_eq("dur.nanoseconds", 0),
     ]);
+}
+
+#[test]
+fn duration_to_locale_string_matches_to_json_until_intl_duration_format() {
+    run_test_actions([
+        TestAction::run("let dur = Temporal.Duration.from('P1Y2M3DT4H5M6.007008009S')"),
+        TestAction::assert("dur.toLocaleString() === dur.toJSON()"),
+        TestAction::assert(
+            "dur.toLocaleString('en-US', { style: 'narrow' }) === dur.toJSON()",
+        ),
+    ]);
+}
+
+#[test]
+fn duration_value_of_throws_type_error_with_compare_hint() {
+    run_test_actions([TestAction::assert_native_error(
+        "Temporal.Duration.from('P1D').valueOf()",
+        JsNativeErrorKind::Type,
+        "Cannot convert a Temporal.Duration to a primitive value. Use Temporal.Duration.compare() for comparison or Temporal.Duration.prototype.toString() for a string representation.",
+    )]);
 }


### PR DESCRIPTION


This PR brings `Temporal.Duration.prototype.toLocaleString()` and `Temporal.Duration.prototype.valueOf()` closer to the Temporal spec.

Since Boa does not currently implement `Intl.DurationFormat`, `Duration.prototype.toLocaleString()` should follow the spec-defined fallback behavior. In practice, that means returning the same serialized output as `toJSON()`.

This change also keeps `Duration.prototype.valueOf()` as a throwing method, while updating the error message to point users to the APIs that are actually appropriate for comparison and string conversion.

## Motivation

`toLocaleString()` previously produced output equivalent to the default duration serialization, but the implementation did not clearly reflect the spec's fallback path when ECMA-402 duration formatting is unavailable.

`valueOf()` already threw as expected, but the error message was not aligned with the spec note and did not direct users toward the best alternatives.

## Changes

### `Temporal.Duration.prototype.toLocaleString()`

- Make `toLocaleString()` delegate to `toJSON()`.
- Preserve the expected API shape with `locales` and `options`, even though those arguments are currently ignored.
- Update the Rustdoc to document the current behavior and clarify that `Intl.DurationFormat` is not implemented yet.

### `Temporal.Duration.prototype.valueOf()`

- Keep the method behavior unchanged in that it always throws `TypeError`.
- Update the error message to reference:
  - `Temporal.Duration.compare()`
  - `Temporal.Duration.prototype.toString()`

## Tests

Added test coverage for the following cases in `core/engine/src/builtins/temporal/duration/tests.rs`:

- `toLocaleString()` returns the same result as `toJSON()`.
- `toLocaleString(locales, options)` still returns the same result while Intl-backed formatting is not implemented.
- `valueOf()` throws `TypeError` with the updated error message.

## Testing

```bash
cargo test -p boa_engine duration_to_locale_string_matches
cargo test -p boa_engine duration_value_of_throws

Note:
This PR does not implement localized duration formatting.

Proper locale-aware output will require Intl.DurationFormat support, along with the necessary locale data plumbing. This change only fixes the spec-defined fallback behavior used when that functionality is not available yet.