### PR TITLE
feat(compiler): Generate single emit opcode for negative numbers

### DIFF
--- a/core/ast/src/expression/literal/mod.rs
+++ b/core/ast/src/expression/literal/mod.rs
@@ -250,6 +250,27 @@ pub enum LiteralKind {
     Undefined,
 }
 
+/// Represents a numeric value.
+#[derive(Debug, Clone, Copy)]
+pub enum Number {
+    /// An integer.
+    Int(i32),
+    /// A floating point number.
+    Num(f64),
+}
+
+impl LiteralKind {
+    /// Returns [`Number::Int`] for [`LiteralKind::Int`], [`Number::Num`] for [`LiteralKind::Num`], and [`None`] otherwise.
+    #[must_use]
+    pub fn as_number(&self) -> Option<Number> {
+        Some(match self {
+            Self::Int(int) => Number::Int(*int),
+            Self::Num(num) => Number::Num(*num),
+            _ => return None,
+        })
+    }
+}
+
 /// Manual implementation, because `Undefined` is never constructed during parsing.
 #[cfg(feature = "arbitrary")]
 impl<'a> arbitrary::Arbitrary<'a> for LiteralKind {

--- a/core/engine/src/bytecompiler/expression/unary.rs
+++ b/core/engine/src/bytecompiler/expression/unary.rs
@@ -1,5 +1,6 @@
 use crate::bytecompiler::{Access, BindingAccessOpcode, ByteCompiler, Register, ToJsString};
 use boa_ast::Expression;
+use boa_ast::expression::literal::Number;
 use boa_ast::expression::operator::{Unary, unary::UnaryOp};
 
 impl ByteCompiler<'_> {
@@ -18,8 +19,19 @@ impl ByteCompiler<'_> {
                 }
             }
             UnaryOp::Minus => {
-                self.compile_expr(unary.target(), dst);
-                self.bytecode.emit_neg(dst.variable());
+                if let Expression::Literal(literal) = unary.target().flatten()
+                    && let Some(number) = literal.kind().as_number()
+                {
+                    match number {
+                        // Handles special case -0
+                        Number::Int(0) => self.emit_store_rational(-0.0, dst),
+                        Number::Int(value) => self.emit_store_integer(-value, dst),
+                        Number::Num(value) => self.emit_store_rational(-value, dst),
+                    }
+                } else {
+                    self.compile_expr(unary.target(), dst);
+                    self.bytecode.emit_neg(dst.variable());
+                }
             }
             UnaryOp::Plus => {
                 self.compile_expr(unary.target(), dst);


### PR DESCRIPTION
A small optimization that replaces the generated output for simple negative numbers, previously emitting `StoreInt8` followed by `Neg`, with a single `StoreInt8` instruction that directly emits the negative value.