### PR TITLE
Fix a spec violation in `Date.prototype.toLocaleString`

### DIFF
--- a/core/engine/src/builtins/intl/date_time_format/mod.rs
+++ b/core/engine/src/builtins/intl/date_time_format/mod.rs
@@ -1025,24 +1025,6 @@ pub(crate) fn format_date_time_locale(
     context: &mut Context,
 ) -> JsResult<JsValue> {
     let options = coerce_options_to_object(options, context)?;
-    if format_type != FormatType::Time
-        && get_option::<DateStyle>(&options, js_string!("dateStyle"), context)?.is_none()
-    {
-        options.create_data_property_or_throw(
-            js_string!("dateStyle"),
-            JsValue::from(js_string!("long")),
-            context,
-        )?;
-    }
-    if format_type != FormatType::Date
-        && get_option::<TimeStyle>(&options, js_string!("timeStyle"), context)?.is_none()
-    {
-        options.create_data_property_or_throw(
-            js_string!("timeStyle"),
-            JsValue::from(js_string!("long")),
-            context,
-        )?;
-    }
     let options_value = options.into();
     let dtf = create_date_time_format(locales, &options_value, format_type, defaults, context)?;
     // FormatDateTime steps 1–2: TimeClip and NaN check (format_timestamp_with_dtf does ToLocalTime + format only).

--- a/core/engine/src/builtins/intl/date_time_format/tests.rs
+++ b/core/engine/src/builtins/intl/date_time_format/tests.rs
@@ -65,3 +65,26 @@ fn dtf_basic() {
         TestAction::assert_eq("result === 'Sunday, 20 December 2020 at 14:23:16'", true),
     ]);
 }
+
+#[cfg(feature = "intl_bundled")]
+#[test]
+fn date_to_locale_string() {
+    run_test_actions([
+        TestAction::run(indoc! {"
+            // Setup date
+            const date = new Date(Date.UTC(2021, 3, 12, 6, 7));
+
+            let result = date.toLocaleString('en-US', { dateStyle: 'short' });
+        "}),
+        TestAction::assert_eq("result === '4/12/21'", true),
+    ]);
+    run_test_actions([
+        TestAction::run(indoc! {"
+            // Setup date
+            const date = new Date(Date.UTC(2021, 3, 12, 6, 7));
+
+            let result = date.toLocaleString('en-US', { timeStyle: 'short' });
+        "}),
+        TestAction::assert_eq("result === '6:07\u{202f}AM'", true),
+    ]);
+}


### PR DESCRIPTION
This Pull Request fixes/closes #5323 

**Changes**
- Eliminates the code which broke the standard behavior, when calling `Date.prototype.toLocaleString` with `dateStyle/timeStyle` options.
- Adds a regression test to ensure that `dateStyle` and `timeStyle` don't force a fallback to a combined date-time string, as per ECMA-402

**Validation**
- Run (all passed)
```
cargo test --package boa_engine --lib --features intl_bundled -- builtins::intl::date_time_format::tests --nocapture
```
- Manual check
```javascript
>> const date = new Date(Date.UTC(2024, 2, 10, 2, 30))
undefined
>> date.toLocaleString("en-US", {dateStyle: "short"})
"3/10/24"
>> date.toLocaleString("en-US", {timeStyle: "short"})
"2:30\u{202f}AM"
```

