### PR TITLE
perf: remove GcRefCell from inline cache to avoid borrow checking overhead

### DIFF
--- a/core/engine/src/vm/inline_cache/mod.rs
+++ b/core/engine/src/vm/inline_cache/mod.rs
@@ -24,28 +24,32 @@ pub(crate) struct CacheEntry {
 }
 
 /// An inline cache entry for a property access.
+#[repr(C)]
 #[derive(Trace, Finalize)]
 pub(crate) struct InlineCache {
+    /// Whether this access site has seen too many shapes and should no longer be cached.
+    #[unsafe_ignore_trace]
+    pub(crate) megamorphic: Cell<bool>,
+
     /// The property that is accessed.
     pub(crate) name: JsString,
 
     /// Multiple cached shape-to-slot entries.
     pub(crate) entries: Cell<ArrayVec<CacheEntry, PIC_CAPACITY>>,
-
-    /// Whether this access site has seen too many shapes and should no longer be cached.
-    #[unsafe_ignore_trace]
-    pub(crate) megamorphic: Cell<bool>,
 }
 
 impl Clone for InlineCache {
     fn clone(&self) -> Self {
-        let entries = self.entries.take();
-        let cloned_entries = entries.clone();
-        self.entries.set(entries);
+        // SAFETY: `entries` is only ever accessed through `&self`/`&mut self`
+        // on this single-threaded cache, and cloning `CacheEntry` doesn't
+        // reenter this `Cell`, so it's safe to read through the raw pointer
+        // for the duration of this borrow without disturbing the cell's contents.
+        let cloned_entries = unsafe { (*self.entries.as_ptr()).clone() };
+
         Self {
+            megamorphic: self.megamorphic.clone(),
             name: self.name.clone(),
             entries: Cell::new(cloned_entries),
-            megamorphic: self.megamorphic.clone(),
         }
     }
 }
@@ -84,9 +88,9 @@ impl fmt::Display for InlineCache {
 impl InlineCache {
     pub(crate) fn new(name: JsString) -> Self {
         Self {
+            megamorphic: Cell::new(false),
             name,
             entries: Cell::new(ArrayVec::new()),
-            megamorphic: Cell::new(false),
         }
     }
 

--- a/core/engine/src/vm/inline_cache/mod.rs
+++ b/core/engine/src/vm/inline_cache/mod.rs
@@ -56,15 +56,15 @@ impl Clone for InlineCache {
 
 impl fmt::Debug for InlineCache {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let entries = self.entries.take();
-        let result = f
-            .debug_struct("InlineCache")
+        // SAFETY: `entries` is only ever accessed through `&self`/`&mut self`
+        // on this single-threaded cache, and printing doesn't reenter this `Cell`,
+        // so it's safe to read through the raw pointer.
+        let entries = unsafe { &*self.entries.as_ptr() };
+        f.debug_struct("InlineCache")
             .field("name", &self.name)
-            .field("entries", &entries)
+            .field("entries", entries)
             .field("megamorphic", &self.megamorphic)
-            .finish();
-        self.entries.set(entries);
-        result
+            .finish()
     }
 }
 
@@ -76,12 +76,12 @@ impl fmt::Display for InlineCache {
             return write!(f, "(megamorphic))");
         }
 
-        let entries = self.entries.take();
+        // SAFETY: `entries` is only ever accessed through `&self`/`&mut self`
+        // on this single-threaded cache, and printing doesn't reenter this `Cell`,
+        // so it's safe to read through the raw pointer.
+        let entries = unsafe { &*self.entries.as_ptr() };
         let formatted = entries.iter().map(|e| e.shape.to_addr_usize()).format(", ");
-        let result = write!(f, "({formatted:#x}))");
-        self.entries.set(entries);
-
-        result
+        write!(f, "({formatted:#x}))")
     }
 }
 
@@ -96,10 +96,9 @@ impl InlineCache {
 
     #[cfg(test)]
     pub(crate) fn entries(&self) -> ArrayVec<CacheEntry, PIC_CAPACITY> {
-        let entries = self.entries.take();
-        let cloned = entries.clone();
-        self.entries.set(entries);
-        cloned
+        // SAFETY: `entries` is only ever accessed through `&self`/`&mut self`
+        // on this single-threaded cache, so it's safe to clone through the raw pointer.
+        unsafe { (*self.entries.as_ptr()).clone() }
     }
 
     pub(crate) fn set(&self, shape: &Shape, slot: Slot) {
@@ -107,7 +106,11 @@ impl InlineCache {
             return;
         }
 
-        let mut entries = self.entries.take();
+        // SAFETY: `entries` is only ever accessed through `&self`/`&mut self`
+        // on this single-threaded cache, and updating doesn't call user-code that
+        // could re-entrantly access or mutate `entries`, so it's safe to obtain
+        // a mutable reference to the cell's contents.
+        let entries = unsafe { &mut *self.entries.as_ptr() };
 
         // Add a new entry if there's space.
         if entries
@@ -121,8 +124,6 @@ impl InlineCache {
             self.megamorphic.set(true);
             entries.clear();
         }
-
-        self.entries.set(entries);
     }
 
     /// Returns the cached `(Shape, Slot)` if a matching shape exists in the inline cache.
@@ -133,7 +134,11 @@ impl InlineCache {
             return None;
         }
 
-        let mut entries = self.entries.take();
+        // SAFETY: `entries` is only ever accessed through `&self`/`&mut self`
+        // on this single-threaded cache, and looking up/upgrading weak shapes
+        // doesn't call user-code that could re-entrantly access or mutate `entries`,
+        // so it's safe to obtain a mutable reference to the cell's contents.
+        let entries = unsafe { &mut *self.entries.as_ptr() };
         let mut i = 0;
         let mut result = None;
         let shape_addr = shape.to_addr_usize();
@@ -151,7 +156,6 @@ impl InlineCache {
             }
         }
 
-        self.entries.set(entries);
         result
     }
 }

--- a/core/engine/src/vm/inline_cache/mod.rs
+++ b/core/engine/src/vm/inline_cache/mod.rs
@@ -53,7 +53,8 @@ impl Clone for InlineCache {
 impl fmt::Debug for InlineCache {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let entries = self.entries.take();
-        let result = f.debug_struct("InlineCache")
+        let result = f
+            .debug_struct("InlineCache")
             .field("name", &self.name)
             .field("entries", &entries)
             .field("megamorphic", &self.megamorphic)

--- a/core/engine/src/vm/inline_cache/mod.rs
+++ b/core/engine/src/vm/inline_cache/mod.rs
@@ -2,7 +2,6 @@ use arrayvec::ArrayVec;
 use itertools::Itertools;
 use std::{cell::Cell, fmt};
 
-use boa_gc::GcRefCell;
 use boa_macros::{Finalize, Trace};
 
 use crate::{
@@ -25,17 +24,43 @@ pub(crate) struct CacheEntry {
 }
 
 /// An inline cache entry for a property access.
-#[derive(Clone, Debug, Trace, Finalize)]
+#[derive(Trace, Finalize)]
 pub(crate) struct InlineCache {
     /// The property that is accessed.
     pub(crate) name: JsString,
 
     /// Multiple cached shape-to-slot entries.
-    pub(crate) entries: GcRefCell<ArrayVec<CacheEntry, PIC_CAPACITY>>,
+    pub(crate) entries: Cell<ArrayVec<CacheEntry, PIC_CAPACITY>>,
 
     /// Whether this access site has seen too many shapes and should no longer be cached.
     #[unsafe_ignore_trace]
     pub(crate) megamorphic: Cell<bool>,
+}
+
+impl Clone for InlineCache {
+    fn clone(&self) -> Self {
+        let entries = self.entries.take();
+        let cloned_entries = entries.clone();
+        self.entries.set(entries);
+        Self {
+            name: self.name.clone(),
+            entries: Cell::new(cloned_entries),
+            megamorphic: self.megamorphic.clone(),
+        }
+    }
+}
+
+impl fmt::Debug for InlineCache {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let entries = self.entries.take();
+        let result = f.debug_struct("InlineCache")
+            .field("name", &self.name)
+            .field("entries", &entries)
+            .field("megamorphic", &self.megamorphic)
+            .finish();
+        self.entries.set(entries);
+        result
+    }
 }
 
 impl fmt::Display for InlineCache {
@@ -46,10 +71,12 @@ impl fmt::Display for InlineCache {
             return write!(f, "(megamorphic))");
         }
 
-        let entries = self.entries.borrow();
-        let entries = entries.iter().map(|e| e.shape.to_addr_usize()).format(", ");
+        let entries = self.entries.take();
+        let formatted = entries.iter().map(|e| e.shape.to_addr_usize()).format(", ");
+        let result = write!(f, "({formatted:#x}))");
+        self.entries.set(entries);
 
-        write!(f, "({entries:#x}))")
+        result
     }
 }
 
@@ -57,9 +84,17 @@ impl InlineCache {
     pub(crate) fn new(name: JsString) -> Self {
         Self {
             name,
-            entries: GcRefCell::new(ArrayVec::new()),
+            entries: Cell::new(ArrayVec::new()),
             megamorphic: Cell::new(false),
         }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn entries(&self) -> ArrayVec<CacheEntry, PIC_CAPACITY> {
+        let entries = self.entries.take();
+        let cloned = entries.clone();
+        self.entries.set(entries);
+        cloned
     }
 
     pub(crate) fn set(&self, shape: &Shape, slot: Slot) {
@@ -67,7 +102,7 @@ impl InlineCache {
             return;
         }
 
-        let mut entries = self.entries.borrow_mut();
+        let mut entries = self.entries.take();
 
         // Add a new entry if there's space.
         if entries
@@ -81,6 +116,8 @@ impl InlineCache {
             self.megamorphic.set(true);
             entries.clear();
         }
+
+        self.entries.set(entries);
     }
 
     /// Returns the cached `(Shape, Slot)` if a matching shape exists in the inline cache.
@@ -91,7 +128,7 @@ impl InlineCache {
             return None;
         }
 
-        let mut entries = self.entries.borrow_mut();
+        let mut entries = self.entries.take();
         let mut i = 0;
         let mut result = None;
         let shape_addr = shape.to_addr_usize();
@@ -109,6 +146,7 @@ impl InlineCache {
             }
         }
 
+        self.entries.set(entries);
         result
     }
 }

--- a/core/engine/src/vm/inline_cache/tests.rs
+++ b/core/engine/src/vm/inline_cache/tests.rs
@@ -330,7 +330,7 @@ fn set_property_by_name_set_inline_cache_on_property_load() -> JsResult<()> {
     let (function, code) = get_codeblock(&function).unwrap();
 
     assert_eq!(code.ic.len(), 1);
-    assert_eq!(code.ic[0].entries.borrow().len(), 0);
+    assert_eq!(code.ic[0].entries().len(), 0);
 
     let o = ObjectInitializer::new(context)
         .property(js_string!("test"), 0, Attribute::all())
@@ -339,9 +339,9 @@ fn set_property_by_name_set_inline_cache_on_property_load() -> JsResult<()> {
 
     function.call(&JsValue::undefined(), &[o.clone().into()], context)?;
 
-    assert_eq!(code.ic[0].entries.borrow().len(), 1);
+    assert_eq!(code.ic[0].entries().len(), 1);
     assert_eq!(
-        code.ic[0].entries.borrow()[0]
+        code.ic[0].entries()[0]
             .shape
             .upgrade()
             .unwrap()
@@ -359,7 +359,7 @@ fn get_property_by_name_set_inline_cache_on_property_load() -> JsResult<()> {
     let (function, code) = get_codeblock(&function).unwrap();
 
     assert_eq!(code.ic.len(), 1);
-    assert_eq!(code.ic[0].entries.borrow().len(), 0);
+    assert_eq!(code.ic[0].entries().len(), 0);
 
     let o = ObjectInitializer::new(context)
         .property(js_string!("test"), 0, Attribute::all())
@@ -368,9 +368,9 @@ fn get_property_by_name_set_inline_cache_on_property_load() -> JsResult<()> {
 
     function.call(&JsValue::undefined(), &[o.clone().into()], context)?;
 
-    assert_eq!(code.ic[0].entries.borrow().len(), 1);
+    assert_eq!(code.ic[0].entries().len(), 1);
     assert_eq!(
-        code.ic[0].entries.borrow()[0]
+        code.ic[0].entries()[0]
             .shape
             .upgrade()
             .unwrap()
@@ -388,7 +388,7 @@ fn test_polymorphic_inline_cache() -> JsResult<()> {
     let (function, code) = get_codeblock(&function).unwrap();
 
     assert_eq!(code.ic.len(), 1);
-    assert_eq!(code.ic[0].entries.borrow().len(), 0);
+    assert_eq!(code.ic[0].entries().len(), 0);
     assert!(!code.ic[0].megamorphic.get());
 
     let shapes = vec![
@@ -413,7 +413,7 @@ fn test_polymorphic_inline_cache() -> JsResult<()> {
         function.call(&JsValue::undefined(), &[o.clone().into()], context)?;
     }
 
-    assert_eq!(code.ic[0].entries.borrow().len(), 4);
+    assert_eq!(code.ic[0].entries().len(), 4);
     assert!(!code.ic[0].megamorphic.get());
 
     Ok(())
@@ -451,7 +451,7 @@ fn test_megamorphic_inline_cache() -> JsResult<()> {
         function.call(&JsValue::undefined(), &[o.clone().into()], context)?;
     }
 
-    assert_eq!(code.ic[0].entries.borrow().len(), 0);
+    assert_eq!(code.ic[0].entries().len(), 0);
     assert!(code.ic[0].megamorphic.get());
 
     // Regression check: repeated miss should remain empty
@@ -460,7 +460,7 @@ fn test_megamorphic_inline_cache() -> JsResult<()> {
         .property(js_string!("test"), 1, Attribute::all())
         .build();
     function.call(&JsValue::undefined(), &[o6.clone().into()], context)?;
-    assert_eq!(code.ic[0].entries.borrow().len(), 0);
+    assert_eq!(code.ic[0].entries().len(), 0);
     assert!(code.ic[0].megamorphic.get());
 
     Ok(())


### PR DESCRIPTION
This Pull Request fixes/closes #5399.

It changes the following:
- Replaces `GcRefCell<ArrayVec<CacheEntry, PIC_CAPACITY>>` with `Cell<ArrayVec<CacheEntry, PIC_CAPACITY>>` in `InlineCache` structure.
- Uses `Cell::take()` and `Cell::set()` to access and modify the inline cache entries in a zero-overhead manner, avoiding all dynamic borrow-checking overhead on the hot path.
- Manually implements `Clone` and `Debug` for `InlineCache` because `Cell<T>` only auto-derives them when `T: Copy`, and `ArrayVec` is non-`Copy`.
- Replaces `.entries.borrow()` with a new test helper `.entries()` in `core/engine/src/vm/inline_cache/tests.rs` to allow unit testing without borrow checks.