### PR TITLE
fix(runtime): start timer handles at 1

### DIFF
--- a/core/runtime/src/interval.rs
+++ b/core/runtime/src/interval.rs
@@ -14,10 +14,18 @@ mod tests;
 
 /// The internal state of the interval module. The value is whether the interval
 /// function is still active.
-#[derive(Default)]
 struct IntervalInnerState {
     active_map: HashMap<u32, CancellationToken>,
     id: u32,
+}
+
+impl Default for IntervalInnerState {
+    fn default() -> Self {
+        Self {
+            active_map: HashMap::default(),
+            id: 1,
+        }
+    }
 }
 
 impl IntervalInnerState {


### PR DESCRIPTION
This Pull Request fixes/closes #5378.

It changes the following:

* Start timer handles at 1 instead of 0.
* Reserve 0 for the "no timer scheduled" sentinel value returned by `setTimeout()` and `setInterval()`.
* Ensure timer handles are positive integers, matching the HTML Timers specification and avoiding collisions with the sentinel value.
