### PR TITLE
feat: implement From<i128> and From<u128> for JsValue

### DIFF
--- a/core/engine/src/value/conversions/mod.rs
+++ b/core/engine/src/value/conversions/mod.rs
@@ -76,7 +76,7 @@ macro_rules! impl_from_integer {
     };
 }
 
-impl_from_integer!(u8, i8, u16, i16, u32, i32, u64, i64, usize, isize);
+impl_from_integer!(u8, i8, u16, i16, u32, i32, u64, i64, u128, i128, usize, isize);
 
 impl From<JsBigInt> for JsValue {
     #[inline]


### PR DESCRIPTION
Closes #1994

Adds i128 and u128 to the existing `impl_from_integer!` macro. Values that fit in i32 use compact integer32 storage; larger values fall back to float64, matching the existing behavior for i64 and u64.