### PR TITLE
perf(bytecompiler): avoid redundant Constant clone in IC initialization

### DIFF
--- a/core/engine/src/bytecompiler/mod.rs
+++ b/core/engine/src/bytecompiler/mod.rs
@@ -988,10 +988,12 @@ impl<'ctx> ByteCompiler<'ctx> {
         let ic_index = self.ic.len() as u32;
 
         let name_index = self.get_or_insert_name(ident);
-        let Constant::String(ref name) = self.constants[name_index as usize].clone() else {
+        let Constant::String(name) = &self.constants[name_index as usize] else {
             unreachable!("there should be a string at index")
         };
-        self.ic.push(InlineCache::new(name.clone()));
+        let is_length = *name == StaticJsStrings::LENGTH;
+        let name = name.clone();
+        self.ic.push(InlineCache::new(name));
 
         if let Some(receiver) = receiver {
             self.bytecode.emit_get_property_by_name_with_this(
@@ -1000,7 +1002,7 @@ impl<'ctx> ByteCompiler<'ctx> {
                 value.variable(),
                 ic_index.into(),
             );
-        } else if name == &StaticJsStrings::LENGTH {
+        } else if is_length {
             self.bytecode.emit_get_length_property(
                 dst.variable(),
                 value.variable(),
@@ -1025,10 +1027,11 @@ impl<'ctx> ByteCompiler<'ctx> {
         let ic_index = self.ic.len() as u32;
 
         let name_index = self.get_or_insert_name(ident);
-        let Constant::String(ref name) = self.constants[name_index as usize].clone() else {
+        let Constant::String(name) = &self.constants[name_index as usize] else {
             unreachable!("there should be a string at index")
         };
-        self.ic.push(InlineCache::new(name.clone()));
+        let name = name.clone();
+        self.ic.push(InlineCache::new(name));
 
         if let Some(receiver) = receiver {
             self.bytecode.emit_set_property_by_name_with_this(


### PR DESCRIPTION
## perf(bytecompiler): avoid redundant Constant clone in IC initialization

### Description

`emit_get_property_by_name` and `emit_set_property_by_name` were cloning the entire `Constant` enum to extract the inner `JsString`, which was then cloned again for the `InlineCache`. This meant two `JsString` clones per property access site during compilation when only one is needed.

The fix borrows the constant by reference and clones only the `JsString` once.

### Before

```rust
let Constant::String(ref name) = self.constants[name_index as usize].clone() else {
    unreachable!("there should be a string at index")
};
self.ic.push(InlineCache::new(name.clone()));
```

1. `.clone()` on the `Constant` enum clones the inner `JsString`
2. `name.clone()` clones the `JsString` again for the `InlineCache`

### After

```rust
let Constant::String(name) = &self.constants[name_index as usize] else {
    unreachable!("there should be a string at index")
};
let name = name.clone();
self.ic.push(InlineCache::new(name));
```

1. Borrow by reference — no clone
2. Single `JsString` clone, moved directly into the `InlineCache`
