### PR TITLE
fix: class constructor scope index mismatch and arguments binding slot allocation

### DIFF
--- a/core/ast/src/scope.rs
+++ b/core/ast/src/scope.rs
@@ -218,7 +218,7 @@ impl Scope {
     pub fn num_bindings_non_local(&self) -> u32 {
         let arguments = JsString::from("arguments");
         let bindings = self.inner.bindings.borrow();
-        
+
         drop(bindings);
         self.inner
             .bindings

--- a/core/ast/src/scope.rs
+++ b/core/ast/src/scope.rs
@@ -216,11 +216,15 @@ impl Scope {
     #[must_use]
     #[allow(clippy::cast_possible_truncation)]
     pub fn num_bindings_non_local(&self) -> u32 {
+        let arguments = JsString::from("arguments");
+        let bindings = self.inner.bindings.borrow();
+        
+        drop(bindings);
         self.inner
             .bindings
             .borrow()
             .iter()
-            .filter(|binding| binding.escapes())
+            .filter(|binding| binding.escapes() || binding.name == arguments)
             .count() as u32
     }
 

--- a/core/engine/src/bytecompiler/class.rs
+++ b/core/engine/src/bytecompiler/class.rs
@@ -119,7 +119,7 @@ impl ByteCompiler<'_> {
                     let _ = compiler.push_scope(name_scope);
                 }
             }
-        
+
             let contains_direct_eval = expr.contains_direct_eval();
             if contains_direct_eval || !expr.scopes().function_scope().all_bindings_local() {
                 compiler.code_block_flags |= CodeBlockFlags::HAS_FUNCTION_SCOPE;
@@ -129,14 +129,14 @@ impl ByteCompiler<'_> {
                     expr.scopes().requires_function_scope(),
                 );
             }
-        
+
             if compiler.code_block_flags.has_function_scope() {
                 let _ = compiler.push_scope(expr.scopes().function_scope());
             } else {
                 compiler.variable_scope = expr.scopes().function_scope().clone();
                 compiler.lexical_scope = expr.scopes().function_scope().clone();
             }
-        
+
             compiler.length = expr.parameters().length();
             compiler.params = expr.parameters().clone();
             compiler.parameter_scope = expr.scopes().parameter_scope();

--- a/core/engine/src/bytecompiler/class.rs
+++ b/core/engine/src/bytecompiler/class.rs
@@ -112,13 +112,34 @@ impl ByteCompiler<'_> {
 
         let value = compiler.register_allocator.alloc();
         if let Some(expr) = &class.constructor {
-            compiler.code_block_flags |= CodeBlockFlags::HAS_FUNCTION_SCOPE;
-            let _ = compiler.push_scope(expr.scopes().function_scope());
-
+            // function.rs の FunctionCompiler と同じロジックでスコープをpush
+            if let Some(name_scope) = class.name_scope {
+                if !name_scope.all_bindings_local() {
+                    compiler.code_block_flags |= CodeBlockFlags::HAS_BINDING_IDENTIFIER;
+                    let _ = compiler.push_scope(name_scope);
+                }
+            }
+        
+            let contains_direct_eval = expr.contains_direct_eval();
+            if contains_direct_eval || !expr.scopes().function_scope().all_bindings_local() {
+                compiler.code_block_flags |= CodeBlockFlags::HAS_FUNCTION_SCOPE;
+            } else {
+                compiler.code_block_flags.set(
+                    CodeBlockFlags::HAS_FUNCTION_SCOPE,
+                    expr.scopes().requires_function_scope(),
+                );
+            }
+        
+            if compiler.code_block_flags.has_function_scope() {
+                let _ = compiler.push_scope(expr.scopes().function_scope());
+            } else {
+                compiler.variable_scope = expr.scopes().function_scope().clone();
+                compiler.lexical_scope = expr.scopes().function_scope().clone();
+            }
+        
             compiler.length = expr.parameters().length();
             compiler.params = expr.parameters().clone();
             compiler.parameter_scope = expr.scopes().parameter_scope();
-
             compiler.function_declaration_instantiation(
                 expr.body(),
                 expr.parameters(),

--- a/core/engine/src/bytecompiler/class.rs
+++ b/core/engine/src/bytecompiler/class.rs
@@ -113,11 +113,11 @@ impl ByteCompiler<'_> {
         let value = compiler.register_allocator.alloc();
         if let Some(expr) = &class.constructor {
             // function.rs の FunctionCompiler と同じロジックでスコープをpush
-            if let Some(name_scope) = class.name_scope {
-                if !name_scope.all_bindings_local() {
-                    compiler.code_block_flags |= CodeBlockFlags::HAS_BINDING_IDENTIFIER;
-                    let _ = compiler.push_scope(name_scope);
-                }
+            if let Some(name_scope) = class.name_scope
+                && !name_scope.all_bindings_local()
+            {
+                compiler.code_block_flags |= CodeBlockFlags::HAS_BINDING_IDENTIFIER;
+                let _ = compiler.push_scope(name_scope);
             }
 
             let contains_direct_eval = expr.contains_direct_eval();


### PR DESCRIPTION
### Description

This PR fixes two related bugs in the bytecode compiler that caused a panic
(`index out of bounds: the len is 0 but the index is 0`) when executing
esbuild-bundled JavaScript code targeting ES2020.

---

### Bug 1: `arguments` binding missing slot in `FunctionEnvironment`

**Root cause:**

`scope_analyzer.rs` always creates an `arguments` binding in the function
scope, but without the `ESCAPES` flag:

```rust
// scope_analyzer.rs
drop(env.create_mutable_binding(arguments.clone(), false));
// → BindingFlags: MUTABLE | LEX (no ESCAPES)
```

`num_bindings_non_local()` only counts bindings with `ESCAPES=true`, so the
`arguments` binding was excluded from the slot count. This caused
`FunctionEnvironment` to be created with 0 bindings, while the bytecode still
emitted `PutLexicalValue(index=0)` for it, resulting in a panic at runtime.

**Fix (`boa_ast/src/scope.rs`):**

Include the `arguments` binding in the slot count unconditionally:

```rust
pub fn num_bindings_non_local(&self) -> u32 {
    let arguments = JsString::from("arguments");
    self.inner
        .bindings
        .borrow()
        .iter()
        .filter(|binding| binding.escapes() || binding.name == arguments)
        .count() as u32
}
```

---

### Bug 2: Class constructor scope index mismatch

**Root cause:**

`scope_analyzer.rs` assigns scope indices to class constructor scopes via
`visit_function_like`, which increments `self.index` before calling
`function_scope.set_index(self.index)`. For example, when
`function_scope.all_bindings_local()` is false:

```rust
self.index += 1;  // e.g. index: 0 → 1
scopes.function_scope.set_index(self.index);  // scope_index = 1
```

However, `compile_class()` in `class.rs` always called `push_scope()` exactly
once for the function scope, placing it at `constant_scope(0)`. At runtime,
`function_construct` uses `code.constant_scope(last_env)` to retrieve the
function scope. Since the `function_scope` had `scope_index=1` but was stored
at `constant_scope(0)`, the wrong (or nonexistent) scope was accessed, causing
a panic.

This is in contrast to `function.rs` (`FunctionCompiler`), which correctly
mirrors the scope index assignment by:
1. Pushing `name_scope` first if it has non-local bindings
2. Conditionally pushing `function_scope` based on `all_bindings_local()` and
   `requires_function_scope()`

**Fix (`boa_engine/src/bytecompiler/class.rs`):**

Apply the same scoping logic as `FunctionCompiler` to the class constructor:

```rust
if let Some(expr) = &class.constructor {
    // Mirror scope_analyzer: push name_scope first if non-local
    if let Some(name_scope) = class.name_scope {
        if !name_scope.all_bindings_local() {
            compiler.code_block_flags |= CodeBlockFlags::HAS_BINDING_IDENTIFIER;
            let _ = compiler.push_scope(name_scope);
        }
    }

    // Mirror FunctionCompiler logic for HAS_FUNCTION_SCOPE
    let contains_direct_eval = expr.contains_direct_eval();
    if contains_direct_eval || !expr.scopes().function_scope().all_bindings_local() {
        compiler.code_block_flags |= CodeBlockFlags::HAS_FUNCTION_SCOPE;
    } else {
        compiler.code_block_flags.set(
            CodeBlockFlags::HAS_FUNCTION_SCOPE,
            expr.scopes().requires_function_scope(),
        );
    }

    if compiler.code_block_flags.has_function_scope() {
        let _ = compiler.push_scope(expr.scopes().function_scope());
    } else {
        compiler.variable_scope = expr.scopes().function_scope().clone();
        compiler.lexical_scope = expr.scopes().function_scope().clone();
    }
    // ... rest of constructor compilation
}
```

---

### Test cases

```javascript
// Bug 1: arguments binding slot
class A {
  constructor() {
    const x = 1;
  }
}
new A();

// Bug 2: class constructor with non-local bindings (closure)
var B = class {
  constructor(components) {
    const { getHasher } = components;
    this.fn = () => getHasher("sha2-256");
  }
};
new B({ getHasher: (x) => x });
```

---

### How it was found

The panic was triggered by esbuild-bundled code with `--target=es2020`, which
transforms class fields into `__publicField()` helper calls. The combination
of multiple `__publicField` calls followed by `const` declarations in a class
constructor exposed both bugs simultaneously.