### PR TITLE
fix(vm): reset implicit return value when pushing new call frames (#4…

### DIFF
--- a/core/engine/src/tests/function.rs
+++ b/core/engine/src/tests/function.rs
@@ -100,6 +100,50 @@ fn implicit_constructor_return_does_not_leak_completion_value_from_same_eval() {
     ]);
 }
 
+/// Regression test for issue #4485.
+/// Checks that generator resumption via `g.next(f())` is not affected
+/// by resetting the accumulator in `push_frame`.
+#[test]
+fn generator_resumption_not_affected_by_return_value_reset() {
+    run_test_actions([TestAction::assert(indoc! {r#"
+        let seen;
+
+        function* gen() {
+            seen = yield 1;
+        }
+
+        function f() {}
+
+        5;
+        var g = gen();
+        g.next();
+        g.next(f());
+        seen === undefined;
+    "#})]);
+}
+
+/// Regression test for issue #4485.
+/// Checks that generator resumption via `g.next(new f())` receives
+/// the constructed object, not a stale caller expression.
+#[test]
+fn generator_resumption_with_constructor_not_affected_by_return_value_reset() {
+    run_test_actions([TestAction::assert(indoc! {r#"
+        let seen;
+
+        function* gen() {
+            seen = yield 1;
+        }
+
+        function f() {}
+
+        ({});
+        var g = gen();
+        g.next();
+        g.next(new f());
+        Object.getPrototypeOf(seen) === f.prototype;
+    "#})]);
+}
+
 #[test]
 fn property_accessor_member_expression_dot_notation_on_function() {
     run_test_actions([TestAction::assert_eq(

--- a/core/engine/src/vm/mod.rs
+++ b/core/engine/src/vm/mod.rs
@@ -586,6 +586,9 @@ impl Vm {
     }
 
     pub(crate) fn push_frame(&mut self, mut frame: CallFrame) {
+        // Each function call starts with an implicit `undefined` return value.
+        self.return_value = JsValue::undefined();
+
         // NOTE: We need to check if we already pushed the registers,
         //       since generator-like functions push the same call
         //       frame with pre-built stack and registers (fp and rp already set).


### PR DESCRIPTION
# PR: fix(vm): reset implicit return value when pushing new call frames

Fixes #4485.

`Vm::return_value` is shared across all call frames but never gets reset in `push_frame()`. This means functions without an explicit `return` leak the caller's last evaluated expression as their return value:

```js
function f() {}
5;
f(); // returns 5 instead of undefined
```

What happens is `SetAccumulator` writes `5` into `vm.return_value` for the caller, then `f()` pushes a new frame without clearing it. When `f` returns, `handle_return()` picks up the stale `5`.

The fix resets `self.return_value = JsValue::undefined()` at the top of `push_frame()`.

### Generators

This was the main concern from the PR #4713 review — whether resetting in `push_frame()` would break generator resumption since `GeneratorContext::resume()` also calls `push_frame()` with `REGISTERS_ALREADY_PUSHED`.

Traced through the code and it's fine: `GeneratorYield` sets `return_value` explicitly before calling `handle_yield()`, and `handle_yield()` consumes it via `take_return_value()`. On resume, the generator runs more opcodes and will set a fresh `return_value` before the next yield/return. The reset only affects the initial state going into the frame, which is what we want.

Added generator-specific regression tests as @jedel1043 requested in #4713.

### Tests

- Plain functions leaking caller values
- Constructor implicit returns
- Cross-eval isolation
- Generator yield + return correctness
- Generator implicit return producing `undefined`
- Nested call chain independence
