### PR TITLE
perf: add fast path to OrdinaryGet

### DIFF
--- a/core/engine/src/object/internal_methods/mod.rs
+++ b/core/engine/src/object/internal_methods/mod.rs
@@ -9,6 +9,7 @@ use std::ops::{Deref, DerefMut};
 
 use super::{
     JsPrototype, PROTOTYPE,
+    property_map::OwnDataLookup,
     shape::slot::{Slot, SlotAttributes},
 };
 use crate::{
@@ -709,6 +710,32 @@ pub(crate) fn ordinary_get(
     receiver: JsValue,
     context: &mut InternalMethodPropertyContext<'_>,
 ) -> JsResult<JsValue> {
+    // Fast path: read a plain data own-property's value directly, skipping
+    // `PropertyDescriptor` construction. Accessors, indexed keys and exotic objects fall
+    // through to the spec path below.
+    if !matches!(key, PropertyKey::Index(_))
+        && obj.vtable().__get_own_property__ as usize
+            == ordinary_get_own_property as *const () as usize
+    {
+        let lookup = obj
+            .borrow()
+            .properties
+            .get_own_data_named(key, context.slot());
+        match lookup {
+            OwnDataLookup::Data(value) => return Ok(value),
+            OwnDataLookup::Absent => {
+                if let Some(parent) = obj.__get_prototype_of__(context)? {
+                    context.slot().set_not_cacheable_if_already_prototype();
+                    context.slot().attributes |= SlotAttributes::PROTOTYPE;
+                    return parent.__get__(key, receiver, context);
+                }
+                return Ok(JsValue::undefined());
+            }
+            // Accessor: fall through to invoke the getter.
+            OwnDataLookup::Accessor => {}
+        }
+    }
+
     // 1. Assert: IsPropertyKey(P) is true.
     // 2. Let desc be ? O.[[GetOwnProperty]](P).
     match obj.__get_own_property__(key, context)? {

--- a/core/engine/src/object/property_map.rs
+++ b/core/engine/src/object/property_map.rs
@@ -14,6 +14,18 @@ use rustc_hash::FxHashMap;
 use std::{collections::hash_map, iter::FusedIterator};
 use thin_vec::ThinVec;
 
+/// Result of [`PropertyMap::get_own_data_named`], the fast-path own-property lookup
+/// used by `OrdinaryGet`.
+#[derive(Debug)]
+pub(crate) enum OwnDataLookup {
+    /// A plain data own property; carries its value read directly from storage.
+    Data(JsValue),
+    /// The own property exists but is an accessor; the caller must use the descriptor path.
+    Accessor,
+    /// No such own property; the caller can proceed directly to the prototype walk.
+    Absent,
+}
+
 /// This represents all the indexed properties.
 ///
 /// The index properties can be stored in two storage methods:
@@ -563,6 +575,32 @@ impl PropertyMap {
         }
 
         None
+    }
+
+    /// Fast path for `OrdinaryGet`: resolves a named own-property lookup in a single shape
+    /// probe, returning a plain data property's value straight from storage without building
+    /// a [`PropertyDescriptor`]. `out_slot` is updated only on a data hit.
+    #[must_use]
+    pub(crate) fn get_own_data_named(
+        &self,
+        key: &PropertyKey,
+        out_slot: &mut Slot,
+    ) -> OwnDataLookup {
+        debug_assert!(!matches!(key, PropertyKey::Index(_)));
+
+        let Some(slot) = self.shape.lookup(key) else {
+            return OwnDataLookup::Absent;
+        };
+        if slot.attributes.is_accessor_descriptor() {
+            return OwnDataLookup::Accessor;
+        }
+
+        out_slot.index = slot.index;
+        // Remove all descriptor attributes, but keep inline caching bits.
+        out_slot.attributes = (out_slot.attributes & SlotAttributes::INLINE_CACHE_BITS)
+            | slot.attributes
+            | SlotAttributes::FOUND;
+        OwnDataLookup::Data(self.storage[slot.index as usize].clone())
     }
 
     /// Get the property with the given key from the [`PropertyMap`].


### PR DESCRIPTION
Adds a fast path to `OrdinaryGet` that reads a plain data property's value directly from object storage, skipping `PropertyDescriptor` construction.

Benchmarks on local machine:

| Benchmark | Δ |
|---|---|
| **strings/slice** | **−21.4%** |
| **intl/numberformat-different-options** | **−14.2%** |
| **strings/split** | **−12.4%** |
| **strings/concat** | **−12.3%** |
| **intl/segmenter-segment** | **−12.2%** |
| **strings/replace** | **−11.9%** |
| **properties/access** | **−10.4%** |
| prototypes/chain | −9.7% |
| intl/listformat-format | −8.8% |
| intl/datetimeformat-format | −7.7% |
| v8-benches/splay | −7.0% |
| v8-benches/regexp | −5.9% |
| basic/nested-loop | −4.8% |
| intl/collator-construction | −4.5% |
| intl/pluralrules-construction | −4.0% |
| intl/numberformat-construction | −3.9% |
| intl/segmenter-construction | −3.8% |
| v8-benches/earley-boyer | −3.7% |
| intl/listformat-construction | −3.4% |
| v8-benches/raytrace | −3.2% |
| json/stringify_circular | −2.9% |
| closures/invoke | −1.6% |
| closures/create | −1.3% |
| intl/datetimeformat-with-options | −0.9% |
| v8-benches/navier-stokes | −0.3% |
| intl/pluralrules-select | −0.1% |
| basic/call-loop | −0.0% |
| json/stringify_deep | +0.0% |
| v8-benches/deltablue | +0.1% |
| v8-benches/crypto | +0.1% |
| v8-benches/richards | +1.5% |
| **intl/collator-compare** | **+3.1%** |
| **intl/datetimeformat_resolved_options** | **+3.2%** |