### PR TITLE
Fix bug in JsString ends_with

### DIFF
--- a/core/string/src/lib.rs
+++ b/core/string/src/lib.rs
@@ -432,7 +432,7 @@ impl JsString {
     // We check the size, so this should never panic.
     #[allow(clippy::missing_panics_doc)]
     pub fn ends_with(&self, needle: JsStr<'_>) -> bool {
-        self.as_str().starts_with(needle)
+        self.as_str().ends_with(needle)
     }
 
     /// Get the `u16` code unit at index. This does not parse any characters if there

--- a/core/string/src/tests.rs
+++ b/core/string/src/tests.rs
@@ -553,3 +553,15 @@ fn trim() {
     let base_str = JsString::from(" \u{000B} Hello World \t ");
     assert_eq!(base_str.trim(), JsString::from("Hello World"));
 }
+
+#[test]
+fn starts_with_and_ends_with_basic() {
+    let basic = JsString::from("abcdef");
+    let start_needle = JsStr::latin1("abc".as_bytes());
+    assert!(basic.starts_with(start_needle));
+    assert!(!basic.ends_with(start_needle));
+
+    let end_needle = JsStr::latin1("def".as_bytes());
+    assert!(!basic.starts_with(end_needle));
+    assert!(basic.ends_with(end_needle));
+}


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This PR closes #5390

Looks like we're calling the wrong method in `ends_with`. Fixes the issue and adds a basic test for `starts_with` and `ends_with`
