### PR TITLE
Implement support for compact formatting in NumberFormat

### DIFF
--- a/core/engine/Cargo.toml
+++ b/core/engine/Cargo.toml
@@ -176,7 +176,7 @@ icu_segmenter = { workspace = true, default-features = false, features = [
     "serde",
 ], optional = true }
 icu_decimal = { workspace = true, default-features = false, features = [
-    "serde",
+    "serde", "unstable"
 ], optional = true }
 writeable = { workspace = true, optional = true }
 yoke = { workspace = true, optional = true }

--- a/core/engine/src/builtins/bigint/mod.rs
+++ b/core/engine/src/builtins/bigint/mod.rs
@@ -224,11 +224,11 @@ impl BigInt {
     ) -> JsResult<JsValue> {
         #[cfg(feature = "intl")]
         {
-            // 1. Let x be ? ThisBigIntValue(this value).
-
-            use fixed_decimal::Decimal;
-
             use crate::builtins::intl::NumberFormat;
+            use fixed_decimal::Decimal;
+            use writeable::Writeable;
+
+            // 1. Let x be ? ThisBigIntValue(this value).
             let x = Self::this_bigint_value(this)?;
             let locales = args.get_or_undefined(0).clone();
             let options = args.get_or_undefined(1).clone();
@@ -239,7 +239,7 @@ impl BigInt {
                 .map_err(|err| JsNativeError::range().with_message(err.to_string()))?;
 
             // 3. Return FormatNumeric(numberFormat, ℝ(x)).
-            Ok(js_string!(number_format.format(x).to_string()).into())
+            Ok(js_string!(number_format.format(x).write_to_string()).into())
         }
 
         #[cfg(not(feature = "intl"))]

--- a/core/engine/src/builtins/intl/number_format/mod.rs
+++ b/core/engine/src/builtins/intl/number_format/mod.rs
@@ -3,18 +3,17 @@ use std::cell::Cell;
 use boa_gc::{Finalize, Trace, custom_trace};
 use fixed_decimal::{Decimal, FloatPrecision, SignDisplay};
 use icu_decimal::{
-    DecimalFormatter, DecimalFormatterPreferences, FormattedDecimal,
+    CompactDecimalFormatter, DecimalFormatter, DecimalFormatterPreferences, FormattedDecimal,
     options::{DecimalFormatterOptions, GroupingStrategy},
     preferences::NumberingSystem,
     provider::{DecimalDigitsV1, DecimalSymbolsV1},
 };
 
-mod options;
 use icu_locale::{Locale, extensions::unicode::Value};
 use icu_provider::{DataMarker, DataMarkerAttributes, DynamicDataProvider, buf::BufferMarker};
 use num_bigint::BigInt;
 use num_traits::Num;
-pub(crate) use options::*;
+use writeable::Writeable;
 
 use super::{
     Service,
@@ -41,18 +40,84 @@ use crate::{
 };
 use crate::{js_error, value::JsVariant};
 
+mod options;
+pub(crate) use options::*;
+
 #[cfg(test)]
 mod tests;
+
+pub(crate) enum FormattedNumber<'a, T> {
+    Decimal(FormattedDecimal<'a>),
+    Compact(T),
+}
+
+impl<T: Writeable> Writeable for FormattedNumber<'_, T> {
+    fn write_to<W: core::fmt::Write + ?Sized>(&self, sink: &mut W) -> core::fmt::Result {
+        match self {
+            FormattedNumber::Decimal(d) => d.write_to(sink),
+            FormattedNumber::Compact(c) => c.write_to(sink),
+        }
+    }
+
+    fn write_to_parts<S: writeable::PartsWrite + ?Sized>(&self, sink: &mut S) -> core::fmt::Result {
+        match self {
+            FormattedNumber::Decimal(d) => d.write_to_parts(sink),
+            FormattedNumber::Compact(c) => c.write_to_parts(sink),
+        }
+    }
+
+    fn writeable_length_hint(&self) -> writeable::LengthHint {
+        match self {
+            FormattedNumber::Decimal(d) => d.writeable_length_hint(),
+            FormattedNumber::Compact(c) => c.writeable_length_hint(),
+        }
+    }
+
+    fn writeable_borrow(&self) -> Option<&str> {
+        match self {
+            FormattedNumber::Decimal(d) => d.writeable_borrow(),
+            FormattedNumber::Compact(c) => c.writeable_borrow(),
+        }
+    }
+
+    fn write_to_string(&self) -> std::borrow::Cow<'_, str> {
+        match self {
+            FormattedNumber::Decimal(d) => d.write_to_string(),
+            FormattedNumber::Compact(c) => c.write_to_string(),
+        }
+    }
+}
+
+#[derive(Debug)]
+enum Formatter {
+    Standard(DecimalFormatter),
+    Scientific(DecimalFormatter),
+    Engineering(DecimalFormatter),
+    Compact {
+        inner: CompactDecimalFormatter,
+        display: CompactDisplay,
+    },
+}
+
+impl Formatter {
+    fn format<'l>(&'l self, decimal: &'l Decimal) -> FormattedNumber<'l, impl Writeable> {
+        match self {
+            Formatter::Standard(fmt) | Formatter::Scientific(fmt) | Formatter::Engineering(fmt) => {
+                FormattedNumber::Decimal(fmt.format(decimal))
+            }
+            Formatter::Compact { inner, .. } => FormattedNumber::Compact(inner.format(decimal)),
+        }
+    }
+}
 
 #[derive(Debug, Finalize, JsData)]
 // Safety: `NumberFormat` only contains non-traceable types.
 pub(crate) struct NumberFormat {
     locale: Locale,
-    formatter: DecimalFormatter,
+    formatter: Formatter,
     numbering_system: NumberingSystem,
     unit_options: UnitFormatOptions,
     digit_options: DigitFormatOptions,
-    notation: Notation,
     use_grouping: GroupingStrategy,
     sign_display: SignDisplay,
     bound_format: Option<JsFunction>,
@@ -76,9 +141,12 @@ impl NumberFormat {
     ///
     /// [full]: https://tc39.es/ecma402/#sec-formatnumber
     /// [parts]: https://tc39.es/ecma402/#sec-formatnumbertoparts
-    pub(crate) fn format<'a>(&'a self, value: &'a mut Decimal) -> FormattedDecimal<'a> {
+    pub(crate) fn format<'l>(
+        &'l self,
+        value: &'l mut Decimal,
+    ) -> FormattedNumber<'l, impl Writeable> {
         // TODO: Missing support from ICU4X for Percent/Currency/Unit formatting.
-        // TODO: Missing support from ICU4X for Scientific/Engineering/Compact notation.
+        // TODO: Missing support from ICU4X for Scientific/Engineering notation.
 
         self.digit_options.format_fixed_decimal(value);
         value.apply_sign_display(self.sign_display);
@@ -328,22 +396,13 @@ impl NumberFormat {
             get_option(&options, js_string!("compactDisplay"), context)?.unwrap_or_default();
 
         // 22. Let defaultUseGrouping be "auto".
-        let mut default_use_grouping = GroupingStrategy::Auto;
-
-        let notation = match notation {
-            NotationKind::Standard => Notation::Standard,
-            NotationKind::Scientific => Notation::Scientific,
-            NotationKind::Engineering => Notation::Engineering,
-            // 23. If notation is "compact", then
-            NotationKind::Compact => {
-                // b. Set defaultUseGrouping to "min2".
-                default_use_grouping = GroupingStrategy::Min2;
-
-                // a. Set numberFormat.[[CompactDisplay]] to compactDisplay.
-                Notation::Compact {
-                    display: compact_display,
-                }
-            }
+        // 23. If notation is "compact", then
+        //     b. Set defaultUseGrouping to "min2".
+        //     a. Set numberFormat.[[CompactDisplay]] to compactDisplay.
+        let default_use_grouping = if notation == NotationKind::Compact {
+            GroupingStrategy::Min2
+        } else {
+            GroupingStrategy::Auto
         };
 
         // 24. NOTE: For historical reasons, the strings "true" and "false" are accepted and replaced with the default value.
@@ -426,12 +485,52 @@ impl NumberFormat {
                 inner: context.intl_provider().erased_provider(),
                 nu: Cell::new(None),
             };
-            let formatter = DecimalFormatter::try_new_with_buffer_provider(
-                &inspector,
-                (&locale).into(),
-                options,
-            )
-            .map_err(|err| JsNativeError::typ().with_message(err.to_string()))?;
+
+            let formatter = match (notation, compact_display) {
+                // TODO: change when scientific/engineering have their own formatters.
+                (NotationKind::Standard, _) => Formatter::Standard(
+                    DecimalFormatter::try_new_with_buffer_provider(
+                        &inspector,
+                        (&locale).into(),
+                        options,
+                    )
+                    .map_err(|err| js_error!(TypeError: "{}", err.to_string()))?,
+                ),
+                (NotationKind::Scientific, _) => Formatter::Scientific(
+                    DecimalFormatter::try_new_with_buffer_provider(
+                        &inspector,
+                        (&locale).into(),
+                        options,
+                    )
+                    .map_err(|err| js_error!(TypeError: "{}", err.to_string()))?,
+                ),
+                (NotationKind::Engineering, _) => Formatter::Engineering(
+                    DecimalFormatter::try_new_with_buffer_provider(
+                        &inspector,
+                        (&locale).into(),
+                        options,
+                    )
+                    .map_err(|err| js_error!(TypeError: "{}", err.to_string()))?,
+                ),
+                (NotationKind::Compact, CompactDisplay::Long) => Formatter::Compact {
+                    inner: CompactDecimalFormatter::try_new_long_with_buffer_provider(
+                        &inspector,
+                        (&locale).into(),
+                        options.into(),
+                    )
+                    .map_err(|err| js_error!(TypeError: "{}", err.to_string()))?,
+                    display: CompactDisplay::Long,
+                },
+                (NotationKind::Compact, CompactDisplay::Short) => Formatter::Compact {
+                    inner: CompactDecimalFormatter::try_new_short_with_buffer_provider(
+                        &inspector,
+                        (&locale).into(),
+                        options.into(),
+                    )
+                    .map_err(|err| js_error!(TypeError: "{}", err.to_string()))?,
+                    display: CompactDisplay::Short,
+                },
+            };
 
             let nu = (|| {
                 let nu = inspector.nu.into_inner()?;
@@ -453,7 +552,6 @@ impl NumberFormat {
             formatter,
             unit_options,
             digit_options,
-            notation,
             use_grouping,
             sign_display,
             bound_format: None,
@@ -521,7 +619,7 @@ impl NumberFormat {
                         let mut x = to_intl_mathematical_value(value, context)?;
 
                         // 5. Return FormatNumeric(nf, x).
-                        Ok(js_string!(nf.borrow().data().format(&mut x).to_string()).into())
+                        Ok(js_string!(nf.borrow().data().format(&mut x).write_to_string()).into())
                     },
                     nf_clone,
                 ),
@@ -667,15 +765,22 @@ impl NumberFormat {
             }
         };
 
-        options
-            .property(js_string!("useGrouping"), use_grouping, Attribute::all())
-            .property(
-                js_string!("notation"),
-                nf.notation.kind().to_js_string(),
-                Attribute::all(),
-            );
+        options.property(js_string!("useGrouping"), use_grouping, Attribute::all());
 
-        if let Notation::Compact { display } = nf.notation {
+        let (notation, compact_display) = match &nf.formatter {
+            Formatter::Standard(_) => (NotationKind::Standard, None),
+            Formatter::Scientific(_) => (NotationKind::Scientific, None),
+            Formatter::Engineering(_) => (NotationKind::Engineering, None),
+            Formatter::Compact { display, .. } => (NotationKind::Compact, Some(*display)),
+        };
+
+        options.property(
+            js_string!("notation"),
+            notation.to_js_string(),
+            Attribute::all(),
+        );
+
+        if let Some(display) = compact_display {
             options.property(
                 js_string!("compactDisplay"),
                 display.to_js_string(),

--- a/core/engine/src/builtins/intl/number_format/options.rs
+++ b/core/engine/src/builtins/intl/number_format/options.rs
@@ -1100,25 +1100,6 @@ impl std::str::FromStr for NotationKind {
 
 impl ParsableOptionType for NotationKind {}
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
-pub(crate) enum Notation {
-    Standard,
-    Scientific,
-    Engineering,
-    Compact { display: CompactDisplay },
-}
-
-impl Notation {
-    pub(crate) fn kind(self) -> NotationKind {
-        match self {
-            Notation::Standard => NotationKind::Standard,
-            Notation::Scientific => NotationKind::Scientific,
-            Notation::Engineering => NotationKind::Engineering,
-            Notation::Compact { .. } => NotationKind::Compact,
-        }
-    }
-}
-
 #[derive(Debug, Copy, Clone, Default, Eq, PartialEq)]
 pub(crate) enum RoundingPriority {
     #[default]

--- a/core/engine/src/builtins/number/mod.rs
+++ b/core/engine/src/builtins/number/mod.rs
@@ -313,6 +313,7 @@ impl Number {
         #[cfg(feature = "intl")]
         {
             use fixed_decimal::{Decimal, FloatPrecision};
+            use writeable::Writeable;
 
             use crate::builtins::intl::NumberFormat;
 
@@ -329,7 +330,7 @@ impl Number {
                 .map_err(|err| JsNativeError::range().with_message(err.to_string()))?;
 
             // 3. Return FormatNumeric(numberFormat, ! ToIntlMathematicalValue(x)).
-            Ok(js_string!(number_format.format(&mut x).to_string()).into())
+            Ok(js_string!(number_format.format(&mut x).write_to_string()).into())
         }
 
         #[cfg(not(feature = "intl"))]


### PR DESCRIPTION
Implements compact formatting for `NumberFormat` with ICU4X 2.2's newly introduced (but unstable) `CompactDecimalFormatter`.

Not worried about using unstable since this change only affects how we handle `NumberFormat` construction.