### PR TITLE
refactor(temporal): remove unnecessary clone in roundTo option parsing

### DIFF
--- a/core/engine/src/builtins/temporal/duration/mod.rs
+++ b/core/engine/src/builtins/temporal/duration/mod.rs
@@ -896,33 +896,30 @@ impl Duration {
                 JsNativeError::typ().with_message("this value must be a Duration object.")
             })?;
 
-        let round_to = match args.first().map(JsValue::variant) {
-            // 3. If roundTo is undefined, then
-            None | Some(JsVariant::Undefined) => {
-                return Err(JsNativeError::typ()
-                    .with_message("roundTo cannot be undefined.")
-                    .into());
-            }
-            // 4. If Type(roundTo) is String, then
-            Some(JsVariant::String(rt)) => {
-                // a. Let paramString be roundTo.
-                let param_string = rt.clone();
-                // b. Set roundTo to OrdinaryObjectCreate(null).
-                let new_round_to = JsObject::with_null_proto();
-                // c. Perform ! CreateDataPropertyOrThrow(roundTo, "smallestUnit", paramString).
-                new_round_to.create_data_property_or_throw(
-                    js_string!("smallestUnit"),
-                    param_string,
-                    context,
-                )?;
-                new_round_to
-            }
+        // 3. If roundTo is undefined, then
+        let round_to_arg = args.get_or_undefined(0);
+        if round_to_arg.is_undefined() {
+            return Err(JsNativeError::typ()
+                .with_message("roundTo cannot be undefined.")
+                .into());
+        }
+        // 4. If Type(roundTo) is String, then
+        let round_to = if let Some(param_string) = round_to_arg.as_string() {
+            // a. Let paramString be roundTo.
+            let param_string = param_string.clone();
+            // b. Set roundTo to OrdinaryObjectCreate(null).
+            let new_round_to = JsObject::with_null_proto();
+            // c. Perform ! CreateDataPropertyOrThrow(roundTo, "smallestUnit", paramString).
+            new_round_to.create_data_property_or_throw(
+                js_string!("smallestUnit"),
+                param_string,
+                context,
+            )?;
+            new_round_to
+        } else {
             // 5. Else,
-            Some(round_to) => {
-                // TODO: remove this clone.
-                // a. Set roundTo to ? GetOptionsObject(roundTo).
-                get_options_object(&JsValue::from(round_to))?
-            }
+            // a. Set roundTo to ? GetOptionsObject(roundTo).
+            get_options_object(round_to_arg)?
         };
 
         // NOTE: 6 & 7 unused in favor of `is_none()`.

--- a/core/engine/src/builtins/temporal/instant/mod.rs
+++ b/core/engine/src/builtins/temporal/instant/mod.rs
@@ -3,7 +3,6 @@
 use super::options::{get_difference_settings, get_digits_option};
 use super::{create_temporal_zoneddatetime, to_temporal_timezone_identifier};
 use crate::js_error;
-use crate::value::JsVariant;
 use crate::{
     Context, JsArgs, JsBigInt, JsData, JsNativeError, JsObject, JsResult, JsString, JsSymbol,
     JsValue,
@@ -495,33 +494,30 @@ impl Instant {
                 JsNativeError::typ().with_message("the this object must be an instant object.")
             })?;
 
-        let round_to = match args.first().map(JsValue::variant) {
-            // 3. If roundTo is undefined, then
-            None | Some(JsVariant::Undefined) => {
-                return Err(JsNativeError::typ()
-                    .with_message("roundTo cannot be undefined.")
-                    .into());
-            }
-            // 4. If Type(roundTo) is String, then
-            Some(JsVariant::String(rt)) => {
-                // a. Let paramString be roundTo.
-                let param_string = rt.clone();
-                // b. Set roundTo to OrdinaryObjectCreate(null).
-                let new_round_to = JsObject::with_null_proto();
-                // c. Perform ! CreateDataPropertyOrThrow(roundTo, "smallestUnit", paramString).
-                new_round_to.create_data_property_or_throw(
-                    js_string!("smallestUnit"),
-                    param_string,
-                    context,
-                )?;
-                new_round_to
-            }
+        // 3. If roundTo is undefined, then
+        let round_to_arg = args.get_or_undefined(0);
+        if round_to_arg.is_undefined() {
+            return Err(JsNativeError::typ()
+                .with_message("roundTo cannot be undefined.")
+                .into());
+        }
+        // 4. If Type(roundTo) is String, then
+        let round_to = if let Some(param_string) = round_to_arg.as_string() {
+            // a. Let paramString be roundTo.
+            let param_string = param_string.clone();
+            // b. Set roundTo to OrdinaryObjectCreate(null).
+            let new_round_to = JsObject::with_null_proto();
+            // c. Perform ! CreateDataPropertyOrThrow(roundTo, "smallestUnit", paramString).
+            new_round_to.create_data_property_or_throw(
+                js_string!("smallestUnit"),
+                param_string,
+                context,
+            )?;
+            new_round_to
+        } else {
             // 5. Else,
-            Some(round_to) => {
-                // TODO: remove this clone.
-                // a. Set roundTo to ? GetOptionsObject(roundTo).
-                get_options_object(&JsValue::from(round_to))?
-            }
+            // a. Set roundTo to ? GetOptionsObject(roundTo).
+            get_options_object(round_to_arg)?
         };
 
         // 6. NOTE: The following steps read options and perform independent validation in

--- a/core/engine/src/builtins/temporal/plain_date_time/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_date_time/mod.rs
@@ -42,7 +42,6 @@ use super::{
     options::{TemporalUnitGroup, get_difference_settings, get_digits_option, get_temporal_unit},
     to_temporal_duration_record, to_temporal_time, to_temporal_timezone_identifier,
 };
-use crate::value::JsVariant;
 
 /// The `Temporal.PlainDateTime` built-in implementation.
 ///
@@ -1323,32 +1322,30 @@ impl PlainDateTime {
                 JsNativeError::typ().with_message("the this object must be a PlainTime object.")
             })?;
 
-        let round_to = match args.first().map(JsValue::variant) {
-            // 3. If roundTo is undefined, then
-            None | Some(JsVariant::Undefined) => {
-                return Err(JsNativeError::typ()
-                    .with_message("roundTo cannot be undefined.")
-                    .into());
-            }
-            // 4. If Type(roundTo) is String, then
-            Some(JsVariant::String(rt)) => {
-                // a. Let paramString be roundTo.
-                let param_string = rt.clone();
-                // b. Set roundTo to OrdinaryObjectCreate(null).
-                let new_round_to = JsObject::with_null_proto();
-                // c. Perform ! CreateDataPropertyOrThrow(roundTo, "smallestUnit", paramString).
-                new_round_to.create_data_property_or_throw(
-                    js_string!("smallestUnit"),
-                    param_string,
-                    context,
-                )?;
-                new_round_to
-            }
+        // 3. If roundTo is undefined, then
+        let round_to_arg = args.get_or_undefined(0);
+        if round_to_arg.is_undefined() {
+            return Err(JsNativeError::typ()
+                .with_message("roundTo cannot be undefined.")
+                .into());
+        }
+        // 4. If Type(roundTo) is String, then
+        let round_to = if let Some(param_string) = round_to_arg.as_string() {
+            // a. Let paramString be roundTo.
+            let param_string = param_string.clone();
+            // b. Set roundTo to OrdinaryObjectCreate(null).
+            let new_round_to = JsObject::with_null_proto();
+            // c. Perform ! CreateDataPropertyOrThrow(roundTo, "smallestUnit", paramString).
+            new_round_to.create_data_property_or_throw(
+                js_string!("smallestUnit"),
+                param_string,
+                context,
+            )?;
+            new_round_to
+        } else {
             // 5. Else,
-            Some(round_to) => {
-                // a. Set roundTo to ? GetOptionsObject(roundTo).
-                get_options_object(&JsValue::from(round_to))?
-            }
+            // a. Set roundTo to ? GetOptionsObject(roundTo).
+            get_options_object(round_to_arg)?
         };
 
         let mut options = RoundingOptions::default();

--- a/core/engine/src/builtins/temporal/plain_time/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_time/mod.rs
@@ -642,32 +642,30 @@ impl PlainTime {
                 JsNativeError::typ().with_message("the this object must be a PlainTime object.")
             })?;
 
-        let round_to = match args.first().map(JsValue::variant) {
-            // 3. If roundTo is undefined, then
-            None | Some(JsVariant::Undefined) => {
-                return Err(JsNativeError::typ()
-                    .with_message("roundTo cannot be undefined.")
-                    .into());
-            }
-            // 4. If Type(roundTo) is String, then
-            Some(JsVariant::String(rt)) => {
-                // a. Let paramString be roundTo.
-                let param_string = rt.clone();
-                // b. Set roundTo to OrdinaryObjectCreate(null).
-                let new_round_to = JsObject::with_null_proto();
-                // c. Perform ! CreateDataPropertyOrThrow(roundTo, "smallestUnit", paramString).
-                new_round_to.create_data_property_or_throw(
-                    js_string!("smallestUnit"),
-                    param_string,
-                    context,
-                )?;
-                new_round_to
-            }
+        // 3. If roundTo is undefined, then
+        let round_to_arg = args.get_or_undefined(0);
+        if round_to_arg.is_undefined() {
+            return Err(JsNativeError::typ()
+                .with_message("roundTo cannot be undefined.")
+                .into());
+        }
+        // 4. If Type(roundTo) is String, then
+        let round_to = if let Some(param_string) = round_to_arg.as_string() {
+            // a. Let paramString be roundTo.
+            let param_string = param_string.clone();
+            // b. Set roundTo to OrdinaryObjectCreate(null).
+            let new_round_to = JsObject::with_null_proto();
+            // c. Perform ! CreateDataPropertyOrThrow(roundTo, "smallestUnit", paramString).
+            new_round_to.create_data_property_or_throw(
+                js_string!("smallestUnit"),
+                param_string,
+                context,
+            )?;
+            new_round_to
+        } else {
             // 5. Else,
-            Some(round_to) => {
-                // a. Set roundTo to ? GetOptionsObject(roundTo).
-                get_options_object(&JsValue::from(round_to))?
-            }
+            // a. Set roundTo to ? GetOptionsObject(roundTo).
+            get_options_object(round_to_arg)?
         };
 
         let mut options = RoundingOptions::default();

--- a/core/engine/src/builtins/temporal/zoneddatetime/mod.rs
+++ b/core/engine/src/builtins/temporal/zoneddatetime/mod.rs
@@ -1469,33 +1469,31 @@ impl ZonedDateTime {
                 JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
             })?;
 
-        let round_to = match args.first().map(JsValue::variant) {
-            // 3. If roundTo is undefined, then
-            None | Some(JsVariant::Undefined) => {
-                // a. Throw a TypeError exception.
-                return Err(JsNativeError::typ()
-                    .with_message("roundTo cannot be undefined.")
-                    .into());
-            }
-            // 4. If Type(roundTo) is String, then
-            Some(JsVariant::String(rt)) => {
-                // a. Let paramString be roundTo.
-                let param_string = rt.clone();
-                // b. Set roundTo to OrdinaryObjectCreate(null).
-                let new_round_to = JsObject::with_null_proto();
-                // c. Perform ! CreateDataPropertyOrThrow(roundTo, "smallestUnit", paramString).
-                new_round_to.create_data_property_or_throw(
-                    js_string!("smallestUnit"),
-                    param_string,
-                    context,
-                )?;
-                new_round_to
-            }
+        // 3. If roundTo is undefined, then
+        let round_to_arg = args.get_or_undefined(0);
+        if round_to_arg.is_undefined() {
+            // a. Throw a TypeError exception.
+            return Err(JsNativeError::typ()
+                .with_message("roundTo cannot be undefined.")
+                .into());
+        }
+        // 4. If Type(roundTo) is String, then
+        let round_to = if let Some(param_string) = round_to_arg.as_string() {
+            // a. Let paramString be roundTo.
+            let param_string = param_string.clone();
+            // b. Set roundTo to OrdinaryObjectCreate(null).
+            let new_round_to = JsObject::with_null_proto();
+            // c. Perform ! CreateDataPropertyOrThrow(roundTo, "smallestUnit", paramString).
+            new_round_to.create_data_property_or_throw(
+                js_string!("smallestUnit"),
+                param_string,
+                context,
+            )?;
+            new_round_to
+        } else {
             // 5. Else,
-            Some(round_to) => {
-                // a. Set roundTo to ? GetOptionsObject(roundTo).
-                get_options_object(&JsValue::from(round_to))?
-            }
+            // a. Set roundTo to ? GetOptionsObject(roundTo).
+            get_options_object(round_to_arg)?
         };
 
         // 6. NOTE: The following steps read options and perform independent validation


### PR DESCRIPTION
# PR: refactor(temporal): remove unnecessary clone in roundTo option parsing

## Summary

The `round` method in 5 Temporal builtins (`Duration`, `Instant`, `PlainDateTime`, `PlainTime`, `ZonedDateTime`) previously matched on `args.first().map(JsValue::variant)` to inspect the `roundTo` argument. In the fallback arm, the extracted `JsVariant` was converted back into a `JsValue` via `JsValue::from(round_to)` just to pass it to `get_options_object(&JsValue)` — an unnecessary round-trip that cloned the inner value.

This PR refactors all 5 call sites to work directly with `&JsValue` via `args.get_or_undefined(0)`, using `is_undefined()` and `as_string()` checks instead of variant pattern matching. This eliminates the clone while preserving identical semantics.

### Changes

- **`duration/mod.rs`** — Replaced `match` on `JsVariant` with `if`/`else` on `&JsValue`
- **`instant/mod.rs`** — Same refactor + removed unused `JsVariant` import
- **`plain_date_time/mod.rs`** — Same refactor + removed unused `JsVariant` import
- **`plain_time/mod.rs`** — Same refactor
- **`zoneddatetime/mod.rs`** — Same refactor

Resolves the `TODO: remove this clone` comments in the affected files.

## Test plan

- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy --all-features --all-targets` passes
- [x] `cargo clippy --no-default-features` passes
- [x] `cargo test -p boa_engine -- temporal` passes
