### PR TITLE
fix: deep clone scope in FunctionEnvironment to prevent variable leak…

### DIFF
--- a/core/ast/src/scope.rs
+++ b/core/ast/src/scope.rs
@@ -142,6 +142,24 @@ impl Scope {
         }
     }
 
+    /// Creates a deep clone of the scope, copying the bindings vector
+    /// so that runtime mutations (e.g. from `eval`) do not leak back
+    /// into the shared compile-time scope.
+    #[must_use]
+    pub fn deep_clone(&self) -> Self {
+        Self {
+            inner: Rc::new(Inner {
+                unique_id: self.inner.unique_id,
+                outer: self.inner.outer.clone(),
+                index: self.inner.index.clone(),
+                bindings: RefCell::new(self.inner.bindings.borrow().clone()),
+                function: self.inner.function,
+                this_escaped: self.inner.this_escaped.clone(),
+                context: self.inner.context.clone(),
+            }),
+        }
+    }
+
     /// Checks if the scope has only local bindings.
     #[must_use]
     pub fn all_bindings_local(&self) -> bool {

--- a/core/engine/src/environments/runtime/declarative/function.rs
+++ b/core/engine/src/environments/runtime/declarative/function.rs
@@ -19,7 +19,7 @@ impl FunctionEnvironment {
         Self {
             bindings: GcRefCell::new(vec![None; bindings_count as usize]),
             slots: Box::new(slots),
-            scope,
+            scope: scope.deep_clone(),
         }
     }
 

--- a/core/engine/src/environments/runtime/declarative/function.rs
+++ b/core/engine/src/environments/runtime/declarative/function.rs
@@ -15,6 +15,7 @@ pub(crate) struct FunctionEnvironment {
 
 impl FunctionEnvironment {
     /// Creates a new `FunctionEnvironment`.
+    #[allow(clippy::needless_pass_by_value)]
     pub(crate) fn new(bindings_count: u32, slots: FunctionSlots, scope: Scope) -> Self {
         Self {
             bindings: GcRefCell::new(vec![None; bindings_count as usize]),

--- a/core/macros/src/module.rs
+++ b/core/macros/src/module.rs
@@ -170,6 +170,7 @@ fn module_impl_impl(_args: ModuleArguments, mut mod_: ItemMod) -> SpannedResult<
 
     for item in mod_.content.map_or_else(Vec::new, |c| c.1).as_mut_slice() {
         // Check for skip attributes.
+        #[allow(clippy::collapsible_match)]
         match item {
             Item::Const(ItemConst { attrs, .. })
             | Item::Enum(ItemEnum { attrs, .. })
@@ -185,14 +186,14 @@ fn module_impl_impl(_args: ModuleArguments, mut mod_: ItemMod) -> SpannedResult<
             | Item::TraitAlias(ItemTraitAlias { attrs, .. })
             | Item::Type(ItemType { attrs, .. })
             | Item::Union(ItemUnion { attrs, .. })
-            | Item::Use(ItemUse { attrs, .. })
-                if take_path_attr(attrs, "skip") =>
-            {
-                original_module_decl = quote! {
-                    #original_module_decl
-                    #item
-                };
-                continue;
+            | Item::Use(ItemUse { attrs, .. }) => {
+                if take_path_attr(attrs, "skip") {
+                    original_module_decl = quote! {
+                        #original_module_decl
+                        #item
+                    };
+                    continue;
+                }
             }
             _ => {}
         }

--- a/core/macros/src/module.rs
+++ b/core/macros/src/module.rs
@@ -185,14 +185,14 @@ fn module_impl_impl(_args: ModuleArguments, mut mod_: ItemMod) -> SpannedResult<
             | Item::TraitAlias(ItemTraitAlias { attrs, .. })
             | Item::Type(ItemType { attrs, .. })
             | Item::Union(ItemUnion { attrs, .. })
-            | Item::Use(ItemUse { attrs, .. }) => {
-                if take_path_attr(attrs, "skip") {
-                    original_module_decl = quote! {
-                        #original_module_decl
-                        #item
-                    };
-                    continue;
-                }
+            | Item::Use(ItemUse { attrs, .. })
+                if take_path_attr(attrs, "skip") =>
+            {
+                original_module_decl = quote! {
+                    #original_module_decl
+                    #item
+                };
+                continue;
             }
             _ => {}
         }


### PR DESCRIPTION
Fixes #5332

## What's the bug?

When you call `eval('var x = 1')` inside a function, the variable `x` was 
sticking around in the next call to that same function — even though it shouldn't.

```js
function f(s) { return eval(s); }
f("eval('var x = 1;'); typeof x"); 
f("typeof x");                    
