### PR TITLE
Refactor methods related to localized strings in `Date`

### DIFF
--- a/core/engine/src/builtins/date/mod.rs
+++ b/core/engine/src/builtins/date/mod.rs
@@ -34,7 +34,7 @@ use boa_macros::js_str;
 
 #[cfg(feature = "intl")]
 use crate::builtins::intl::date_time_format::{
-    FormatDefaults, FormatType, format_date_time_locale,
+    FormatDefaults, FormatType, create_date_time_format, format_timestamp_with_dtf,
 };
 
 pub(crate) mod utils;
@@ -1670,7 +1670,8 @@ impl Date {
         // 6. Return ! FormatDateTime(dateFormat, x).
         let locales = args.get_or_undefined(0);
         let options = args.get_or_undefined(1);
-        format_date_time_locale(locales, options, required, defaults, x, context)
+        let dtf = create_date_time_format(locales, options, required, defaults, context)?;
+        format_timestamp_with_dtf(&dtf, x, context)
     }
 
     /// [`Date.prototype.toLocaleDateString()`][spec].

--- a/core/engine/src/builtins/date/mod.rs
+++ b/core/engine/src/builtins/date/mod.rs
@@ -1665,13 +1665,13 @@ impl Date {
             // 1. Let dateObject be the this value.
             // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
             // 3. Let x be dateObject.[[DateValue]].
-            let t = this
+            let x = this
                 .as_object()
                 .and_then(|obj| obj.downcast_ref::<Date>().as_deref().copied())
                 .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?
                 .0;
             // 4. If x is NaN, return "Invalid Date".
-            if t.is_nan() {
+            if x.is_nan() {
                 return Ok(JsValue::new(js_string!("Invalid Date")));
             }
             // 5. Let dateFormat be ? CreateDateTimeFormat(%Intl.DateTimeFormat%, locales, options, date, date).
@@ -1683,7 +1683,7 @@ impl Date {
                 options,
                 FormatType::Date,
                 FormatDefaults::Date,
-                t,
+                x,
                 context,
             )
         }
@@ -1716,13 +1716,13 @@ impl Date {
             // 1. Let dateObject be the this value.
             // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
             // 3. Let x be dateObject.[[DateValue]].
-            let t = this
+            let x = this
                 .as_object()
                 .and_then(|obj| obj.downcast_ref::<Date>().as_deref().copied())
                 .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?
                 .0;
             // 4. If x is NaN, return "Invalid Date".
-            if t.is_nan() {
+            if x.is_nan() {
                 return Ok(JsValue::new(js_string!("Invalid Date")));
             }
             // 5. Let dateFormat be ? CreateDateTimeFormat(%Intl.DateTimeFormat%, locales, options, any, all).
@@ -1734,7 +1734,7 @@ impl Date {
                 options,
                 FormatType::Any,
                 FormatDefaults::All,
-                t,
+                x,
                 context,
             )
         }
@@ -1768,13 +1768,13 @@ impl Date {
             // 1. Let dateObject be the this value.
             // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
             // 3. Let x be dateObject.[[DateValue]].
-            let t = this
+            let x = this
                 .as_object()
                 .and_then(|obj| obj.downcast_ref::<Date>().as_deref().copied())
                 .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?
                 .0;
             // 4. If x is NaN, return "Invalid Date".
-            if t.is_nan() {
+            if x.is_nan() {
                 return Ok(JsValue::new(js_string!("Invalid Date")));
             }
             // 5. Let timeFormat be ? CreateDateTimeFormat(%Intl.DateTimeFormat%, locales, options, time, time).
@@ -1786,7 +1786,7 @@ impl Date {
                 options,
                 FormatType::Time,
                 FormatDefaults::Time,
-                t,
+                x,
                 context,
             )
         }

--- a/core/engine/src/builtins/date/mod.rs
+++ b/core/engine/src/builtins/date/mod.rs
@@ -1641,6 +1641,38 @@ impl Date {
         func.call(this, &[], context)
     }
 
+    /// Shared implementation of `Date.prototype.toLocaleString`,
+    /// `Date.prototype.toLocaleDateString`, and `Date.prototype.toLocaleTimeString`
+    /// methods with the corresponding formatting params
+    #[inline]
+    fn to_locale_string_with(
+        this: &JsValue,
+        args: &[JsValue],
+        required: FormatType,
+        defaults: FormatDefaults,
+        context: &mut Context,
+    ) -> JsResult<JsValue> {
+        // 1. Let dateObject be the this value.
+        // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
+        // 3. Let x be dateObject.[[DateValue]].
+        let x = this
+            .as_object()
+            .and_then(|obj| obj.downcast_ref::<Date>().as_deref().copied())
+            .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?
+            .0;
+
+        // 4. If x is NaN, return "Invalid Date".
+        if x.is_nan() {
+            return Ok(JsValue::new(js_string!("Invalid Date")));
+        }
+
+        // 5. Let dateFormat be ? CreateDateTimeFormat(%Intl.DateTimeFormat%, locales, options, required, defaults).
+        // 6. Return ! FormatDateTime(dateFormat, x).
+        let locales = args.get_or_undefined(0);
+        let options = args.get_or_undefined(1);
+        format_date_time_locale(locales, options, required, defaults, x, context)
+    }
+
     /// [`Date.prototype.toLocaleDateString()`][spec].
     ///
     /// The `toLocaleDateString()` method returns the date portion of the given Date instance according
@@ -1662,30 +1694,7 @@ impl Date {
     ) -> JsResult<JsValue> {
         #[cfg(feature = "intl")]
         {
-            // 1. Let dateObject be the this value.
-            // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
-            // 3. Let x be dateObject.[[DateValue]].
-            let x = this
-                .as_object()
-                .and_then(|obj| obj.downcast_ref::<Date>().as_deref().copied())
-                .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?
-                .0;
-            // 4. If x is NaN, return "Invalid Date".
-            if x.is_nan() {
-                return Ok(JsValue::new(js_string!("Invalid Date")));
-            }
-            // 5. Let dateFormat be ? CreateDateTimeFormat(%Intl.DateTimeFormat%, locales, options, date, date).
-            // 6. Return ! FormatDateTime(dateFormat, x).
-            let locales = args.get_or_undefined(0);
-            let options = args.get_or_undefined(1);
-            format_date_time_locale(
-                locales,
-                options,
-                FormatType::Date,
-                FormatDefaults::Date,
-                x,
-                context,
-            )
+            Self::to_locale_string_with(this, args, FormatType::Date, FormatDefaults::Date, context)
         }
         #[cfg(not(feature = "intl"))]
         {
@@ -1713,30 +1722,7 @@ impl Date {
     ) -> JsResult<JsValue> {
         #[cfg(feature = "intl")]
         {
-            // 1. Let dateObject be the this value.
-            // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
-            // 3. Let x be dateObject.[[DateValue]].
-            let x = this
-                .as_object()
-                .and_then(|obj| obj.downcast_ref::<Date>().as_deref().copied())
-                .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?
-                .0;
-            // 4. If x is NaN, return "Invalid Date".
-            if x.is_nan() {
-                return Ok(JsValue::new(js_string!("Invalid Date")));
-            }
-            // 5. Let dateFormat be ? CreateDateTimeFormat(%Intl.DateTimeFormat%, locales, options, any, all).
-            // 6. Return ! FormatDateTime(dateFormat, x).
-            let locales = args.get_or_undefined(0);
-            let options = args.get_or_undefined(1);
-            format_date_time_locale(
-                locales,
-                options,
-                FormatType::Any,
-                FormatDefaults::All,
-                x,
-                context,
-            )
+            Self::to_locale_string_with(this, args, FormatType::Any, FormatDefaults::All, context)
         }
         #[cfg(not(feature = "intl"))]
         {
@@ -1765,30 +1751,7 @@ impl Date {
     ) -> JsResult<JsValue> {
         #[cfg(feature = "intl")]
         {
-            // 1. Let dateObject be the this value.
-            // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
-            // 3. Let x be dateObject.[[DateValue]].
-            let x = this
-                .as_object()
-                .and_then(|obj| obj.downcast_ref::<Date>().as_deref().copied())
-                .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?
-                .0;
-            // 4. If x is NaN, return "Invalid Date".
-            if x.is_nan() {
-                return Ok(JsValue::new(js_string!("Invalid Date")));
-            }
-            // 5. Let timeFormat be ? CreateDateTimeFormat(%Intl.DateTimeFormat%, locales, options, time, time).
-            // 6. Return ! FormatDateTime(timeFormat, x).
-            let locales = args.get_or_undefined(0);
-            let options = args.get_or_undefined(1);
-            format_date_time_locale(
-                locales,
-                options,
-                FormatType::Time,
-                FormatDefaults::Time,
-                x,
-                context,
-            )
+            Self::to_locale_string_with(this, args, FormatType::Time, FormatDefaults::Time, context)
         }
         #[cfg(not(feature = "intl"))]
         {

--- a/core/engine/src/builtins/date/mod.rs
+++ b/core/engine/src/builtins/date/mod.rs
@@ -1644,6 +1644,7 @@ impl Date {
     /// Shared implementation of `Date.prototype.toLocaleString`,
     /// `Date.prototype.toLocaleDateString`, and `Date.prototype.toLocaleTimeString`
     /// methods with the corresponding formatting params
+    #[cfg(feature = "intl")]
     #[inline]
     fn to_locale_string_with(
         this: &JsValue,

--- a/core/engine/src/builtins/date/mod.rs
+++ b/core/engine/src/builtins/date/mod.rs
@@ -32,6 +32,11 @@ use crate::{
 use boa_gc::{Finalize, Trace};
 use boa_macros::js_str;
 
+#[cfg(feature = "intl")]
+use crate::builtins::intl::date_time_format::{
+    FormatDefaults, FormatType, format_date_time_locale,
+};
+
 pub(crate) mod utils;
 
 #[cfg(test)]
@@ -1657,9 +1662,6 @@ impl Date {
     ) -> JsResult<JsValue> {
         #[cfg(feature = "intl")]
         {
-            use crate::builtins::intl::date_time_format::{
-                FormatDefaults, FormatType, format_date_time_locale,
-            };
             // 1. Let dateObject be the this value.
             // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
             // 3. Let x be dateObject.[[DateValue]].
@@ -1711,9 +1713,6 @@ impl Date {
     ) -> JsResult<JsValue> {
         #[cfg(feature = "intl")]
         {
-            use crate::builtins::intl::date_time_format::{
-                FormatDefaults, FormatType, format_date_time_locale,
-            };
             // 1. Let dateObject be the this value.
             // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
             // 3. Let x be dateObject.[[DateValue]].
@@ -1766,9 +1765,6 @@ impl Date {
     ) -> JsResult<JsValue> {
         #[cfg(feature = "intl")]
         {
-            use crate::builtins::intl::date_time_format::{
-                FormatDefaults, FormatType, format_date_time_locale,
-            };
             // 1. Let dateObject be the this value.
             // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
             // 3. Let x be dateObject.[[DateValue]].

--- a/core/engine/src/builtins/date/mod.rs
+++ b/core/engine/src/builtins/date/mod.rs
@@ -1685,10 +1685,6 @@ impl Date {
     ///
     /// [spec]: https://tc39.es/ecma402/#sup-date.prototype.tolocaledatestring
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleDateString
-    #[allow(
-        unused_variables,
-        reason = "`args` and `context` are used when the `intl` feature is enabled"
-    )]
     pub(crate) fn to_locale_date_string(
         this: &JsValue,
         args: &[JsValue],
@@ -1700,7 +1696,7 @@ impl Date {
         }
         #[cfg(not(feature = "intl"))]
         {
-            Self::to_string(this, &[], context)
+            Self::to_string(this, args, context)
         }
     }
 
@@ -1713,10 +1709,6 @@ impl Date {
     ///
     /// [spec]: https://tc39.es/ecma402/#sup-date.prototype.tolocalestring
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleString
-    #[allow(
-        unused_variables,
-        reason = "`args` and `context` are used when the `intl` feature is enabled"
-    )]
     pub(crate) fn to_locale_string(
         this: &JsValue,
         args: &[JsValue],
@@ -1728,7 +1720,7 @@ impl Date {
         }
         #[cfg(not(feature = "intl"))]
         {
-            Self::to_string(this, &[], context)
+            Self::to_string(this, args, context)
         }
     }
 
@@ -1742,10 +1734,6 @@ impl Date {
     ///
     /// [spec]: https://tc39.es/ecma402/#sup-date.prototype.tolocaletimestring
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleTimeString
-    #[allow(
-        unused_variables,
-        reason = "`args` and `context` are used when the `intl` feature is enabled"
-    )]
     pub(crate) fn to_locale_time_string(
         this: &JsValue,
         args: &[JsValue],
@@ -1757,7 +1745,7 @@ impl Date {
         }
         #[cfg(not(feature = "intl"))]
         {
-            Self::to_string(this, &[], context)
+            Self::to_string(this, args, context)
         }
     }
 

--- a/core/engine/src/builtins/intl/date_time_format/mod.rs
+++ b/core/engine/src/builtins/intl/date_time_format/mod.rs
@@ -283,8 +283,7 @@ impl DateTimeFormat {
                         if x.is_nan() {
                             return Err(js_error!(RangeError: "formatted date cannot be NaN"));
                         }
-                        let result = format_timestamp_with_dtf(dtf.borrow().data(), x, context)?;
-                        Ok(JsValue::from(result))
+                        format_timestamp_with_dtf(dtf.borrow().data(), x, context)
                     },
                     dtf_clone,
                 ),
@@ -849,11 +848,11 @@ pub(crate) fn create_date_time_format(
 ///
 /// Then calls `ToLocalTime::from_local_epoch_milliseconds` to obtain calendar fields,
 /// and formats the resulting `ZonedDateTime` with ICU4X.
-fn format_timestamp_with_dtf(
+pub(crate) fn format_timestamp_with_dtf(
     dtf: &DateTimeFormat,
     timestamp: f64,
     context: &mut Context,
-) -> JsResult<JsString> {
+) -> JsResult<JsValue> {
     // PartitionDateTimePattern ( dtf, x ) step 3:
     // Let epochNanoseconds be ℤ(ℝ(x) × 10^6).
     //
@@ -895,7 +894,7 @@ fn format_timestamp_with_dtf(
         zone: tz_info_at_time,
     };
     let result = dtf.formatter.format(&zdt).to_string();
-    Ok(JsString::from(result))
+    Ok(JsString::from(result).into())
 }
 
 fn date_time_style_format(
@@ -1011,27 +1010,26 @@ fn unwrap_date_time_format(
         .into())
 }
 
-/// Shared helper used by Date.prototype.toLocaleString,
-/// Date.prototype.toLocaleDateString, and Date.prototype.toLocaleTimeString.
-/// Applies `ToDateTimeOptions` defaults, calls [`create_date_time_format`], and formats
-/// the timestamp via [`format_timestamp_with_dtf`] without allocating a JS object.
-#[allow(clippy::too_many_arguments)]
-pub(crate) fn format_date_time_locale(
-    locales: &JsValue,
-    options: &JsValue,
-    format_type: FormatType,
-    defaults: FormatDefaults,
-    timestamp: f64,
-    context: &mut Context,
-) -> JsResult<JsValue> {
-    let options = coerce_options_to_object(options, context)?;
-    let options_value = options.into();
-    let dtf = create_date_time_format(locales, &options_value, format_type, defaults, context)?;
-    // FormatDateTime steps 1–2: TimeClip and NaN check (format_timestamp_with_dtf does ToLocalTime + format only).
-    let x = time_clip(timestamp);
-    if x.is_nan() {
-        return Err(js_error!(RangeError: "formatted date cannot be NaN"));
-    }
-    let result = format_timestamp_with_dtf(&dtf, x, context)?;
-    Ok(JsValue::from(result))
-}
+// /// Shared helper used by Date.prototype.toLocaleString,
+// /// Date.prototype.toLocaleDateString, and Date.prototype.toLocaleTimeString.
+// /// Applies `ToDateTimeOptions` defaults, calls [`create_date_time_format`], and formats
+// /// the timestamp via [`format_timestamp_with_dtf`] without allocating a JS object.
+// #[allow(clippy::too_many_arguments)]
+// pub(crate) fn format_date_time_locale(
+//     locales: &JsValue,
+//     options: &JsValue,
+//     format_type: FormatType,
+//     defaults: FormatDefaults,
+//     timestamp: f64,
+//     context: &mut Context,
+// ) -> JsResult<JsValue> {
+//     let options = coerce_options_to_object(options, context)?;
+//     let options_value = options.into();
+//     // FormatDateTime steps 1–2: TimeClip and NaN check (format_timestamp_with_dtf does ToLocalTime + format only).
+//     let x = time_clip(timestamp);
+//     if x.is_nan() {
+//         return Err(js_error!(RangeError: "formatted date cannot be NaN"));
+//     }
+//     let result = format_timestamp_with_dtf(&dtf, x, context)?;
+//     Ok(JsValue::from(result))
+// }

--- a/core/engine/src/builtins/intl/date_time_format/mod.rs
+++ b/core/engine/src/builtins/intl/date_time_format/mod.rs
@@ -820,9 +820,10 @@ pub(crate) fn create_date_time_format(
 
 /// Formats a timestamp (epoch milliseconds) using the given [`DateTimeFormat`] internals.
 ///
-/// It corresponds the `ToLocalTime` / `PartitionDateTimePattern` logic from
-/// [11.5.6](https://tc39.es/ecma402/#sec-partitiondatetimepattern) and
-/// [11.5.12](https://tc39.es/ecma402/#sec-tolocaltime).
+/// It corresponds the logic from [`PartitionDateTimePattern`][11.5.6] and [`ToLocalTime`][11.5.12].
+///
+/// [11.5.6]: https://tc39.es/ecma402/#sec-partitiondatetimepattern
+/// [11.5.12]: https://tc39.es/ecma402/#sec-tolocaltime
 ///
 /// This helper implements:
 ///

--- a/core/engine/src/builtins/intl/date_time_format/mod.rs
+++ b/core/engine/src/builtins/intl/date_time_format/mod.rs
@@ -820,10 +820,6 @@ pub(crate) fn create_date_time_format(
 
 /// Formats a timestamp (epoch milliseconds) using the given [`DateTimeFormat`] internals.
 ///
-/// This is the shared implementation used by:
-/// - the bound `format` function created in `get_format`, and
-/// - [`format_date_time_locale`] used by `Date.prototype.toLocaleString` (and friends).
-///
 /// It corresponds the `ToLocalTime` / `PartitionDateTimePattern` logic from
 /// [11.5.6](https://tc39.es/ecma402/#sec-partitiondatetimepattern) and
 /// [11.5.12](https://tc39.es/ecma402/#sec-tolocaltime).
@@ -938,8 +934,7 @@ fn best_fit_date_time_format(format_options: &FormatOptions) -> JsResult<Composi
         .map_err(|e| JsNativeError::range().with_message(e.to_string()).into())
 }
 
-/// Represents the `required` and `defaults` arguments in the abstract operation
-/// `toDateTimeOptions`.
+/// Identifies a specific category of date-time components.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub(crate) enum FormatType {
     Date,
@@ -947,13 +942,11 @@ pub(crate) enum FormatType {
     Any,
 }
 
-/// Indicates which default fields should be applied when `ToDateTimeOptions`
-/// determines defaults are needed. `All` applies both date and time defaults.
+/// Identifies which default values to use when none are specified.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub(crate) enum FormatDefaults {
     Date,
     Time,
-    /// Apply both date and time defaults (e.g. for `toLocaleString`).
     All,
 }
 

--- a/core/engine/src/builtins/intl/date_time_format/mod.rs
+++ b/core/engine/src/builtins/intl/date_time_format/mod.rs
@@ -278,11 +278,6 @@ impl DateTimeFormat {
                         };
 
                         // 5. Return ? FormatDateTime(dtf, x).
-                        // A.O 11.5.6 PartitionDateTimePattern: 1. TimeClip(x). 2. If NaN throw. Then ToLocalTime and format.
-                        let x = time_clip(x);
-                        if x.is_nan() {
-                            return Err(js_error!(RangeError: "formatted date cannot be NaN"));
-                        }
                         format_timestamp_with_dtf(dtf.borrow().data(), x, context)
                     },
                     dtf_clone,
@@ -829,18 +824,15 @@ pub(crate) fn create_date_time_format(
 /// - the bound `format` function created in `get_format`, and
 /// - [`format_date_time_locale`] used by `Date.prototype.toLocaleString` (and friends).
 ///
-/// It corresponds to the *post*-`TimeClip` portion of
-/// [`FormatDateTime(dtf, x)`](https://tc39.es/ecma402/#sec-formatdatetime),
-/// and the `ToLocalTime` / `PartitionDateTimePattern` logic from
+/// It corresponds the `ToLocalTime` / `PartitionDateTimePattern` logic from
 /// [11.5.6](https://tc39.es/ecma402/#sec-partitiondatetimepattern) and
 /// [11.5.12](https://tc39.es/ecma402/#sec-tolocaltime).
 ///
-/// Callers must have already applied `TimeClip` and `NaN` check
-/// (`FormatDateTime` steps 1–2). This helper implements:
+/// This helper implements:
 ///
 /// 11.5.6 `PartitionDateTimePattern` ( dtf, x )
-/// 1. Let x be TimeClip(x). (Done by caller)
-/// 2. If x is `NaN`, throw a `RangeError` exception. (Done by caller)
+/// 1. Let x be TimeClip(x).
+/// 2. If x is `NaN`, throw a `RangeError` exception.
 /// 3. Let epochNanoseconds be ℤ(ℝ(x) × 10^6).
 /// 4. Let timeZone be dtf.[[`TimeZone`]].
 /// 5. Let offsetNs be GetOffsetNanosecondsFor(timeZone, epochNanoseconds).
@@ -853,11 +845,18 @@ pub(crate) fn format_timestamp_with_dtf(
     timestamp: f64,
     context: &mut Context,
 ) -> JsResult<JsValue> {
+    // PartitionDateTimePattern ( dtf, x ) step 1:
+    // 1. Let x be TimeClip(x).
+    let x = time_clip(timestamp);
+
+    // PartitionDateTimePattern ( dtf, x ) step 2:
+    // 2. If x is `NaN`, throw a `RangeError` exception.
+    if x.is_nan() {
+        return Err(js_error!(RangeError: "formatted date cannot be NaN"));
+    }
     // PartitionDateTimePattern ( dtf, x ) step 3:
     // Let epochNanoseconds be ℤ(ℝ(x) × 10^6).
-    //
-    // NOTE: `timestamp` is already `TimeClip`'d by the caller and represents *UTC epoch milliseconds*.
-    let epoch_ns = timestamp as i128 * 1_000_000;
+    let epoch_ns = x as i128 * 1_000_000;
 
     // PartitionDateTimePattern ( dtf, x ) step 4:
     // Let timeZone be dtf.[[`TimeZone`]].
@@ -883,7 +882,7 @@ pub(crate) fn format_timestamp_with_dtf(
 
     // PartitionDateTimePattern ( dtf, x ) step 6:
     // Let tz be 𝔽(ℝ(x) + ℝ(offsetNs) / 10^6).
-    let tz = timestamp + f64::from(time_zone_offset_seconds * 1_000);
+    let tz = x + f64::from(time_zone_offset_seconds * 1_000);
     let fields = ToLocalTime::from_local_epoch_milliseconds(tz)?;
     let dt = fields.to_formattable_datetime()?;
     let tz_info = time_zone.to_time_zone_info();
@@ -1009,27 +1008,3 @@ fn unwrap_date_time_format(
         .with_message("object was not an initialized `Intl.DateTimeFormat` object")
         .into())
 }
-
-// /// Shared helper used by Date.prototype.toLocaleString,
-// /// Date.prototype.toLocaleDateString, and Date.prototype.toLocaleTimeString.
-// /// Applies `ToDateTimeOptions` defaults, calls [`create_date_time_format`], and formats
-// /// the timestamp via [`format_timestamp_with_dtf`] without allocating a JS object.
-// #[allow(clippy::too_many_arguments)]
-// pub(crate) fn format_date_time_locale(
-//     locales: &JsValue,
-//     options: &JsValue,
-//     format_type: FormatType,
-//     defaults: FormatDefaults,
-//     timestamp: f64,
-//     context: &mut Context,
-// ) -> JsResult<JsValue> {
-//     let options = coerce_options_to_object(options, context)?;
-//     let options_value = options.into();
-//     // FormatDateTime steps 1–2: TimeClip and NaN check (format_timestamp_with_dtf does ToLocalTime + format only).
-//     let x = time_clip(timestamp);
-//     if x.is_nan() {
-//         return Err(js_error!(RangeError: "formatted date cannot be NaN"));
-//     }
-//     let result = format_timestamp_with_dtf(&dtf, x, context)?;
-//     Ok(JsValue::from(result))
-// }


### PR DESCRIPTION
Refactoring of the logic added by 26271b7. This PR is a prerequisite for #5199

It changes the following:

- Introduced a shared implementation for `toLocaleString`, `toLocaleDateString`, and `toLocaleTimeString`
- Removed `format_date_time_locale` as unnecessary
- Some related minor improvements

Testing:
- `cargo test -p boa_engine --lib -- date::tests::date_proto_to_locale_string_intl` (skipped)
- `cargo test -p boa_engine --features intl_bundled --lib -- date::tests::date_proto_to_locale_string_intl` (passed)