### PR TITLE
Improvements to the safety of boa_string

### DIFF
--- a/core/string/src/builder.rs
+++ b/core/string/src/builder.rs
@@ -114,7 +114,9 @@ impl<D: InternalStringType> JsStringBuilder<D> {
     #[must_use]
     unsafe fn current_layout(&self) -> Layout {
         // SAFETY:
-        // Caller should ensure that the inner is allocated.
+        // 1. Caller should ensure that the inner is allocated.
+        // 2. `unwrap_unchecked` is safe because this layout was successfully
+        //    allocated previously with the same capacity, so it cannot overflow.
         unsafe {
             Layout::for_value(self.inner.as_ref())
                 .extend(Layout::array::<D::Byte>(self.capacity()).unwrap_unchecked())

--- a/core/string/src/builder.rs
+++ b/core/string/src/builder.rs
@@ -68,11 +68,6 @@ impl<D: InternalStringType> JsStringBuilder<D> {
         self.cap
     }
 
-    /// Returns the allocated byte of inner `RawJsString`'s data.
-    #[must_use]
-    const fn allocated_data_byte_len(&self) -> usize {
-        self.len() * Self::DATA_SIZE
-    }
 
     /// Returns the capacity calculated from given layout.
     #[must_use]
@@ -305,18 +300,7 @@ impl<D: InternalStringType> JsStringBuilder<D> {
         self.len() == 0
     }
 
-    /// Checks if all bytes in inner `RawJsString`'s data are ascii.
-    #[inline]
-    #[must_use]
-    pub fn is_ascii(&self) -> bool {
-        // SAFETY:
-        // `NonNull` verified for us that the pointer returned by `alloc` is valid,
-        // meaning we can read to its pointed memory.
-        let data = unsafe {
-            std::slice::from_raw_parts(self.data().cast::<u8>(), self.allocated_data_byte_len())
-        };
-        data.is_ascii()
-    }
+
 
     /// Extracts a slice containing the elements in the inner `RawJsString`.
     #[inline]
@@ -519,6 +503,24 @@ impl<D: InternalStringType> Clone for JsStringBuilder<D> {
 
         // SAFETY: source_len has checked to be less or equal to self's capacity.
         unsafe { self.set_len(source_len) };
+    }
+}
+
+impl JsStringBuilder<Latin1> {
+    /// Checks if all bytes in inner `RawJsString`'s data are ascii.
+    #[inline]
+    #[must_use]
+    pub fn is_ascii(&self) -> bool {
+        self.as_slice().is_ascii()
+    }
+}
+
+impl JsStringBuilder<Utf16> {
+    /// Checks if all u16 in inner `RawJsString`'s data are ascii (<= 0x7F).
+    #[inline]
+    #[must_use]
+    pub fn is_ascii(&self) -> bool {
+        self.as_slice().iter().all(|&c| c <= 0x7F)
     }
 }
 

--- a/core/string/src/builder.rs
+++ b/core/string/src/builder.rs
@@ -68,7 +68,6 @@ impl<D: InternalStringType> JsStringBuilder<D> {
         self.cap
     }
 
-
     /// Returns the capacity calculated from given layout.
     #[must_use]
     const fn capacity_from_layout(layout: Layout) -> usize {
@@ -199,7 +198,10 @@ impl<D: InternalStringType> JsStringBuilder<D> {
     /// Caller should ensure the capacity is large enough to hold elements.
     #[inline]
     pub const unsafe fn extend_from_slice_unchecked(&mut self, v: &[D::Byte]) {
-        // SAFETY: Caller should ensure the capacity is large enough to hold elements.
+        // SAFETY:
+        // 1. Caller must ensure `self.len() + v.len() <= self.capacity()` so the destination pointer is in-bounds.
+        // 2. Pointers are aligned: `v` is aligned by Rust's slice guarantee; `self.data()` is aligned because the allocation layout was padded to `D::Byte`'s alignment.
+        // 3. Regions do not overlap because `v` is an immutable reference and `self` is an exclusive mutable reference.
         unsafe {
             ptr::copy_nonoverlapping(v.as_ptr(), self.data().add(self.len()), v.len());
         }
@@ -301,8 +303,6 @@ impl<D: InternalStringType> JsStringBuilder<D> {
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
-
-
 
     /// Extracts a slice containing the elements in the inner `RawJsString`.
     #[inline]

--- a/core/string/src/builder.rs
+++ b/core/string/src/builder.rs
@@ -613,15 +613,15 @@ pub enum Segment<'a> {
 }
 
 impl Segment<'_> {
-    /// Checks if the segment consists solely of `ASCII` characters.
+    /// Checks if the segment can be represented as `Latin1` characters.
     #[inline]
     #[must_use]
-    fn is_ascii(&self) -> bool {
+    fn can_be_latin1(&self) -> bool {
         match self {
             Segment::String(s) => s.as_str().is_latin1(),
             Segment::Str(s) => s.is_latin1(),
-            Segment::Latin1(b) => *b <= 0x7f,
-            Segment::CodePoint(ch) => *ch as u32 <= 0x7F,
+            Segment::Latin1(_) => true,
+            Segment::CodePoint(ch) => *ch as u32 <= 0xFF,
         }
     }
 }
@@ -726,11 +726,11 @@ impl<'seg, 'ref_str: 'seg> CommonJsStringBuilder<'seg> {
         self.segments.push(seg.into());
     }
 
-    /// Checks if all string segments contains only `ASCII` bytes.
+    /// Checks if all string segments can be represented as `Latin1` characters.
     #[inline]
     #[must_use]
-    pub fn is_ascii(&self) -> bool {
-        self.segments.iter().all(Segment::is_ascii)
+    pub fn can_be_latin1(&self) -> bool {
+        self.segments.iter().all(Segment::can_be_latin1)
     }
 
     /// Returns the number of string segment in inner vector.
@@ -832,16 +832,16 @@ impl<'seg, 'ref_str: 'seg> CommonJsStringBuilder<'seg> {
     ///
     /// This function first checks if the instance is empty:
     /// - If it is empty, it returns the default `JsString`.
-    /// - If it contains only ASCII characters, it safely encodes it as `Latin1`.
-    /// - If it contains non-ASCII characters, it falls back to encoding using `UTF-16`.
+    /// - If it can be represented as Latin1 characters, it safely encodes it as `Latin1`.
+    /// - Otherwise, it falls back to encoding using `UTF-16`.
     #[inline]
     #[must_use]
     pub fn build(self) -> JsString {
         if self.is_empty() {
             JsString::default()
-        } else if self.is_ascii() {
+        } else if self.can_be_latin1() {
             // SAFETY:
-            // All string segment contains only ascii byte, so this can be encoded as `Latin1`.
+            // All string segments can be represented as Latin1, so this can be encoded as `Latin1`.
             unsafe { self.build_as_latin1() }
         } else {
             self.build_from_utf16()


### PR DESCRIPTION
I had it on my todo list to unsafe review `boa_string`. I didn't get around to it: it's a lot of unsafe code, but I did spend some time asking an appropriately primed agent to perform a review, and it had some findings. 

It found some issues around ascii-checking.

Full report:

<details>


# Unsafe Rust Review

This review performs a first pass safety audit of the `unsafe` code in `boa_string` v0.21.1), applying the **Rust Safety Comments** guidelines.

## Executive Summary

The codebase generally follows good safety practices, including many explicit `// SAFETY:` comments. However, we identified:
1.  **One logical inconsistency** in `Segment::is_ascii` which affects safe builder behavior (confusing behavior and missed optimizations, though technically sound).
2.  **One severe latent bug** in `JsStringBuilder::<u16>::is_ascii` which returns incorrect results for non-ASCII UTF-16 characters.
3.  **A few undocumented/under-documented unsafe assumptions** (e.g., `unwrap_unchecked` in layout math, redundant-looking `transmute`).
4.  **Opportunities to improve safety comments** to be more "locally verifiable" as per the guidelines.

---

## Detailed Findings by File

### 1. `third_party/rust/boa_string/v0_21/src/builder.rs`

#### 🔴 Inconsistent `Segment::is_ascii` (Logical Inconsistency)

*   **Location:** [builder.rs:L616-624](file:///google/src/files/head/depot/google3/third_party/rust/boa_string/v0_21/src/builder.rs#L616-L624)
*   **Code:**
    ```rust
    fn is_ascii(&self) -> bool {
        match self {
            Segment::String(s) => s.as_str().is_latin1(),
            Segment::Str(s) => s.is_latin1(),
            Segment::Latin1(b) => *b <= 0x7f,
            Segment::CodePoint(ch) => *ch as u32 <= 0x7F,
        }
    }
    ```
*   **Analysis:**
    This method is highly inconsistent:
    *   For `String` and `Str` segments, it checks `is_latin1()`, which returns `true` for any Latin1 string (values `0..=255`), including **non-ASCII** characters (e.g., `é` / `0xEB`).
    *   For `Latin1` (u8) and `CodePoint` (char) segments, it strictly checks for ASCII (`<= 0x7F`).
    
    This causes inconsistent behavior in safe `CommonJsStringBuilder::build()`:
    *   If you have a `Segment::String` containing non-ASCII Latin1, `is_ascii()` returns `true`, and it builds via `build_as_latin1`.
    *   If you have a `Segment::Latin1(0xEB)` (same character), `is_ascii()` returns `false`, forcing a fallback to `UTF-16` encoding.
    
    **Safety Impact Evaluation:**
    While this method acts as a guard for the `unsafe` function `build_as_latin1()`, this inconsistency **does not lead to unsoundness (UB)**:
    *   The "permissive" case (allowing non-ASCII `String`/`Str`) is safe because these segments are already Latin1 and fit perfectly into `u8` without loss of representation or truncation.
    *   The "strict" cases (restricting `Latin1`/`CodePoint` to ASCII) are overly conservative but safe. They merely cause a safe fallback to UTF-16.
    
*   **Recommendation:**
    Rename `is_ascii` to `can_be_latin1` (or similar) and make the checks consistent:
    ```rust
    fn can_be_latin1(&self) -> bool {
        match self {
            Segment::String(s) => s.as_str().is_latin1(),
            Segment::Str(s) => s.is_latin1(),
            Segment::Latin1(_) => true, // u8 is always valid Latin1
            Segment::CodePoint(ch) => *ch as u32 <= 0xFF, // Latin1 range
        }
    }
    ```
    If the intent was strictly ASCII, then `String` and `Str` segments must be scanned to ensure they contain no characters `> 0x7F`.

---

#### 🔴 Severe Bug in `JsStringBuilder::<u16>::is_ascii` (Potential Unsoundness)

*   **Location:** [builder.rs:L309-317](file:///google/src/files/head/depot/google3/third_party/rust/boa_string/v0_21/src/builder.rs#L309-L317)
*   **Code:**
    ```rust
    pub fn is_ascii(&self) -> bool {
        // SAFETY:
        // `NonNull` verified for us that the pointer returned by `alloc` is valid,
        // meaning we can read to its pointed memory.
        let data = unsafe {
            std::slice::from_raw_parts(self.data().cast::<u8>(), self.allocated_data_byte_len())
        };
        data.is_ascii()
    }
    ```
*   **Analysis:**
    When `D = u16` (i.e., `Utf16JsStringBuilder`), this function casts the raw `*mut u16` data pointer to `*const u8` and checks if the raw bytes are ASCII.
    This is **broken on Little Endian systems** for certain non-ASCII UTF-16 characters:
    *   Example: The character `0x0100` (`Ā`) is represented in memory as bytes `[0x00, 0x01]`.
    *   Since both `0x00` and `0x01` are `< 128`, `data.is_ascii()` will return **`true`**.
    *   Thus, the builder falsely claims a non-ASCII string is ASCII.
    
    **Safety Impact Evaluation:**
    Currently, this method is only called on `Latin1JsStringBuilder` (`JsStringBuilder<u8>`), where it behaves correctly. However, because `JsStringBuilder` is generic and this method is `pub`, this is a critical latent bug. If future code or external users rely on `is_ascii()` to guard unsafe operations on `Utf16JsStringBuilder` (e.g., assuming it can be safely downgraded to Latin1/u8), it would lead to silent data corruption or UB.

*   **Recommendation:**
    Move `is_ascii` to a specialized `impl JsStringBuilder<u8>` block so it cannot be called on the `u16` variant, or implement it correctly for `u16` (e.g., checking if all `u16` elements are `<= 0x7F`).

---

#### 🟡 Missing Safety Justification for `unwrap_unchecked`

*   **Location:** [builder.rs:L124-125](file:///google/src/files/head/depot/google3/third_party/rust/boa_string/v0_21/src/builder.rs#L124-L125)
*   **Code:**
    ```rust
    Layout::for_value(self.inner.as_ref())
        .extend(Layout::array::<D>(self.capacity()).unwrap_unchecked())
        .unwrap_unchecked()
    ```
*   **Analysis:**
    `unwrap_unchecked` is used on `Layout::array` and `Layout::extend`. This is unsafe if they return `Err` (which happens on overflow).
    *   **Why it is likely safe:** This layout is reconstructed for an *already allocated* object (`self.inner`). Since it was successfully allocated previously (via `new_layout`), we know the capacity and type size do not overflow.
    *   **Required Action:** Add a `// SAFETY:` comment explaining this invariant.
*   **Draft Safety Comment:**
    ```rust
    // SAFETY:
    // 1. `self.inner` is verified to be allocated.
    // 2. `unwrap_unchecked` is safe because this layout was successfully 
    //    allocated previously with the same capacity, so it cannot overflow.
    ```

---

#### 🟢 `extend_from_slice_unchecked` Pointers copy

*   **Location:** [builder.rs:L202-208](file:///google/src/files/head/depot/google3/third_party/rust/boa_string/v0_21/src/builder.rs#L202-L208)
*   **Code:**
    ```rust
    pub const unsafe fn extend_from_slice_unchecked(&mut self, v: &[D]) {
        // SAFETY: Caller should ensure the capacity is large enough to hold elements.
        unsafe {
            ptr::copy_nonoverlapping(v.as_ptr(), self.data().add(self.len()), v.len());
        }
        self.len += v.len();
    }
    ```
*   **Analysis:**
    The safety comment is correct but could be more thorough by addressing the other preconditions of `copy_nonoverlapping` (alignment, overlap):
*   **Draft Safety Comment:**
    ```rust
    // SAFETY:
    // 1. Caller must ensure `self.len() + v.len() <= self.capacity()` so the destination pointer is in-bounds.
    // 2. Pointers are aligned: `v` is aligned by Rust's slice guarantee; `self.data()` is aligned because the allocation layout was padded to `D`'s alignment.
    // 3. Regions do not overlap because `v` is an immutable reference and `self` is an exclusive mutable reference.
    ```

---

### 2. `third_party/rust/boa_string/v0_21/src/common.rs`

#### 🟡 Redundant/Confusing `transmute` in `get_string`

*   **Location:** [common.rs:L73-74](file:///google/src/files/head/depot/google3/third_party/rust/boa_string/v0_21/src/common.rs#L73-L74)
*   **Code:**
    ```rust
    let str = *RAW_STATICS_CACHE.get(string)?;

    // SAFETY: Type of T in is `&'static JsStr<'static>`, so this is safe.
    let ptr = unsafe { std::mem::transmute::<&JsStr<'_>, &'static JsStr<'static>>(str) };
    ```
*   **Analysis:**
    *   `RAW_STATICS_CACHE` is defined as `LazyLock<FxHashSet<&'static JsStr<'static>>>`.
    *   `RAW_STATICS_CACHE.get` should return `Option<&&'static JsStr<'static>>`.
    *   Dereferencing it once (`*`) should yield `&'static JsStr<'static>`.
    *   If `str` is already `&'static JsStr<'static>`, the transmute from `&JsStr<'_>` to `&'static JsStr<'static>` is redundant and confusing.
    *   If the compiler forced a shorter lifetime due to type inference, the safety relies on the fact that the value *definitely* came from the static cache.
*   **Recommendation:**
    1.  Try to remove the `transmute` and see if it compiles. It might require binding the cache deref to a static lifetime variable first:
        ```rust
        let cache: &'static FxHashSet<&'static JsStr<'static>> = &*RAW_STATICS_CACHE;
        let str = *cache.get(string)?;
        // `str` should now have `'static` lifetime naturally.
        ```
    2.  If `transmute` is indeed required, clarify the safety comment:
        ```rust
        // SAFETY: `str` is retrieved from `RAW_STATICS_CACHE` which only contains 
        // references to static memory (`&'static JsStr<'static>`), so promoting 
        // the lifetime to `'static` is sound.
        ```

---

### 3. `third_party/rust/boa_string/v0_21/src/str.rs`

*   **Status:** **PASS**
*   `JsStr` uses `std::slice::from_raw_parts` to reconstruct slices from raw pointers in `variant()` and `as_latin1()`.
*   **Justification:** These are well-guarded by the `is_latin1` tag and the fact that `JsStr` is constructed from valid Rust slices with lifetime `'a` (which is preserved in `JsStr<'a>`).
*   The `Sync` and `Send` implementations are correctly documented and sound (the type is immutable).


</details>