### PR TITLE
feat(engine): HostHooks::on_tick for interrupting sync interpreter

### DIFF
--- a/core/engine/src/context/hooks.rs
+++ b/core/engine/src/context/hooks.rs
@@ -197,6 +197,18 @@ pub trait HostHooks {
         now.unix_timestamp() * 1000 + i64::from(now.millisecond())
     }
 
+    /// Called periodically by the synchronous interpreter (every ~1024
+    /// bytecode instructions). Return `Err` to terminate execution with the
+    /// given [`JsError`]. Embedders use this to enforce wall-clock budgets
+    /// and cancellation against pure-JS loops (`while(true){}`) that
+    /// otherwise have no interruption point.
+    ///
+    /// The default implementation is a no-op; the cost of the periodic call
+    /// itself is one increment + one compare per instruction.
+    fn on_tick(&self) -> JsResult<()> {
+        Ok(())
+    }
+
     /// Returns the offset of the local timezone to the `utc` timezone in seconds.
     fn local_timezone_offset_seconds(&self, unix_time_seconds: i64) -> i32 {
         OffsetDateTime::from_unix_timestamp(unix_time_seconds)

--- a/core/engine/src/vm/mod.rs
+++ b/core/engine/src/vm/mod.rs
@@ -986,6 +986,15 @@ impl Context {
     }
 
     pub(crate) fn run(&mut self) -> CompletionRecord {
+        // Call HostHooks::on_tick every TICK_INTERVAL bytecode instructions so
+        // embedders can enforce wall-clock budgets and cancellation against
+        // pure-JS loops (`while(true){}`, etc.) that otherwise have no
+        // interruption point. 1024 keeps per-instruction overhead at a single
+        // increment + compare while bounding the worst-case "still running"
+        // window after a deadline expires.
+        const TICK_INTERVAL: u32 = 1024;
+        let mut tick_counter: u32 = 0;
+
         while let Some(byte) = self
             .vm
             .frame()
@@ -994,6 +1003,14 @@ impl Context {
             .bytes
             .get(self.vm.frame().pc as usize)
         {
+            tick_counter += 1;
+            if tick_counter >= TICK_INTERVAL {
+                tick_counter = 0;
+                if let Err(err) = self.host_hooks().on_tick() {
+                    return CompletionRecord::Throw(err);
+                }
+            }
+
             let opcode = Opcode::decode(*byte);
 
             match self.execute_one(


### PR DESCRIPTION
## Summary

Adds a periodic `on_tick(&self) -> JsResult<()>` callback to the `HostHooks` trait, invoked every ~1024 bytecode instructions inside `Vm::run`. Returning `Err` terminates execution with that error.

This gives embedders a way to interrupt synchronous JS — `while(true){}` and similar pure-JS loops that currently have no interruption point. The existing `call_job_callback` hook only fires at promise/microtask boundaries, so it can't catch a script that never yields.

## Motivation

Building a sandboxed JS runtime on top of Boa, I hit the well-known limitation that pure-JS infinite loops can't be terminated by the embedder. The escape hatches (separate thread + timeout, custom JobQueue, etc.) all have downsides: extra threads and lifetime juggling, or only working for promise-heavy code.

A per-instruction host hook is the lowest-overhead general solution. The patch is 29 lines.

## Design

- `HostHooks::on_tick(&self) -> JsResult<()>` with a no-op default impl — no existing consumer changes behavior
- `Vm::run` decrements a `u32` counter every instruction; when it hits `TICK_INTERVAL` (1024) it resets and calls `on_tick`
- If the hook returns `Err`, that error becomes the script's `CompletionRecord::Throw`

### Overhead

One `u32` increment + one compare per bytecode instruction. The interval is a compile-time constant; LLVM should hoist the constant compare cheaply. With `TICK_INTERVAL = 1024` the worst-case latency after a deadline expires is roughly N microseconds for N being the per-instruction time × 1024 — well under a millisecond on modern hardware.

### Why not a feature flag?

The default impl is a no-op so there's nothing to gate. Embedders who don't implement `on_tick` get exactly the previous behavior. If the increment+compare overhead is a measurable concern in some benchmark I'm not aware of, happy to put it behind a feature.

## Use case

\`\`\`rust
struct DeadlineHooks { deadline: Instant }

impl HostHooks for DeadlineHooks {
    fn on_tick(&self) -> JsResult<()> {
        if Instant::now() > self.deadline {
            Err(JsNativeError::error()
                .with_message("deadline exceeded")
                .into())
        } else {
            Ok(())
        }
    }
}
\`\`\`

In my downstream this closes the last "but you can hang the interpreter" gap in a default-deny capability sandbox.

## Notes

- Branched off `main` (not `releases/0.21`) so the patch lands against current `Vm::run`. The 0.21 release has structurally the same loop; happy to backport if useful.
- I didn't add a `TICK_INTERVAL` knob on the builder — wanted to keep the surface minimal for review. If you'd prefer it configurable, I can wire it through `ContextBuilder`.
- Tests: I've been running the patched copy in my downstream for the use case above; happy to add a Boa-level test that overrides `on_tick` and verifies `while(true){}` is killable if you'd like one before merge.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>