### PR TITLE
test(regexp): enable duplicate named capturing groups tests

### DIFF
--- a/test262_config.toml
+++ b/test262_config.toml
@@ -12,7 +12,6 @@ features = [
     "Intl.RelativeTimeFormat",
     "Intl-enumeration",
     "Intl.DurationFormat",
-    "regexp-duplicate-named-groups",
     "explicit-resource-management",
     "joint-iteration",
 
@@ -79,8 +78,6 @@ tests = [
     "test/intl402/Locale/prototype/calendar/canonicalize.js",
     "test/intl402/Locale/constructor-non-iana-canon.js",
     "test/intl402/Locale/constructor-options-canonicalized.js",
-    # TODO: Remove this once regress fixes the named groups parsing issue.
-    "test/built-ins/RegExp/named-groups/non-unicode-property-names-valid.js",
     # Source Phase Imports: AbstractModuleSource built-in and static `import source` not yet implemented.
     "test/built-ins/AbstractModuleSource/proto.js",
     "test/built-ins/AbstractModuleSource/name.js",


### PR DESCRIPTION
## test(regexp): enable duplicate named capturing groups tests

Closes #4442.

The `regress` crate v0.11.1 (already in our dependencies) supports duplicate named capturing groups. This removes the feature skip and individual test skip that were blocking test262 coverage for this Stage 4 proposal.

### Changes

- Remove `"regexp-duplicate-named-groups"` from ignored features in `test262_config.toml`
- Remove the `non-unicode-property-names-valid.js` test skip (its TODO comment says to remove once regress fixes named groups parsing, which v0.11 did)

The `SpecEdition::ES16` mapping in `edition.rs` was already in place.
