### PR TITLE
fix(lexer): replace Error::unexpected with Error::syntax for unknown …

### DIFF
--- a/core/parser/src/lexer/error.rs
+++ b/core/parser/src/lexer/error.rs
@@ -41,20 +41,6 @@ impl Error {
     {
         Self::Syntax(err.into(), pos.into())
     }
-
-    /// Creates an "unexpected" syntax error (found X, with message).
-    #[inline]
-    pub(crate) fn unexpected<F, M, P>(found: F, message: M, pos: P) -> Self
-    where
-        F: fmt::Display,
-        M: Into<Box<str>>,
-        P: Into<Position>,
-    {
-        Self::Syntax(
-            format!("unexpected {found}, {}", message.into().as_ref()).into(),
-            pos.into(),
-        )
-    }
 }
 
 impl fmt::Display for Error {

--- a/core/parser/src/lexer/operator.rs
+++ b/core/parser/src/lexer/operator.rs
@@ -163,9 +163,11 @@ impl<R> Tokenizer<R> for Operator {
                 Token::new_by_position_group(Punctuator::Neg.into(), start_pos, cursor.pos_group())
             }
             op => {
-                return Err(Error::unexpected(
-                    char::from(op),
-                    "expected valid operator",
+                return Err(Error::syntax(
+                    format!(
+                        "unexpected character '{}' in operator",
+                        char::from_u32(u32::from(op)).unwrap_or('\u{FFFD}')
+                    ),
                     start_pos.position(),
                 ));
             }


### PR DESCRIPTION
## fix(lexer): replace Error::unexpected with Error::syntax for unknown operators

Resubmit of #4985 (approved but closed before merging due to automation).

The operator lexer's catch-all arm used `Error::unexpected`, which produces a generic "expected valid operator" message. This replaces it with `Error::syntax` and a formatted message that includes the actual character, making it easier to diagnose malformed input.

Also removes the now-unused `Error::unexpected` method from the lexer error module to keep `-D warnings` clean. The parser error module has its own `unexpected` method which is unaffected.

### Changes

- `core/parser/src/lexer/operator.rs` — switch from `Error::unexpected` to `Error::syntax` with descriptive format string
- `core/parser/src/lexer/error.rs` — remove unused `unexpected` method
