### PR TITLE
Remove manual Headers iterator registration

### DIFF
--- a/core/runtime/src/fetch/mod.rs
+++ b/core/runtime/src/fetch/mod.rs
@@ -8,16 +8,13 @@
 //! [mdn]: https://developer.mozilla.org/en-US/docs/Web/API/fetch
 
 use crate::fetch::headers::JsHeaders;
-use crate::fetch::headers_iterator::{HeadersIterator, IterationKind};
 use crate::fetch::request::{JsRequest, RequestInit};
 use crate::fetch::response::JsResponse;
 use boa_engine::class::Class;
-use boa_engine::object::FunctionObjectBuilder;
-use boa_engine::property::PropertyDescriptor;
 use boa_engine::realm::Realm;
 use boa_engine::{
-    Context, Finalize, JsData, JsError, JsObject, JsResult, JsString, JsSymbol, JsValue,
-    NativeObject, Trace, boa_module, js_error, js_string, native_function::NativeFunction,
+    Context, Finalize, JsData, JsError, JsObject, JsResult, JsString, JsValue, NativeObject, Trace,
+    boa_module, js_error,
 };
 use either::Either;
 use http::{HeaderName, HeaderValue, Request as HttpRequest, Request};
@@ -209,24 +206,6 @@ pub mod js_module {
     }
 }
 
-fn headers_symbol_iterator(
-    this: &JsValue,
-    _: &[JsValue],
-    context: &mut Context,
-) -> JsResult<JsValue> {
-    let this_object = this.as_object().ok_or_else(
-        || js_error!(TypeError: "`Headers.prototype[Symbol.iterator]` requires a `Headers` object"),
-    )?;
-
-    let Ok(headers) = this_object.clone().downcast::<JsHeaders>() else {
-        return Err(
-            js_error!(TypeError: "`Headers.prototype[Symbol.iterator]` requires a `Headers` object"),
-        );
-    };
-
-    HeadersIterator::create_headers_iterator(headers, IterationKind::KeyAndValue, context)
-}
-
 /// Register the `fetch` function in the realm, as well as ALL supporting classes.
 /// Pass `None` as the realm to register globally.
 ///
@@ -243,34 +222,5 @@ pub fn register<F: Fetcher>(
         context.insert_data(FetcherRc(Rc::new(fetcher)));
     }
     js_module::boa_register::<F>(realm.clone(), context)?;
-
-    // TODO(#4688): Replace this manual `[Symbol.iterator]` wiring once `#[boa(class)]`
-    // supports symbol-named methods.
-    let headers_proto = match realm {
-        Some(realm) => realm.get_class::<JsHeaders>(),
-        None => context.get_global_class::<JsHeaders>(),
-    }
-    .ok_or_else(|| js_error!(Error: "Headers class should be registered"))?
-    .prototype();
-
-    let iterator = FunctionObjectBuilder::new(
-        context.realm(),
-        NativeFunction::from_fn_ptr(headers_symbol_iterator),
-    )
-    .name(js_string!("[Symbol.iterator]"))
-    .length(0)
-    .constructor(false)
-    .build();
-
-    headers_proto.define_property_or_throw(
-        JsSymbol::iterator(),
-        PropertyDescriptor::builder()
-            .value(iterator)
-            .writable(true)
-            .enumerable(false)
-            .configurable(true),
-        context,
-    )?;
-
     Ok(())
 }

--- a/core/runtime/src/fetch/tests/headers.rs
+++ b/core/runtime/src/fetch/tests/headers.rs
@@ -132,7 +132,6 @@ fn headers_iterator_throws_on_invalid_this() {
                     throw Error("expected the call above to throw");
                 } catch (e) {
                     assert(e instanceof TypeError);
-                    assertEq(e.message, "`Headers.prototype[Symbol.iterator]` requires a `Headers` object");
                 }
 
                 try {
@@ -140,7 +139,6 @@ fn headers_iterator_throws_on_invalid_this() {
                     throw Error("expected the call above to throw");
                 } catch (e) {
                     assert(e instanceof TypeError);
-                    assertEq(e.message, "`Headers.prototype[Symbol.iterator]` requires a `Headers` object");
                 }
             "#,
         ),


### PR DESCRIPTION
This Pull Request is a follow-up to #4697, which closed #4688.

It changes the following:

- Removes the remaining manual `Headers.prototype[Symbol.iterator]` registration from fetch runtime setup.
- Uses the existing `#[boa(symbol = "iterator")]` class method as the single implementation path.
- Updates the invalid receiver regression test to assert the `TypeError` contract instead of the old manual error message.

Tests run:

- `cargo fmt --check`
- `git diff --check`
- `cargo test -p boa_runtime headers`
- `cargo test -p boa_engine recursion_in`
- `cargo test`