### PR TITLE
fix( /remaining): convert panics to EngineError::Panic using js_expect

### DIFF
--- a/core/engine/src/vm/opcode/binary_ops/mod.rs
+++ b/core/engine/src/vm/opcode/binary_ops/mod.rs
@@ -1,5 +1,5 @@
 use super::{IndexOperand, RegisterOperand};
-use crate::{Context, JsResult, error::JsNativeError, vm::opcode::Operation};
+use crate::{Context, JsExpect, JsResult, error::JsNativeError, vm::opcode::Operation};
 
 pub(crate) mod logical;
 pub(crate) mod macro_defined;
@@ -129,7 +129,7 @@ impl InPrivate {
             .frame()
             .environments
             .resolve_private_identifier(name)
-            .expect("private name must be in environment");
+            .js_expect("private name must be in environment")?;
 
         let value = rhs.private_element_find(&name, true, true).is_some();
 

--- a/core/engine/src/vm/opcode/call/mod.rs
+++ b/core/engine/src/vm/opcode/call/mod.rs
@@ -5,7 +5,7 @@ use dynify::Dynify;
 
 use super::{IndexOperand, RegisterOperand};
 use crate::{
-    Context, JsError, JsObject, JsResult, JsValue, NativeFunction,
+    Context, JsError, JsExpect, JsObject, JsResult, JsValue, NativeFunction,
     builtins::{Promise, promise::PromiseCapability},
     error::JsNativeError,
     job::NativeAsyncJob,
@@ -107,12 +107,12 @@ impl CallEvalSpread {
         let arguments_array = context.vm.stack.pop();
         let arguments_array_object = arguments_array
             .as_object()
-            .expect("arguments array in call spread function must be an object");
+            .js_expect("arguments array in call spread function must be an object")?;
         let arguments = arguments_array_object
             .borrow()
             .properties()
             .to_dense_indexed_properties()
-            .expect("arguments array in call spread function must be dense");
+            .js_expect("arguments array in call spread function must be dense")?;
 
         let func = context.vm.stack.calling_convention_get_function(0);
 
@@ -223,12 +223,12 @@ impl CallSpread {
         let arguments_array = context.vm.stack.pop();
         let arguments_array_object = arguments_array
             .as_object()
-            .expect("arguments array in call spread function must be an object");
+            .js_expect("arguments array in call spread function must be an object")?;
         let arguments = arguments_array_object
             .borrow()
             .properties()
             .to_dense_indexed_properties()
-            .expect("arguments array in call spread function must be dense");
+            .js_expect("arguments array in call spread function must be dense")?;
 
         let argument_count = arguments.len();
         context
@@ -303,13 +303,13 @@ fn parse_import_attributes(
             for entry in entries {
                 let entry = entry
                     .as_object()
-                    .expect("entry from EnumerableOwnProperties must be an object");
+                    .js_expect("entry from EnumerableOwnProperties must be an object")?;
 
                 // 1. Let key be entry.[[Key]].
                 let key = entry.get(0, context)?;
                 let key_str = key
                     .as_string()
-                    .expect("key from EnumerableOwnProperties must be a string")
+                    .js_expect("key from EnumerableOwnProperties must be a string")?
                     .clone();
 
                 // 2. Let value be entry.[[Value]].

--- a/core/engine/src/vm/opcode/copy/mod.rs
+++ b/core/engine/src/vm/opcode/copy/mod.rs
@@ -1,5 +1,5 @@
 use super::RegisterOperand;
-use crate::{Context, JsResult, vm::opcode::Operation};
+use crate::{Context, JsExpect, JsResult, vm::opcode::Operation};
 use thin_vec::ThinVec;
 
 /// `CopyDataProperties` implements the Opcode Operation for `Opcode::CopyDataProperties`
@@ -22,10 +22,10 @@ impl CopyDataProperties {
             let key = context.vm.get_register(key.into()).clone();
             excluded_keys.push(
                 key.to_property_key(context)
-                    .expect("key must be property key"),
+                    .js_expect("key must be property key")?,
             );
         }
-        let object = object.as_object().expect("not an object");
+        let object = object.as_object().js_expect("not an object")?;
         object.copy_data_properties(&source, excluded_keys, context)?;
         Ok(())
     }

--- a/core/engine/src/vm/opcode/get/name.rs
+++ b/core/engine/src/vm/opcode/get/name.rs
@@ -1,5 +1,5 @@
 use crate::{
-    Context, JsResult, JsValue,
+    Context, JsExpect, JsResult, JsValue,
     error::JsNativeError,
     object::{internal_methods::InternalMethodPropertyContext, shape::slot::SlotAttributes},
     property::PropertyKey,
@@ -62,7 +62,7 @@ impl GetNameGlobal {
             let object_borrowed = object.borrow();
             if let Some((shape, slot)) = ic.get(object_borrowed.shape()) {
                 let mut result = if slot.attributes.contains(SlotAttributes::PROTOTYPE) {
-                    let prototype = shape.prototype().expect("prototype should have value");
+                    let prototype = shape.prototype().js_expect("prototype should have value")?;
                     let prototype = prototype.borrow();
                     prototype.properties().storage[slot.index as usize].clone()
                 } else {
@@ -71,11 +71,10 @@ impl GetNameGlobal {
 
                 drop(object_borrowed);
                 if slot.attributes.has_get() && result.is_object() {
-                    result = result.as_object().expect("should contain getter").call(
-                        &object.clone().into(),
-                        &[],
-                        context,
-                    )?;
+                    result = result
+                        .as_object()
+                        .js_expect("should contain getter")?
+                        .call(&object.clone().into(), &[], context)?;
                 }
                 context.vm.set_register(dst.into(), result);
                 return Ok(());

--- a/core/engine/src/vm/opcode/get/private.rs
+++ b/core/engine/src/vm/opcode/get/private.rs
@@ -1,5 +1,5 @@
 use crate::{
-    Context, JsResult,
+    Context, JsExpect, JsResult,
     vm::opcode::{IndexOperand, Operation, RegisterOperand},
 };
 
@@ -28,7 +28,7 @@ impl GetPrivateField {
             .frame()
             .environments
             .resolve_private_identifier(name)
-            .expect("private name must be in environment");
+            .js_expect("private name must be in environment")?;
 
         let result = object.private_get(&name, context)?;
         context.vm.set_register(dst.into(), result);

--- a/core/engine/src/vm/opcode/get/property.rs
+++ b/core/engine/src/vm/opcode/get/property.rs
@@ -1,7 +1,7 @@
 use boa_string::StaticJsStrings;
 
 use crate::{
-    Context, JsResult, JsValue, js_string,
+    Context, JsExpect, JsResult, JsValue, js_string,
     object::{internal_methods::InternalMethodPropertyContext, shape::slot::SlotAttributes},
     property::PropertyKey,
     vm::opcode::{IndexOperand, Operation, RegisterOperand},
@@ -41,7 +41,7 @@ fn get_by_name<const LENGTH: bool>(
     let object_borrowed = object.borrow();
     if let Some((shape, slot)) = ic.get(object_borrowed.shape()) {
         let mut result = if slot.attributes.contains(SlotAttributes::PROTOTYPE) {
-            let prototype = shape.prototype().expect("prototype should have value");
+            let prototype = shape.prototype().js_expect("prototype should have value")?;
             let prototype = prototype.borrow();
             prototype.properties().storage[slot.index as usize].clone()
         } else {
@@ -50,11 +50,10 @@ fn get_by_name<const LENGTH: bool>(
 
         drop(object_borrowed);
         if slot.attributes.has_get() && result.is_object() {
-            result =
-                result
-                    .as_object()
-                    .expect("should contain getter")
-                    .call(receiver, &[], context)?;
+            result = result
+                .as_object()
+                .js_expect("should contain getter")?
+                .call(receiver, &[], context)?;
         }
         context.vm.set_register(dst.into(), result);
         return Ok(());

--- a/core/engine/src/vm/opcode/iteration/iterator.rs
+++ b/core/engine/src/vm/opcode/iteration/iterator.rs
@@ -143,7 +143,7 @@ impl IteratorNext {
             .frame_mut()
             .iterators
             .pop()
-            .expect("iterator stack should have at least an iterator");
+            .js_expect("iterator stack should have at least an iterator")?;
 
         iterator.step(context)?;
 
@@ -178,7 +178,7 @@ impl IteratorFinishAsyncNext {
             .frame_mut()
             .iterators
             .pop()
-            .expect("iterator on the call frame must exist");
+            .js_expect("iterator on the call frame must exist")?;
 
         let resume_kind = context
             .vm
@@ -249,7 +249,7 @@ impl IteratorValue {
             .frame_mut()
             .iterators
             .pop()
-            .expect("iterator on the call frame must exist");
+            .js_expect("iterator on the call frame must exist")?;
 
         let iter_value = iterator.value(context)?;
         context.vm.set_register(value.into(), iter_value);
@@ -358,7 +358,7 @@ impl IteratorToArray {
             .frame_mut()
             .iterators
             .pop()
-            .expect("iterator on the call frame must exist");
+            .js_expect("iterator on the call frame must exist")?;
 
         let mut values = Vec::new();
 

--- a/core/engine/src/vm/opcode/set/private.rs
+++ b/core/engine/src/vm/opcode/set/private.rs
@@ -1,5 +1,5 @@
 use crate::{
-    Context, JsResult, js_str, js_string,
+    Context, JsExpect, JsResult, js_str, js_string,
     object::PrivateElement,
     property::PropertyDescriptor,
     vm::opcode::{IndexOperand, Operation, RegisterOperand},
@@ -31,7 +31,7 @@ impl SetPrivateField {
             .frame()
             .environments
             .resolve_private_identifier(name)
-            .expect("private name must be in environment");
+            .js_expect("private name must be in environment")?;
 
         base_obj.private_set(&name, value.clone(), context)?;
         Ok(())
@@ -67,7 +67,7 @@ impl DefinePrivateField {
 
         let object = object
             .as_object()
-            .expect("class prototype must be an object");
+            .js_expect("class prototype must be an object")?;
 
         let name = object.private_name(name);
         object.private_field_add(&name, value, context)?;


### PR DESCRIPTION
Part of #3241.

Converts all convertible `.expect()` panics to `.js_expect()?` in:
- `opcode/get/property.rs` (2)
- `opcode/get/name.rs` (2)
- `opcode/get/private.rs` (1)
- `opcode/binary_ops/mod.rs` (1)
- `opcode/copy/mod.rs` (2)
- `opcode/set/private.rs` (2)
- `opcode/call/mod.rs` (6)
- `opcode/iteration/iterator.rs` (4)

Total: 20 panics converted.