### PR TITLE
Fix console grouping indentation and add compatibility methods

### DIFF
--- a/cli/src/logger.rs
+++ b/cli/src/logger.rs
@@ -45,7 +45,7 @@ impl Logger for SharedExternalPrinterLogger {
     #[inline]
     fn log(&self, msg: String, state: &ConsoleState, _context: &mut Context) -> JsResult<()> {
         let indent = state.indent();
-        self.print(format!("{msg:>indent$}\n"));
+        self.print(format!("{:indent$}{msg}\n", ""));
         Ok(())
     }
 
@@ -62,7 +62,7 @@ impl Logger for SharedExternalPrinterLogger {
     #[inline]
     fn error(&self, msg: String, state: &ConsoleState, _context: &mut Context) -> JsResult<()> {
         let indent = state.indent();
-        self.print(format!("{msg:>indent$}\n"));
+        self.print(format!("{:indent$}{msg}\n", ""));
         Ok(())
     }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -410,33 +410,42 @@ fn evaluate_expr(
             Ok(v) => println!("{v}"),
             Err(v) => eprintln!("{v:?}"),
         }
-    } else {
-        let mut counters = Counters::new(args.time);
-        let script = {
-            let _timer = counters.new_timer("Parsing");
-            Script::parse(Source::from_bytes(line), None, context)
-        };
-
-        match script {
-            Ok(script) => {
-                let result = {
-                    let _timer = counters.new_timer("Execution");
-                    let result = script.evaluate(context);
-                    if let Err(err) = context.run_jobs() {
-                        printer.print(uncaught_job_error(&err));
-                    }
-                    result
-                };
-                match result {
-                    Ok(v) => printer.print(format!("{}\n", v.display())),
-                    Err(ref v) => printer.print(uncaught_error(v)),
-                }
-            }
-            Err(ref v) => printer.print(uncaught_error(v)),
-        }
+        return Ok(());
     }
 
-    Ok(())
+    let mut counters = Counters::new(args.time);
+    let script = {
+        let _timer = counters.new_timer("Parsing");
+        Script::parse(Source::from_bytes(line), None, context)
+    };
+
+    match script {
+        Ok(script) => {
+            let result = {
+                let _timer = counters.new_timer("Execution");
+                let result = script.evaluate(context);
+                if let Err(err) = context.run_jobs() {
+                    printer.print(uncaught_job_error(&err));
+                    return Err(eyre!("Job evaluation failed"));
+                }
+                result
+            };
+            match result {
+                Ok(v) => {
+                    printer.print(format!("{}\n", v.display()));
+                    Ok(())
+                }
+                Err(ref v) => {
+                    printer.print(uncaught_error(v));
+                    Err(eyre!("Expression execution failed"))
+                }
+            }
+        }
+        Err(ref v) => {
+            printer.print(uncaught_error(v));
+            Err(eyre!("Parsing failed"))
+        }
+    }
 }
 
 fn evaluate_file(
@@ -518,11 +527,13 @@ fn evaluate_file(
             if !v.is_undefined() {
                 println!("{}", v.display());
             }
+            Ok(())
         }
-        Err(v) => printer.print(uncaught_error(&v)),
+        Err(v) => {
+            printer.print(uncaught_error(&v));
+            Err(eyre!("Script execution failed"))
+        }
     }
-
-    Ok(())
 }
 
 fn evaluate_files(

--- a/core/runtime/src/console/mod.rs
+++ b/core/runtime/src/console/mod.rs
@@ -97,7 +97,7 @@ impl Logger for DefaultLogger {
     #[inline]
     fn log(&self, msg: String, state: &ConsoleState, _context: &mut Context) -> JsResult<()> {
         let indent = state.indent();
-        writeln!(std::io::stdout(), "{msg:>indent$}").map_err(JsError::from_rust)
+        writeln!(std::io::stdout(), "{:indent$}{msg}", "").map_err(JsError::from_rust)
     }
 
     #[inline]
@@ -113,7 +113,7 @@ impl Logger for DefaultLogger {
     #[inline]
     fn error(&self, msg: String, state: &ConsoleState, _context: &mut Context) -> JsResult<()> {
         let indent = state.indent();
-        writeln!(std::io::stderr(), "{msg:>indent$}").map_err(JsError::from_rust)
+        writeln!(std::io::stderr(), "{:indent$}{msg}", "").map_err(JsError::from_rust)
     }
 }
 
@@ -384,6 +384,11 @@ impl Console {
             0,
         )
         .function(
+            console_method(Self::error, state.clone(), logger.clone()),
+            js_string!("exception"),
+            0,
+        )
+        .function(
             console_method(Self::warn, state.clone(), logger.clone()),
             js_string!("warn"),
             0,
@@ -434,8 +439,23 @@ impl Console {
             0,
         )
         .function(
-            console_method(Self::dir, state, logger.clone()),
+            console_method(Self::dir, state.clone(), logger.clone()),
             js_string!("dirxml"),
+            0,
+        )
+        .function(
+            console_method(Self::time_stamp, state.clone(), logger.clone()),
+            js_string!("timeStamp"),
+            0,
+        )
+        .function(
+            console_method(Self::profile, state.clone(), logger.clone()),
+            js_string!("profile"),
+            0,
+        )
+        .function(
+            console_method(Self::profile_end, state, logger.clone()),
+            js_string!("profileEnd"),
             0,
         )
         .build()
@@ -915,6 +935,45 @@ impl Console {
             &console.state,
             context,
         )?;
+        Ok(JsValue::undefined())
+    }
+
+    /// `console.timeStamp(label)`
+    ///
+    /// This method is a no-op in Boa.
+    fn time_stamp(
+        _: &JsValue,
+        _: &[JsValue],
+        _: &Self,
+        _: &impl Logger,
+        _: &mut Context,
+    ) -> JsResult<JsValue> {
+        Ok(JsValue::undefined())
+    }
+
+    /// `console.profile(label)`
+    ///
+    /// This method is a no-op in Boa.
+    fn profile(
+        _: &JsValue,
+        _: &[JsValue],
+        _: &Self,
+        _: &impl Logger,
+        _: &mut Context,
+    ) -> JsResult<JsValue> {
+        Ok(JsValue::undefined())
+    }
+
+    /// `console.profileEnd(label)`
+    ///
+    /// This method is a no-op in Boa.
+    fn profile_end(
+        _: &JsValue,
+        _: &[JsValue],
+        _: &Self,
+        _: &impl Logger,
+        _: &mut Context,
+    ) -> JsResult<JsValue> {
         Ok(JsValue::undefined())
     }
 }

--- a/core/runtime/src/console/tests.rs
+++ b/core/runtime/src/console/tests.rs
@@ -123,7 +123,7 @@ impl Logger for RecordingLogger {
     fn log(&self, msg: String, state: &ConsoleState, _: &mut Context) -> JsResult<()> {
         use std::fmt::Write;
         let indent = state.indent();
-        writeln!(self.log.borrow_mut(), "{msg:>indent$}").map_err(JsError::from_rust)
+        writeln!(self.log.borrow_mut(), "{:indent$}{msg}", "").map_err(JsError::from_rust)
     }
 
     fn info(&self, msg: String, state: &ConsoleState, context: &mut Context) -> JsResult<()> {


### PR DESCRIPTION
This PR fixes indentation in console.group() and adds console.exception(), console.timeStamp(), console.profile(), and console.profileEnd().