### PR TITLE
Don't double-include line and column information in SyntaxError (fixes #5357)

### DIFF
--- a/core/engine/src/tests/mod.rs
+++ b/core/engine/src/tests/mod.rs
@@ -480,6 +480,15 @@ fn strict_mode_reserved_name() {
 }
 
 #[test]
+fn issue5357() {
+    run_test_actions([TestAction::assert_native_error(
+        "foo(); @",
+        JsNativeErrorKind::Syntax,
+        "unexpected '@' at line 1, col 8",
+    )]);
+}
+
+#[test]
 fn empty_statement() {
     run_test_actions([TestAction::assert_eq(
         indoc! {r#"

--- a/core/parser/src/lexer/mod.rs
+++ b/core/parser/src/lexer/mod.rs
@@ -342,11 +342,7 @@ impl<R> Lexer<R> {
                     NumberLiteral::new(next_ch as u8).lex(&mut self.cursor, start, interner)
                 }
                 _ => {
-                    let details = format!(
-                        "unexpected '{c}' at line {}, column {}",
-                        start.line_number(),
-                        start.column_number()
-                    );
+                    let details = format!("unexpected '{c}'");
                     Err(Error::syntax(details, start.position()))
                 }
             }?;


### PR DESCRIPTION
This Pull Request fixes #5357

The SyntaxError includes the location information already so it doesn't need to add the line and column number in the error message as well.