### PR TITLE
fix: route StdClock through crate::sys::time to prevent wasm panics

### DIFF
--- a/core/engine/src/context/time.rs
+++ b/core/engine/src/context/time.rs
@@ -196,9 +196,9 @@ impl Clock for StdClock {
     }
 
     fn system_time_millis(&self) -> i64 {
-        let now = std::time::SystemTime::now();
+        let now = crate::sys::time::SystemTime::now();
         let duration = now
-            .duration_since(std::time::UNIX_EPOCH)
+            .duration_since(crate::sys::time::UNIX_EPOCH)
             .expect("System clock is before Unix epoch");
         duration.as_millis() as i64
     }


### PR DESCRIPTION
This Pull Request fixes/closes #5397.

It changes the following:
- Routes StdClock through crate::sys::time to prevent wasm panics.