### PR TITLE
refactor: `TypedArray` uses `usize` instead of `u64` for internal properties

### DIFF
--- a/core/engine/src/builtins/array/array_iterator.rs
+++ b/core/engine/src/builtins/array/array_iterator.rs
@@ -119,7 +119,7 @@ impl ArrayIterator {
                     .into());
             };
 
-            f.array_length(buf.len())
+            f.array_length(buf.len()) as u64
         } else {
             array_iterator.array.length_of_array_like(context)?
         };

--- a/core/engine/src/builtins/atomics/mod.rs
+++ b/core/engine/src/builtins/atomics/mod.rs
@@ -686,6 +686,9 @@ fn validate_atomic_access(
 
     // 2. Let accessIndex be ? ToIndex(requestIndex).
     let access_index = request_index.to_index(context)?;
+    let access_index: usize = access_index
+        .try_into()
+        .map_err(|_| JsNativeError::range().with_message("index too large"))?;
 
     // 3. Assert: accessIndex ≥ 0.
     //    ensured by the type.
@@ -698,7 +701,7 @@ fn validate_atomic_access(
     }
 
     // 8. Return (accessIndex × elementSize) + offset.
-    let offset = ((access_index * kind.element_size()) + offset) as usize;
+    let offset = (access_index * kind.element_size()) + offset;
     Ok(AtomicAccess {
         byte_offset: offset,
         kind,

--- a/core/engine/src/builtins/typed_array/builtin.rs
+++ b/core/engine/src/builtins/typed_array/builtin.rs
@@ -1825,7 +1825,7 @@ impl BuiltinTypedArray {
         //     and srcBuffer.[[ArrayBufferData]] is targetBuffer.[[ArrayBufferData]], let
         //     sameSharedArrayBuffer be true; otherwise, let sameSharedArrayBuffer be false.
         // 19. If SameValue(srcBuffer, targetBuffer) is true or sameSharedArrayBuffer is true, then
-        let src_byte_index = if BufferObject::equals(&src_buf_obj, &target_buf_obj) {
+        let mut src_byte_index = if BufferObject::equals(&src_buf_obj, &target_buf_obj) {
             // 19a. Let srcByteLength be source.[[ByteLength]].
             // see above
 
@@ -1855,7 +1855,7 @@ impl BuiltinTypedArray {
         };
 
         // 22. Let targetByteIndex be targetOffset × targetElementSize + targetByteOffset.
-        let target_byte_index = target_offset * target_element_size + target_byte_offset;
+        let mut target_byte_index = target_offset * target_element_size + target_byte_offset;
 
         let src_buffer = src_buf_obj.as_buffer();
         let src_buffer = src_buffer
@@ -1895,9 +1895,6 @@ impl BuiltinTypedArray {
         else {
             // 23. Let limit be targetByteIndex + targetElementSize × srcLength.
             let limit = target_byte_index + target_element_size * src_length;
-
-            let mut src_byte_index = src_byte_index;
-            let mut target_byte_index = target_byte_index;
 
             // a. Repeat, while targetByteIndex < limit,
             while target_byte_index < limit {
@@ -1973,9 +1970,7 @@ impl BuiltinTypedArray {
         let src = source.to_object(context)?;
 
         // 5. Let srcLength be ? LengthOfArrayLike(src).
-        let src_length = src.length_of_array_like(context)?;
-
-        let src_length = src_length.to_usize()?; // boundary conversion
+        let src_length = src.length_of_array_like(context)?.to_usize()?; // boundary conversion
 
         // 6. If targetOffset = +∞, throw a RangeError exception.
         let target_offset = match target_offset {
@@ -1985,9 +1980,8 @@ impl BuiltinTypedArray {
                     .with_message("Target offset cannot be positive infinity")
                     .into());
             }
-        };
-
-        let target_offset = target_offset.to_usize()?; // boundary conversion
+        }
+        .to_usize()?; // boundary conversion
 
         // 7. If srcLength + targetOffset > targetLength, throw a RangeError exception.
         if src_length + target_offset > target_length {

--- a/core/engine/src/builtins/typed_array/builtin.rs
+++ b/core/engine/src/builtins/typed_array/builtin.rs
@@ -510,19 +510,22 @@ impl BuiltinTypedArray {
         // 5. If relativeTarget is -∞, let to be 0.
         // 6. Else if relativeTarget < 0, let to be max(len + relativeTarget, 0).
         // 7. Else, let to be min(relativeTarget, len).
-        let to = Array::get_relative_start(context, args.get_or_undefined(0), len)?;
+        let to =
+            Array::get_relative_start(context, args.get_or_undefined(0), len as u64)?.to_usize()?;
 
         // 8. Let relativeStart be ? ToIntegerOrInfinity(start).
         // 9. If relativeStart is -∞, let from be 0.
         // 10. Else if relativeStart < 0, let from be max(len + relativeStart, 0).
         // 11. Else, let from be min(relativeStart, len).
-        let from = Array::get_relative_start(context, args.get_or_undefined(1), len)?;
+        let from =
+            Array::get_relative_start(context, args.get_or_undefined(1), len as u64)?.to_usize()?;
 
         // 12. If end is undefined, let relativeEnd be len; else let relativeEnd be ? ToIntegerOrInfinity(end).
         // 13. If relativeEnd is -∞, let final be 0.
         // 14. Else if relativeEnd < 0, let final be max(len + relativeEnd, 0).
         // 15. Else, let final be min(relativeEnd, len).
-        let final_ = Array::get_relative_end(context, args.get_or_undefined(2), len)?;
+        let final_ =
+            Array::get_relative_end(context, args.get_or_undefined(2), len as u64)?.to_usize()?;
 
         // 16. Let count be min(final - from, len - to).
         let count = match (final_.checked_sub(from), len.checked_sub(to)) {
@@ -560,16 +563,16 @@ impl BuiltinTypedArray {
             let byte_offset = ta.byte_offset();
 
             // h. Let bufferByteLimit be (len × elementSize) + byteOffset.
-            let buffer_byte_limit = ((len * element_size) + byte_offset) as usize;
+            let buffer_byte_limit = (len * element_size) + byte_offset;
 
             // i. Let toByteIndex be (targetIndex × elementSize) + byteOffset.
-            let to_byte_index = (to * element_size + byte_offset) as usize;
+            let to_byte_index = to * element_size + byte_offset;
 
             // j. Let fromByteIndex be (startIndex × elementSize) + byteOffset.
-            let from_byte_index = (from * element_size + byte_offset) as usize;
+            let from_byte_index = from * element_size + byte_offset;
 
             // k. Let countBytes be count × elementSize.
-            let mut count_bytes = (count * element_size) as usize;
+            let mut count_bytes = count * element_size;
 
             // Readjust considering the buffer_byte_limit. A resize could
             // have readjusted the buffer size, which could put `count_bytes`
@@ -729,13 +732,15 @@ impl BuiltinTypedArray {
         // 7. If relativeStart = -∞, let startIndex be 0.
         // 8. Else if relativeStart < 0, let startIndex be max(len + relativeStart, 0).
         // 9. Else, let startIndex be min(relativeStart, len).
-        let start_index = Array::get_relative_start(context, args.get_or_undefined(1), len)?;
+        let start_index =
+            Array::get_relative_start(context, args.get_or_undefined(1), len as u64)?.to_usize()?;
 
         // 10. If end is undefined, let relativeEnd be len; else let relativeEnd be ? ToIntegerOrInfinity(end).
         // 11. If relativeEnd = -∞, let endIndex be 0.
         // 12. Else if relativeEnd < 0, let endIndex be max(len + relativeEnd, 0).
         // 13. Else, let endIndex be min(relativeEnd, len).
-        let end_index = Array::get_relative_end(context, args.get_or_undefined(2), len)?;
+        let end_index =
+            Array::get_relative_end(context, args.get_or_undefined(2), len as u64)?.to_usize()?;
 
         // 14. Set taRecord to MakeTypedArrayWithBufferWitnessRecord(O, seq-cst).
         // 15. If IsTypedArrayOutOfBounds(taRecord) is true, throw a TypeError exception.
@@ -882,7 +887,7 @@ impl BuiltinTypedArray {
         // 4. Let findRec be ? FindViaPredicate(O, len, ascending, predicate, thisArg).
         let (_, value) = find_via_predicate(
             &ta.upcast(),
-            len,
+            len as u64,
             Direction::Ascending,
             predicate,
             this_arg,
@@ -918,7 +923,7 @@ impl BuiltinTypedArray {
         // 4. Let findRec be ? FindViaPredicate(O, len, ascending, predicate, thisArg).
         let (index, _) = find_via_predicate(
             &ta.upcast(),
-            len,
+            len as u64,
             Direction::Ascending,
             predicate,
             this_arg,
@@ -954,7 +959,7 @@ impl BuiltinTypedArray {
         // 4. Let findRec be ? FindViaPredicate(O, len, descending, predicate, thisArg).
         let (_, value) = find_via_predicate(
             &ta.upcast(),
-            len,
+            len as u64,
             Direction::Descending,
             predicate,
             this_arg,
@@ -990,7 +995,7 @@ impl BuiltinTypedArray {
         // 4. Let findRec be ? FindViaPredicate(O, len, descending, predicate, thisArg).
         let (index, _) = find_via_predicate(
             &ta.upcast(),
-            len,
+            len as u64,
             Direction::Descending,
             predicate,
             this_arg,
@@ -1094,8 +1099,10 @@ impl BuiltinTypedArray {
             // 10. Else,
             // a. Let k be len + n.
             // b. If k < 0, set k to 0.
-            len.saturating_add_signed(n)
+            (len as u64).saturating_add_signed(n)
         };
+
+        let k = k.to_usize()?;
 
         // 11. Repeat, while k < len,
         let ta = ta.upcast();
@@ -1158,8 +1165,10 @@ impl BuiltinTypedArray {
         } else {
             // a. Let k be len + n.
             // b. If k < 0, set k to 0.
-            len.saturating_add_signed(n)
+            (len as u64).saturating_add_signed(n)
         };
+
+        let k = k.to_usize()?;
 
         // 11. Repeat, while k < len,
         let ta = ta.upcast();
@@ -1210,7 +1219,7 @@ impl BuiltinTypedArray {
         };
 
         // 6. Let R be the empty String.
-        let mut r = Vec::with_capacity(len as usize);
+        let mut r = Vec::with_capacity(len);
 
         // 7. Let k be 0.
         // 8. Repeat, while k < len,
@@ -1276,6 +1285,9 @@ impl BuiltinTypedArray {
         if len == 0 {
             return Ok((-1).into());
         }
+
+        // concert to u64 for spec-compliant ops
+        let len = len as u64;
 
         // 5. If fromIndex is present, let n be ? ToIntegerOrInfinity(fromIndex); else let n be len - 1.
         let k = match args.get(1) {
@@ -1623,7 +1635,7 @@ impl BuiltinTypedArray {
         let (ta, buf_len) = TypedArray::validate(this, Ordering::SeqCst)?;
 
         // 3. Let len be TypedArrayLength(taRecord).
-        let len = ta.borrow().data().array_length(buf_len);
+        let len = ta.borrow().data().array_length(buf_len) as u64;
         let kind = ta.borrow().data().kind();
 
         // 4. Let A be ? TypedArrayCreateSameType(O, « 𝔽(length) »).
@@ -1791,6 +1803,8 @@ impl BuiltinTypedArray {
                 .into());
         };
 
+        let target_offset = target_offset.to_usize()?; // boundary conversion
+
         // 16. If srcLength + targetOffset > targetLength, throw a RangeError exception.
         if src_length + target_offset > target_length {
             return Err(JsNativeError::range()
@@ -1813,8 +1827,8 @@ impl BuiltinTypedArray {
         // 19. If SameValue(srcBuffer, targetBuffer) is true or sameSharedArrayBuffer is true, then
         let src_byte_index = if BufferObject::equals(&src_buf_obj, &target_buf_obj) {
             // a. Let srcByteLength be source.[[ByteLength]].
-            let src_byte_offset = src_byte_offset as usize;
-            let src_byte_length = src_byte_length as usize;
+            let src_byte_offset = src_byte_offset;
+            let src_byte_length = src_byte_length;
 
             let s = {
                 let slice = src_buf_obj.as_buffer();
@@ -1856,9 +1870,9 @@ impl BuiltinTypedArray {
 
         // 24. If srcType is the same as targetType, then
         if src_type == target_type {
-            let src_byte_index = src_byte_index as usize;
-            let target_byte_index = target_byte_index as usize;
-            let byte_count = (target_element_size * src_length) as usize;
+            let src_byte_index = src_byte_index;
+            let target_byte_index = target_byte_index;
+            let byte_count = target_element_size * src_length;
 
             // a. NOTE: If srcType and targetType are the same, the transfer must be performed in a manner that preserves the bit-level encoding of the source data.
             // b. Repeat, while targetByteIndex < limit,
@@ -1883,10 +1897,10 @@ impl BuiltinTypedArray {
         // 25. Else,
         else {
             // 23. Let limit be targetByteIndex + targetElementSize × srcLength.
-            let limit = (target_byte_index + target_element_size * src_length) as usize;
+            let limit = target_byte_index + target_element_size * src_length;
 
-            let mut src_byte_index = src_byte_index as usize;
-            let mut target_byte_index = target_byte_index as usize;
+            let mut src_byte_index = src_byte_index;
+            let mut target_byte_index = target_byte_index;
 
             // a. Repeat, while targetByteIndex < limit,
             while target_byte_index < limit {
@@ -1913,10 +1927,10 @@ impl BuiltinTypedArray {
                 }
 
                 // iii. Set srcByteIndex to srcByteIndex + srcElementSize.
-                src_byte_index += src_element_size as usize;
+                src_byte_index += src_element_size;
 
                 // iv. Set targetByteIndex to targetByteIndex + targetElementSize.
-                target_byte_index += target_element_size as usize;
+                target_byte_index += target_element_size;
             }
         }
 
@@ -1964,6 +1978,8 @@ impl BuiltinTypedArray {
         // 5. Let srcLength be ? LengthOfArrayLike(src).
         let src_length = src.length_of_array_like(context)?;
 
+        let src_length = src_length.to_usize()?; // boundary conversion
+
         // 6. If targetOffset = +∞, throw a RangeError exception.
         let target_offset = match target_offset {
             U64OrPositiveInfinity::U64(target_offset) => target_offset,
@@ -1973,6 +1989,8 @@ impl BuiltinTypedArray {
                     .into());
             }
         };
+
+        let target_offset = target_offset.to_usize()?; // boundary conversion
 
         // 7. If srcLength + targetOffset > targetLength, throw a RangeError exception.
         if src_length + target_offset > target_length {
@@ -2031,13 +2049,16 @@ impl BuiltinTypedArray {
         // 5. If relativeStart = -∞, let startIndex be 0.
         // 6. Else if relativeStart < 0, let startIndex be max(srcArrayLength + relativeStart, 0).
         // 7. Else, let startIndex be min(relativeStart, srcArrayLength).
-        let start_index = Array::get_relative_start(context, args.get_or_undefined(0), src_len)?;
+        let start_index =
+            Array::get_relative_start(context, args.get_or_undefined(0), src_len as u64)?
+                .to_usize()?;
 
         // 8. If end is undefined, let relativeEnd be srcArrayLength; else let relativeEnd be ? ToIntegerOrInfinity(end).
         // 9. If relativeEnd = -∞, let endIndex be 0.
         // 10. Else if relativeEnd < 0, let endIndex be max(srcArrayLength + relativeEnd, 0).
         // 11. Else, let endIndex be min(relativeEnd, srcArrayLength).
-        let end_index = Array::get_relative_end(context, args.get_or_undefined(1), src_len)?;
+        let end_index = Array::get_relative_end(context, args.get_or_undefined(1), src_len as u64)?
+            .to_usize()?;
 
         // 12. Let countBytes be max(endIndex - startIndex, 0).
         let count = end_index.saturating_sub(start_index);
@@ -2073,7 +2094,7 @@ impl BuiltinTypedArray {
         let end_index = min(end_index, src_borrow.data().array_length(src_buf_len));
 
         // d. Set countBytes to maxlen(endIndex - startIndex, 0).
-        let count = end_index.saturating_sub(start_index) as usize;
+        let count = end_index.saturating_sub(start_index);
 
         // The inner buffer may have resized between getting the indices and getting the buffer
         // itself. Check that the count is not zero again before proceeding.
@@ -2115,7 +2136,7 @@ impl BuiltinTypedArray {
 
         // g. If srcType is targetType, then
         {
-            let byte_count = count * src_type.element_size() as usize;
+            let byte_count = count * src_type.element_size();
 
             // i. NOTE: The transfer must be performed in a manner that preserves the bit-level encoding of the source data.
             // ii. Let srcBuffer be O.[[ViewedArrayBuffer]].
@@ -2128,10 +2149,10 @@ impl BuiltinTypedArray {
             let src_byte_offset = src_borrow.data().byte_offset();
 
             // vi. Let srcByteIndex be (startIndex × elementSize) + srcByteOffset.
-            let src_byte_index = (start_index * element_size + src_byte_offset) as usize;
+            let src_byte_index = start_index * element_size + src_byte_offset;
 
             // vii. Let targetByteIndex be A.[[ByteOffset]].
-            let target_byte_index = target_borrow.data().byte_offset() as usize;
+            let target_byte_index = target_borrow.data().byte_offset();
 
             // viii. Let endByteIndex be targetByteIndex + (countBytes × elementSize).
             // Not needed by the impl.
@@ -2293,7 +2314,7 @@ impl BuiltinTypedArray {
 
         let ta = ta.upcast();
         // 7. Let sortedList be ? SortIndexedProperties(obj, len, SortCompare, read-through-holes).
-        let sorted = Array::sort_indexed_properties(&ta, len, sort_compare, false, context)?;
+        let sorted = Array::sort_indexed_properties(&ta, len as u64, sort_compare, false, context)?;
 
         // 8. Let j be 0.
         // 9. Repeat, while j < len,
@@ -2333,7 +2354,7 @@ impl BuiltinTypedArray {
         let (ta, buf_len) = TypedArray::validate(this, Ordering::SeqCst)?;
 
         // 4. Let len be TypedArrayLength(taRecord).
-        let len = ta.borrow().data().array_length(buf_len);
+        let len = ta.borrow().data().array_length(buf_len) as u64;
 
         // 5. Let A be ? TypedArrayCreateSameType(O, « 𝔽(len) »).
         let new_array = Self::from_kind_and_length(ta.borrow().data().kind(), len, context)?;
@@ -2420,7 +2441,9 @@ impl BuiltinTypedArray {
         // 9. If relativeStart = -∞, let startIndex be 0.
         // 10. Else if relativeStart < 0, let startIndex be max(srcLength + relativeStart, 0).
         // 11. Else, let startIndex be min(relativeStart, srcLength).
-        let start_index = Array::get_relative_start(context, args.get_or_undefined(0), src_len)?;
+        let start_index =
+            Array::get_relative_start(context, args.get_or_undefined(0), src_len as u64)?
+                .to_usize()?;
 
         // 14. Let beginByteOffset be srcByteOffset + (startIndex × elementSize).
         let begin_byte_offset = src_byte_offset + (start_index * element_size);
@@ -2446,7 +2469,7 @@ impl BuiltinTypedArray {
             //     b. If relativeEnd = -∞, let endIndex be 0.
             //     c. Else if relativeEnd < 0, let endIndex be max(srcLength + relativeEnd, 0).
             //     d. Else, let endIndex be min(relativeEnd, srcLength).
-            let end_index = Array::get_relative_end(context, end, src_len)?;
+            let end_index = Array::get_relative_end(context, end, src_len as u64)?.to_usize()?;
 
             //     e. Let newLength be max(endIndex - startIndex, 0).
             let new_len = end_index.saturating_sub(start_index);
@@ -2535,7 +2558,7 @@ impl BuiltinTypedArray {
             }
         };
 
-        let mut r = Vec::with_capacity((len + len.saturating_sub(1)) as usize);
+        let mut r = Vec::with_capacity(len + len.saturating_sub(1));
 
         for k in 0..len {
             if k > 0 {
@@ -2598,7 +2621,7 @@ impl BuiltinTypedArray {
         let (ta, buf_len) = TypedArray::validate(this, Ordering::SeqCst)?;
 
         // 3. Let len be TypedArrayLength(taRecord).
-        let len = ta.borrow().data().array_length(buf_len);
+        let len = ta.borrow().data().array_length(buf_len) as u64;
         let kind = ta.borrow().data().kind();
 
         // 4. Let relativeIndex be ? ToIntegerOrInfinity(index).
@@ -2629,7 +2652,7 @@ impl BuiltinTypedArray {
             let inner = ta.borrow();
             let buf = inner.data().viewed_array_buffer().as_buffer();
             let s = buf.bytes(Ordering::Relaxed)?;
-            inner.data().validate_index_u64(rel, s.len())
+            inner.data().validate_index_usize(rel, s.len())
         })()
         .ok_or_else(|| {
             JsNativeError::range().with_message("invalid integer index for TypedArray operation")
@@ -2643,7 +2666,7 @@ impl BuiltinTypedArray {
         let ta = ta.upcast();
         for k in 0..len {
             // a. Let Pk be ! ToString(𝔽(k)).
-            let value = if k == actual_index {
+            let value = if k == actual_index as u64 {
                 // b. If k is actualIndex, let fromValue be numericValue.
                 numeric_value.clone()
             } else {
@@ -2776,7 +2799,7 @@ impl BuiltinTypedArray {
         let element_size = T::ERASED.element_size();
 
         // 4. Let byteLength be elementSize × length.
-        let byte_length = element_size * length;
+        let byte_length = element_size as u64 * length;
 
         // 5. Let data be ? AllocateArrayBuffer(%ArrayBuffer%, byteLength).
         let data = ArrayBuffer::allocate(
@@ -2799,9 +2822,9 @@ impl BuiltinTypedArray {
             // 8. Set O.[[ByteOffset]] to 0.
             0,
             // 7. Set O.[[ByteLength]] to byteLength.
-            Some(byte_length),
+            Some(byte_length.to_usize()?),
             // 9. Set O.[[ArrayLength]] to length.
-            Some(length),
+            Some(length.to_usize()?),
         ))
     }
 
@@ -2922,8 +2945,8 @@ impl BuiltinTypedArray {
         // 11. If elementType is srcType, then
 
         let new_buffer = if element_type == src_type {
-            let start = src_byte_offset as usize;
-            let count = byte_length as usize;
+            let start = src_byte_offset;
+            let count = byte_length;
             // a. Let data be ? CloneArrayBuffer(srcData, srcByteOffset, byteLength).
             src_data.subslice(start..start + count).clone(context)?
         } else {
@@ -2937,7 +2960,7 @@ impl BuiltinTypedArray {
                     .array_buffer()
                     .constructor()
                     .into(),
-                byte_length,
+                byte_length as u64,
                 None,
                 context,
             )?;
@@ -2956,11 +2979,11 @@ impl BuiltinTypedArray {
                         .into());
                 }
 
-                let src_element_size = src_element_size as usize;
-                let target_element_size = element_size as usize;
+                let src_element_size = src_element_size;
+                let target_element_size = element_size;
 
                 // c. Let srcByteIndex be srcByteOffset.
-                let mut src_byte_index = src_byte_offset as usize;
+                let mut src_byte_index = src_byte_offset;
 
                 // d. Let targetByteIndex be 0.
                 let mut target_byte_index = 0;
@@ -3035,7 +3058,7 @@ impl BuiltinTypedArray {
         context: &mut Context,
     ) -> JsResult<JsObject> {
         // 1. Let elementSize be TypedArrayElementSize(O).
-        let element_size = T::ERASED.element_size();
+        let element_size = T::ERASED.element_size() as u64;
 
         // 2. Let offset be ? ToIndex(byteOffset).
         let offset = byte_offset.to_index(context)?;
@@ -3130,7 +3153,13 @@ impl BuiltinTypedArray {
         Ok(JsObject::from_proto_and_data_with_shared_shape(
             context.root_shape(),
             proto,
-            TypedArray::new(buffer, T::ERASED, offset, byte_length, array_length),
+            TypedArray::new(
+                buffer,
+                T::ERASED,
+                offset.to_usize()?,
+                byte_length.map(|x| x.to_usize()).transpose()?,
+                array_length.map(|x| x.to_usize()).transpose()?,
+            ),
         )
         .upcast())
     }
@@ -3290,4 +3319,20 @@ pub(crate) fn is_valid_integer_index(obj: &JsObject, index: f64) -> JsResult<boo
     };
 
     Ok(inner.validate_index(index, buf_len).is_some())
+}
+
+trait ToUsize {
+    /// Helper to convert from u64 (used in spec) to usize (used in implementation)
+    fn to_usize(self) -> JsResult<usize>;
+}
+
+impl ToUsize for u64 {
+    #[inline]
+    fn to_usize(self) -> JsResult<usize> {
+        usize::try_from(self).map_err(|_| {
+            JsNativeError::range()
+                .with_message("index too large")
+                .into()
+        })
+    }
 }

--- a/core/engine/src/builtins/typed_array/builtin.rs
+++ b/core/engine/src/builtins/typed_array/builtin.rs
@@ -1790,7 +1790,7 @@ impl BuiltinTypedArray {
         // 14. Let srcByteOffset be source.[[ByteOffset]].
         let src_byte_offset = src_array.data().byte_offset();
 
-        // a. Let srcByteLength be source.[[ByteLength]].
+        // 19a. Let srcByteLength be source.[[ByteLength]].
         let src_byte_length = src_array.data().byte_length(src_buf_len);
 
         drop(target_array);
@@ -1826,9 +1826,8 @@ impl BuiltinTypedArray {
         //     sameSharedArrayBuffer be true; otherwise, let sameSharedArrayBuffer be false.
         // 19. If SameValue(srcBuffer, targetBuffer) is true or sameSharedArrayBuffer is true, then
         let src_byte_index = if BufferObject::equals(&src_buf_obj, &target_buf_obj) {
-            // a. Let srcByteLength be source.[[ByteLength]].
-            let src_byte_offset = src_byte_offset;
-            let src_byte_length = src_byte_length;
+            // 19a. Let srcByteLength be source.[[ByteLength]].
+            // see above
 
             let s = {
                 let slice = src_buf_obj.as_buffer();
@@ -1870,8 +1869,6 @@ impl BuiltinTypedArray {
 
         // 24. If srcType is the same as targetType, then
         if src_type == target_type {
-            let src_byte_index = src_byte_index;
-            let target_byte_index = target_byte_index;
             let byte_count = target_element_size * src_length;
 
             // a. NOTE: If srcType and targetType are the same, the transfer must be performed in a manner that preserves the bit-level encoding of the source data.
@@ -2979,7 +2976,6 @@ impl BuiltinTypedArray {
                         .into());
                 }
 
-                let src_element_size = src_element_size;
                 let target_element_size = element_size;
 
                 // c. Let srcByteIndex be srcByteOffset.
@@ -3157,8 +3153,8 @@ impl BuiltinTypedArray {
                 buffer,
                 T::ERASED,
                 offset.to_usize()?,
-                byte_length.map(|x| x.to_usize()).transpose()?,
-                array_length.map(|x| x.to_usize()).transpose()?,
+                byte_length.map(ToUsize::to_usize).transpose()?,
+                array_length.map(ToUsize::to_usize).transpose()?,
             ),
         )
         .upcast())

--- a/core/engine/src/builtins/typed_array/builtin.rs
+++ b/core/engine/src/builtins/typed_array/builtin.rs
@@ -1635,11 +1635,11 @@ impl BuiltinTypedArray {
         let (ta, buf_len) = TypedArray::validate(this, Ordering::SeqCst)?;
 
         // 3. Let len be TypedArrayLength(taRecord).
-        let len = ta.borrow().data().array_length(buf_len) as u64;
+        let len = ta.borrow().data().array_length(buf_len);
         let kind = ta.borrow().data().kind();
 
         // 4. Let A be ? TypedArrayCreateSameType(O, « 𝔽(length) »).
-        let new_array = Self::from_kind_and_length(kind, len, context)?;
+        let new_array = Self::from_kind_and_length(kind, len as u64, context)?;
 
         // 5. Let k be 0.
         // 6. Repeat, while k < length,
@@ -2621,7 +2621,7 @@ impl BuiltinTypedArray {
         let (ta, buf_len) = TypedArray::validate(this, Ordering::SeqCst)?;
 
         // 3. Let len be TypedArrayLength(taRecord).
-        let len = ta.borrow().data().array_length(buf_len) as u64;
+        let len = ta.borrow().data().array_length(buf_len);
         let kind = ta.borrow().data().kind();
 
         // 4. Let relativeIndex be ? ToIntegerOrInfinity(index).
@@ -2647,7 +2647,7 @@ impl BuiltinTypedArray {
         let actual_index = (|| {
             let rel = u64::try_from(relative_index)
                 .ok()
-                .or_else(|| len.checked_add_signed(relative_index))?;
+                .or_else(|| (len as u64).checked_add_signed(relative_index))?;
 
             let inner = ta.borrow();
             let buf = inner.data().viewed_array_buffer().as_buffer();
@@ -2659,14 +2659,14 @@ impl BuiltinTypedArray {
         })?;
 
         // 10. Let A be ? TypedArrayCreateSameType(O, « 𝔽(len) »).
-        let new_array = Self::from_kind_and_length(kind, len, context)?;
+        let new_array = Self::from_kind_and_length(kind, len as u64, context)?;
 
         // 11. Let k be 0.
         // 12. Repeat, while k < len,
         let ta = ta.upcast();
         for k in 0..len {
             // a. Let Pk be ! ToString(𝔽(k)).
-            let value = if k == actual_index as u64 {
+            let value = if k == actual_index {
                 // b. If k is actualIndex, let fromValue be numericValue.
                 numeric_value.clone()
             } else {

--- a/core/engine/src/builtins/typed_array/mod.rs
+++ b/core/engine/src/builtins/typed_array/mod.rs
@@ -466,19 +466,19 @@ impl TypedArrayKind {
     }
 
     /// Gets the size of the type of element of this `TypedArrayKind`.
-    pub(crate) const fn element_size(self) -> u64 {
+    pub(crate) const fn element_size(self) -> usize {
         match self {
             TypedArrayKind::Int8 | TypedArrayKind::Uint8 | TypedArrayKind::Uint8Clamped => {
-                size_of::<u8>() as u64
+                size_of::<u8>()
             }
-            TypedArrayKind::Int16 | TypedArrayKind::Uint16 => size_of::<u16>() as u64,
+            TypedArrayKind::Int16 | TypedArrayKind::Uint16 => size_of::<u16>(),
             #[cfg(feature = "float16")]
-            TypedArrayKind::Float16 => size_of::<u16>() as u64,
+            TypedArrayKind::Float16 => size_of::<u16>(),
             TypedArrayKind::Int32 | TypedArrayKind::Uint32 | TypedArrayKind::Float32 => {
-                size_of::<u32>() as u64
+                size_of::<u32>()
             }
             TypedArrayKind::BigInt64 | TypedArrayKind::BigUint64 | TypedArrayKind::Float64 => {
-                size_of::<u64>() as u64
+                size_of::<u64>()
             }
         }
     }

--- a/core/engine/src/builtins/typed_array/object.rs
+++ b/core/engine/src/builtins/typed_array/object.rs
@@ -31,9 +31,9 @@ use super::{TypedArrayKind, is_valid_integer_index};
 pub struct TypedArray {
     viewed_array_buffer: BufferObject,
     kind: TypedArrayKind,
-    byte_offset: u64,
-    byte_length: Option<u64>,
-    array_length: Option<u64>,
+    byte_offset: usize,
+    byte_length: Option<usize>,
+    array_length: Option<usize>,
 }
 
 impl JsData for TypedArray {
@@ -59,9 +59,9 @@ impl TypedArray {
     pub(crate) const fn new(
         viewed_array_buffer: BufferObject,
         kind: TypedArrayKind,
-        byte_offset: u64,
-        byte_length: Option<u64>,
-        array_length: Option<u64>,
+        byte_offset: usize,
+        byte_length: Option<usize>,
+        array_length: Option<usize>,
     ) -> Self {
         Self {
             viewed_array_buffer,
@@ -81,9 +81,6 @@ impl TypedArray {
     ///
     /// [spec]: https://tc39.es/ecma262/sec-istypedarrayoutofbounds
     pub(crate) fn is_out_of_bounds(&self, buf_byte_len: usize) -> bool {
-        // Checks when allocating the buffer ensure the length fits inside an `u64`.
-        let buf_byte_len = buf_byte_len as u64;
-
         // 1. Let O be taRecord.[[Object]].
         // 2. Let bufferByteLength be taRecord.[[CachedBufferByteLength]].
         // 3. Assert: IsDetachedBuffer(O.[[ViewedArrayBuffer]]) is true if and only if bufferByteLength is detached.
@@ -112,7 +109,7 @@ impl TypedArray {
 
     /// Get the `TypedArray` object's byte offset.
     #[must_use]
-    pub const fn byte_offset(&self) -> u64 {
+    pub const fn byte_offset(&self) -> usize {
         self.byte_offset
     }
 
@@ -134,7 +131,7 @@ impl TypedArray {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-typedarraybytelength
     #[must_use]
-    pub fn byte_length(&self, buf_byte_len: usize) -> u64 {
+    pub fn byte_length(&self, buf_byte_len: usize) -> usize {
         // 1. If IsTypedArrayOutOfBounds(taRecord) is true, return 0.
         if self.is_out_of_bounds(buf_byte_len) {
             return 0;
@@ -168,10 +165,9 @@ impl TypedArray {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-typedarraylength
     #[must_use]
-    pub fn array_length(&self, buf_byte_len: usize) -> u64 {
+    pub fn array_length(&self, buf_byte_len: usize) -> usize {
         // 1. Assert: IsTypedArrayOutOfBounds(taRecord) is false.
         debug_assert!(!self.is_out_of_bounds(buf_byte_len));
-        let buf_byte_len = buf_byte_len as u64;
 
         // 2. Let O be taRecord.[[Object]].
 
@@ -229,7 +225,7 @@ impl TypedArray {
     ///
     /// Note: if this is only used for bounds checking, it is recommended to use
     /// the `Ordering::Relaxed` ordering to get the buffer slice.
-    pub(crate) fn validate_index(&self, index: f64, buf_len: usize) -> Option<u64> {
+    pub(crate) fn validate_index(&self, index: f64, buf_len: usize) -> Option<usize> {
         // 2. If IsIntegralNumber(index) is false, return false.
         if index.is_nan() || index.is_infinite() || index.fract() != 0.0 {
             return None;
@@ -254,7 +250,7 @@ impl TypedArray {
         }
 
         // 9. Return true.
-        Some(index as u64)
+        Some(index as usize) // index is already validated to be within usize range (buf_len is usize)
     }
 
     /// Validates a `u64` index to be in bounds for the inner buffer of this `TypedArray`.
@@ -262,7 +258,7 @@ impl TypedArray {
     /// This is an optimized variant of [`validate_index`](Self::validate_index) for cases where
     /// the index is already known to be a non-negative integer (`u64`), skipping the redundant
     /// checks for `NaN`, infinity, fractional values, and negative zero.
-    pub(crate) fn validate_index_u64(&self, index: u64, buf_len: usize) -> Option<u64> {
+    pub(crate) fn validate_index_usize(&self, index: u64, buf_len: usize) -> Option<usize> {
         // 1. If IsTypedArrayOutOfBounds(taRecord) is true, return false.
         if self.is_out_of_bounds(buf_len) {
             return None;
@@ -272,12 +268,12 @@ impl TypedArray {
         let length = self.array_length(buf_len);
 
         // 3. If index ≥ length, return false.
-        if index >= length {
+        if index >= length as u64 {
             return None;
         }
 
         // 4. Return true.
-        Some(index)
+        Some(index as usize)
     }
 }
 
@@ -682,7 +678,7 @@ fn typed_array_get_element(obj: &JsObject, index: f64) -> JsResult<Option<JsValu
     let size = inner.kind.element_size();
 
     // 4. Let byteIndexInBuffer be (ℝ(index) × elementSize) + offset.
-    let byte_index = ((index * size) + offset) as usize;
+    let byte_index = (index * size) + offset;
 
     // 5. Let elementType be TypedArrayElementType(O).
     let elem_type = inner.kind();
@@ -741,7 +737,7 @@ pub(crate) fn typed_array_set_element(
     let size = elem_type.element_size();
 
     //     c. Let byteIndexInBuffer be (ℝ(index) × elementSize) + offset.
-    let byte_index = ((index * size) + offset) as usize;
+    let byte_index = (index * size) + offset;
 
     //     e. Perform SetValueInBuffer(O.[[ViewedArrayBuffer]], byteIndexInBuffer, elementType, numValue, true, unordered).
     // SAFETY: The TypedArray object guarantees that the buffer is aligned.

--- a/core/engine/src/object/builtins/jstypedarray.rs
+++ b/core/engine/src/object/builtins/jstypedarray.rs
@@ -1211,8 +1211,8 @@ impl JsUint8Array {
                     .with_message("typed array is outside the bounds of its inner buffer")
                     .into());
             }
-            let byte_offset = ta.byte_offset() as usize;
-            let byte_len = ta.byte_length(buf_byte_len) as usize;
+            let byte_offset = ta.byte_offset();
+            let byte_len = ta.byte_length(buf_byte_len);
             slice.subslice(byte_offset..byte_offset + byte_len).to_vec()
         };
         Ok(vec)

--- a/core/engine/src/value/display/typed_array.rs
+++ b/core/engine/src/value/display/typed_array.rs
@@ -46,10 +46,10 @@ pub(super) fn log_typed_array(
 
     write!(f, "{type_name}({length}) [ ")?;
 
-    let offset = inner.byte_offset() as usize;
-    let elem_size = kind.element_size() as usize;
+    let offset = inner.byte_offset();
+    let elem_size = kind.element_size();
 
-    for i in 0..length as usize {
+    for i in 0..length {
         if i > 0 {
             f.write_str(", ")?;
         }


### PR DESCRIPTION
Part of #4766 .
2nd atttempt after #4787 .
Compared to the previous attempt, this PR limits the scope of change to `TypedArray` only (as opposed to touching `Array` as well like in #4787 ).

We also keep the spec-defined checks (for which `u64` is used).

`TypedArray` test262 tests pass on 32-bit (well 4 failed ones actually but main also fails 4 so).

If this approach is perceived as good/reasonable, i will do this for `DataView` too.