### PR TITLE
fix(built-ins): modify `IsTypedArrayFixedLength` implementation to match spec

### DIFF
--- a/core/engine/src/builtins/typed_array/object.rs
+++ b/core/engine/src/builtins/typed_array/object.rs
@@ -4,7 +4,7 @@ use std::sync::atomic::Ordering;
 
 use crate::{
     Context, JsExpect, JsNativeError, JsResult, JsString, JsValue,
-    builtins::array_buffer::BufferObject,
+    builtins::array_buffer::{BufferObject, BufferRef},
     object::{
         JsData, JsObject,
         internal_methods::{
@@ -295,7 +295,14 @@ pub(crate) fn typed_array_exotic_prevent_extensions(
             .downcast_ref::<TypedArray>()
             .js_expect("must be a TypedArray")?;
 
-        ta.viewed_array_buffer().as_buffer().is_fixed_len()
+        if ta.is_auto_length() {
+            return Ok(false);
+        }
+
+        match ta.viewed_array_buffer().as_buffer() {
+            BufferRef::Buffer(buf) => !buf.is_fixed_len(),
+            _ => true
+        }
     };
 
     // 1. If IsTypedArrayFixedLength(O) is false, return false.

--- a/core/engine/src/builtins/typed_array/object.rs
+++ b/core/engine/src/builtins/typed_array/object.rs
@@ -312,8 +312,8 @@ pub(crate) fn typed_array_exotic_prevent_extensions(
 ) -> JsResult<bool> {
     let is_fixed_length = {
         let ta = obj
-        .downcast_ref::<TypedArray>()
-        .js_expect("must be a TypedArray")?;
+            .downcast_ref::<TypedArray>()
+            .js_expect("must be a TypedArray")?;
 
         ta.is_fixed_length()
     }; // Note: this block ensures that the borrow of obj is dropped

--- a/core/engine/src/builtins/typed_array/object.rs
+++ b/core/engine/src/builtins/typed_array/object.rs
@@ -300,7 +300,7 @@ pub(crate) fn typed_array_exotic_prevent_extensions(
         }
 
         match ta.viewed_array_buffer().as_buffer() {
-            BufferRef::Buffer(buf) => !buf.is_fixed_len(),
+            BufferRef::Buffer(buf) => buf.is_fixed_len(),
             BufferRef::SharedBuffer(_) => true,
         }
     };

--- a/core/engine/src/builtins/typed_array/object.rs
+++ b/core/engine/src/builtins/typed_array/object.rs
@@ -290,28 +290,39 @@ pub(crate) fn typed_array_exotic_prevent_extensions(
     obj: &JsObject,
     context: &mut Context,
 ) -> JsResult<bool> {
-    let is_fixed_length = {
-        let ta = obj
-            .downcast_ref::<TypedArray>()
-            .js_expect("must be a TypedArray")?;
-
-        if ta.is_auto_length() {
-            return Ok(false);
-        }
-
-        match ta.viewed_array_buffer().as_buffer() {
-            BufferRef::Buffer(buf) => buf.is_fixed_len(),
-            BufferRef::SharedBuffer(_) => true,
-        }
-    };
-
     // 1. If IsTypedArrayFixedLength(O) is false, return false.
-    if !is_fixed_length {
+    if !is_typed_array_fixed_length(obj)? {
         return Ok(false);
     }
 
     // 2. Return OrdinaryPreventExtensions(O).
     ordinary_prevent_extensions(obj, context)
+}
+
+/// Abstract operation `IsTypedArrayFixedLength ( O )`.
+///
+/// More information:
+///  - [ECMAScript reference][spec]
+///
+/// [spec]: https://tc39.es/ecma262/#sec-istypedarrayfixedlength
+fn is_typed_array_fixed_length(obj: &JsObject) -> JsResult<bool> {
+    let ta = obj
+        .downcast_ref::<TypedArray>()
+        .js_expect("must be a TypedArray")?;
+
+    // 1. If O.[[ArrayLength]] is auto, return false.
+    if ta.is_auto_length() {
+        return Ok(false);
+    }
+
+    // 2. Let buffer be O.[[ViewedArrayBuffer]].
+    let is_fixed_length = match ta.viewed_array_buffer().as_buffer() {
+        // 3. If IsFixedLengthArrayBuffer(buffer) is false and IsSharedArrayBuffer(buffer) is false, return false.
+        BufferRef::Buffer(buf) => buf.is_fixed_len(),
+        BufferRef::SharedBuffer(_) => true,
+    };
+
+    Ok(is_fixed_length)
 }
 
 /// `CanonicalNumericIndexString ( argument )`

--- a/core/engine/src/builtins/typed_array/object.rs
+++ b/core/engine/src/builtins/typed_array/object.rs
@@ -301,7 +301,7 @@ pub(crate) fn typed_array_exotic_prevent_extensions(
 
         match ta.viewed_array_buffer().as_buffer() {
             BufferRef::Buffer(buf) => !buf.is_fixed_len(),
-            _ => true
+            BufferRef::SharedBuffer(_) => true,
         }
     };
 

--- a/core/engine/src/builtins/typed_array/object.rs
+++ b/core/engine/src/builtins/typed_array/object.rs
@@ -279,6 +279,26 @@ impl TypedArray {
         // 4. Return true.
         Some(index)
     }
+
+    /// Abstract operation `IsTypedArrayFixedLength ( O )`.
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-istypedarrayfixedlength
+    fn is_fixed_length(&self) -> bool {
+        // 1. If O.[[ArrayLength]] is auto, return false.
+        if self.is_auto_length() {
+            return false;
+        }
+
+        // 2. Let buffer be O.[[ViewedArrayBuffer]].
+        match self.viewed_array_buffer().as_buffer() {
+            // 3. If IsFixedLengthArrayBuffer(buffer) is false and IsSharedArrayBuffer(buffer) is false, return false.
+            BufferRef::Buffer(buf) => buf.is_fixed_len(),
+            BufferRef::SharedBuffer(_) => true,
+        }
+    }
 }
 
 // Integer-Indexed Exotic Objects [[PreventExtensions]] ( O )
@@ -290,39 +310,22 @@ pub(crate) fn typed_array_exotic_prevent_extensions(
     obj: &JsObject,
     context: &mut Context,
 ) -> JsResult<bool> {
+    let is_fixed_length = {
+        let ta = obj
+        .downcast_ref::<TypedArray>()
+        .js_expect("must be a TypedArray")?;
+
+        ta.is_fixed_length()
+    }; // Note: this block ensures that the borrow of obj is dropped
+    // so it may be re-borrowed in step 3
+
     // 1. If IsTypedArrayFixedLength(O) is false, return false.
-    if !is_typed_array_fixed_length(obj)? {
+    if !is_fixed_length {
         return Ok(false);
     }
 
     // 2. Return OrdinaryPreventExtensions(O).
     ordinary_prevent_extensions(obj, context)
-}
-
-/// Abstract operation `IsTypedArrayFixedLength ( O )`.
-///
-/// More information:
-///  - [ECMAScript reference][spec]
-///
-/// [spec]: https://tc39.es/ecma262/#sec-istypedarrayfixedlength
-fn is_typed_array_fixed_length(obj: &JsObject) -> JsResult<bool> {
-    let ta = obj
-        .downcast_ref::<TypedArray>()
-        .js_expect("must be a TypedArray")?;
-
-    // 1. If O.[[ArrayLength]] is auto, return false.
-    if ta.is_auto_length() {
-        return Ok(false);
-    }
-
-    // 2. Let buffer be O.[[ViewedArrayBuffer]].
-    let is_fixed_length = match ta.viewed_array_buffer().as_buffer() {
-        // 3. If IsFixedLengthArrayBuffer(buffer) is false and IsSharedArrayBuffer(buffer) is false, return false.
-        BufferRef::Buffer(buf) => buf.is_fixed_len(),
-        BufferRef::SharedBuffer(_) => true,
-    };
-
-    Ok(is_fixed_length)
 }
 
 /// `CanonicalNumericIndexString ( argument )`

--- a/core/engine/src/builtins/typed_array/tests.rs
+++ b/core/engine/src/builtins/typed_array/tests.rs
@@ -173,5 +173,12 @@ fn typedarray_exotic_prevent_extensions() {
         TestAction::run("Object.preventExtensions(fixedLengthWithOffset);"),
         TestAction::assert("!Object.isExtensible(fixedLength)"),
         TestAction::assert("!Object.isExtensible(fixedLengthWithOffset)"),
+        TestAction::run("const rab = new ArrayBuffer(4);"),
+        TestAction::run("const fixedLength1 = new Uint8Array(rab, 0, 4);"),
+        TestAction::run("const fixedLengthWithOffset1 = new Uint8Array(rab, 2, 2);"),
+        TestAction::run("Object.preventExtensions(fixedLength1);"),
+        TestAction::run("Object.preventExtensions(fixedLengthWithOffset1);"),
+        TestAction::assert("!Object.isExtensible(fixedLength1)"),
+        TestAction::assert("!Object.isExtensible(fixedLengthWithOffset1)"),
     ]);
 }

--- a/core/engine/src/builtins/typed_array/tests.rs
+++ b/core/engine/src/builtins/typed_array/tests.rs
@@ -161,3 +161,17 @@ fn typedarray_conversion_mismatch_throws() {
         ),
     ]);
 }
+
+#[test]
+fn typedarray_exotic_prevent_extensions() {
+    // ref: https://github.com/tc39/test262/blob/main/test/staging/built-ins/Object/preventExtensions/preventExtensions-variable-length-typed-arrays.js
+    run_test_actions([
+        TestAction::run("const gsab = new SharedArrayBuffer(4, { maxByteLength: 8 });"),
+        TestAction::run("const fixedLength = new Uint8Array(gsab, 0, 4);"),
+        TestAction::run("const fixedLengthWithOffset = new Uint8Array(gsab, 2, 2);"),
+        TestAction::run("Object.preventExtensions(fixedLength);"),
+        TestAction::run("Object.preventExtensions(fixedLengthWithOffset);"),
+        TestAction::assert("!Object.isExtensible(fixedLength)"),
+        TestAction::assert("!Object.isExtensible(fixedLengthWithOffset)"),
+    ]);
+}


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request fixes/closes #5256.

As required by ecma262, `Object.preventExtensions` may be applied to typed arrays without error if the `IsTypedArrayFixedLength` is not false. Prior to this commit, this check was incorrectly implemented via `ArrayBuffer::is_fixed_len` which does not/can not include an AUTO length check. This discrepancy lies in that the requirements of a fixed-length `TypedArray` slightly differ from a fixed-length arraybuffer.

It adds and replaces the checks as specified by [`sec-istypedarrayfixedlength`](https://tc39.es/ecma262/#sec-istypedarrayfixedlength). Now, [typed_array_exotic_prevent_extensions](https://github.com/boa-dev/boa/blob/main/core/engine/src/builtins/typed_array/object.rs#L289) should
- return `Ok(false)` when the `TypedArray` is auto length or when the backing `ArrayBuffer` is resizable.
- failing the above, call `ordinary_prevent_extensions` if the backing array is a `SharedArrayBuffer`.

This PR also adds a test to ensure what the title of this issue says. In addition, test262's `test/staging/built-ins/preventExtensions` should now pass completely.