### PR TITLE
fix(intl): implement percent style for Intl.NumberFormat

### DIFF
--- a/core/engine/src/builtins/bigint/mod.rs
+++ b/core/engine/src/builtins/bigint/mod.rs
@@ -239,7 +239,7 @@ impl BigInt {
                 .map_err(|err| JsNativeError::range().with_message(err.to_string()))?;
 
             // 3. Return FormatNumeric(numberFormat, ℝ(x)).
-            Ok(js_string!(number_format.format(x).to_string()).into())
+            Ok(number_format.format_to_js_string(x).into())
         }
 
         #[cfg(not(feature = "intl"))]

--- a/core/engine/src/builtins/intl/number_format/mod.rs
+++ b/core/engine/src/builtins/intl/number_format/mod.rs
@@ -68,13 +68,34 @@ impl NumberFormat {
     /// [full]: https://tc39.es/ecma402/#sec-formatnumber
     /// [parts]: https://tc39.es/ecma402/#sec-formatnumbertoparts
     pub(crate) fn format<'a>(&'a self, value: &'a mut Decimal) -> FormattedDecimal<'a> {
-        // TODO: Missing support from ICU4X for Percent/Currency/Unit formatting.
+        // TODO: Missing support from ICU4X for Currency/Unit formatting.
         // TODO: Missing support from ICU4X for Scientific/Engineering/Compact notation.
+
+        // For percent style, multiply by 100 per the spec:
+        // https://tc39.es/ecma402/#sec-formatnumber
+        // "If the numberFormat.[[Style]] is "percent", let x be 100 × x."
+        if self.unit_options.style() == Style::Percent {
+            value.multiply_pow10(2);
+        }
 
         self.digit_options.format_fixed_decimal(value);
         value.apply_sign_display(self.sign_display);
 
         self.formatter.format(value)
+    }
+
+    /// Formats a value to a [`JsString`], including any style-specific affixes
+    /// (e.g., the percent sign for `style: "percent"`).
+    pub(crate) fn format_to_js_string(&self, value: &mut Decimal) -> JsString {
+        let formatted = self.format(value).to_string();
+
+        match self.unit_options.style() {
+            // Append the percent sign with a narrow no-break space (U+202F) for
+            // locale-neutral output. ICU4X doesn't yet provide a PercentFormatter,
+            // so this is a workaround.
+            Style::Percent => js_string!(format!("{formatted}\u{202F}%").as_str()),
+            _ => js_string!(formatted.as_str()),
+        }
     }
 }
 
@@ -512,7 +533,7 @@ impl NumberFormat {
                         let mut x = to_intl_mathematical_value(value, context)?;
 
                         // 5. Return FormatNumeric(nf, x).
-                        Ok(js_string!(nf.borrow().data().format(&mut x).to_string()).into())
+                        Ok(nf.borrow().data().format_to_js_string(&mut x).into())
                     },
                     nf_clone,
                 ),

--- a/core/engine/src/builtins/intl/number_format/tests.rs
+++ b/core/engine/src/builtins/intl/number_format/tests.rs
@@ -1,4 +1,7 @@
+use indoc::indoc;
+
 use crate::builtins::intl::number_format::RoundingIncrement;
+use crate::{TestAction, js_string, run_test_actions};
 use fixed_decimal::RoundingIncrement::*;
 
 #[test]
@@ -38,4 +41,32 @@ fn u16_to_rounding_increment_rainy_day() {
     for num in INVALID_CASES {
         assert!(RoundingIncrement::from_u16(num).is_none());
     }
+}
+
+#[cfg(feature = "intl_bundled")]
+#[test]
+fn percent_style_formats_correctly() {
+    // Test case from issue #5246: percent style should multiply by 100
+    // and append a percent sign.
+    run_test_actions([
+        TestAction::run(indoc! {"
+            var nf = new Intl.NumberFormat('en-US', { style: 'percent' });
+            var result = nf.format(0.56);
+        "}),
+        TestAction::assert_eq("result", js_string!("56\u{202F}%")),
+    ]);
+}
+
+#[cfg(feature = "intl_bundled")]
+#[test]
+fn percent_style_with_significant_digits() {
+    // Test case from issue #5246: BigInt toLocaleString with percent style
+    // and maximumSignificantDigits.
+    run_test_actions([
+        TestAction::run(indoc! {"
+            var options = { maximumSignificantDigits: 4, style: 'percent' };
+            var result = (0.8877).toLocaleString('de-DE', options);
+        "}),
+        TestAction::assert_eq("result", js_string!("88,77\u{202F}%")),
+    ]);
 }

--- a/core/engine/src/builtins/number/mod.rs
+++ b/core/engine/src/builtins/number/mod.rs
@@ -329,7 +329,7 @@ impl Number {
                 .map_err(|err| JsNativeError::range().with_message(err.to_string()))?;
 
             // 3. Return FormatNumeric(numberFormat, ! ToIntlMathematicalValue(x)).
-            Ok(js_string!(number_format.format(&mut x).to_string()).into())
+            Ok(number_format.format_to_js_string(&mut x).into())
         }
 
         #[cfg(not(feature = "intl"))]


### PR DESCRIPTION
## Summary

Closes #5246.

- Multiply input by 100 (`multiply_pow10(2)`) for `style: "percent"` per [ECMA-402 FormatNumeric](https://tc39.es/ecma402/#sec-formatnumber)
- Append percent sign to the formatted output via new `format_to_js_string()` helper
- Update all three call sites (`NumberFormat.format`, `Number.toLocaleString`, `BigInt.toLocaleString`) to use the new helper

## Known limitation

The percent sign is currently appended with a narrow no-break space (U+202F) uniformly across all locales. This is correct for most locales (e.g., French `"50 %"`, German `"50 %"`), but some locales (e.g., English) conventionally use no space (`"50%"`). The proper fix requires locale-aware percent formatting from ICU4X (see [icu4x#4483](https://github.com/unicode-org/icu4x/issues/4483)). Once `PercentFormatter` is available upstream, this workaround should be replaced.

## Test262 conformance (`test/intl402/NumberFormat`)

| Test result | main | PR | difference |
|---|---|---|---|
| Passed | 132 | 133 | +1 |
| Ignored | 0 | 0 | 0 |
| Failed | 121 | 120 | -1 |
| Panics | 0 | 0 | 0 |

Fixed tests (1):
- `test/prototype/format/percent-formatter.js` (previously Failed)

No regressions.

## Test plan

- [x] `cargo test -p boa_engine --features intl_bundled -- number_format` — all 4 tests pass
- [x] `cargo test -p boa_engine --features intl_bundled -- to_locale_string` — existing tests unaffected
- [x] `cargo clippy --all-features --all-targets` — no warnings
- [x] `cargo fmt -- --check` — clean
- [x] `boa_tester` against `test/intl402/NumberFormat` — +1 fixed, 0 broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)