### PR TITLE
expose fractionalSecondDigits as a property of resolvedOptions()

### DIFF
--- a/core/engine/src/builtins/intl/date_time_format/mod.rs
+++ b/core/engine/src/builtins/intl/date_time_format/mod.rs
@@ -17,7 +17,9 @@ use crate::{
         },
         intl::{
             Service,
-            date_time_format::options::{DateStyle, FormatMatcher, FormatOptions, TimeStyle},
+            date_time_format::options::{
+                DateStyle, FormatMatcher, FormatOptions, SubsecondDigits, TimeStyle,
+            },
             locale::{canonicalize_locale_list, filter_locales, resolve_locale},
             options::{IntlOptions, coerce_options_to_object},
         },
@@ -87,6 +89,7 @@ pub(crate) struct DateTimeFormat {
     hour_cycle: Option<IcuHourCycle>,
     date_style: Option<DateStyle>,
     time_style: Option<TimeStyle>,
+    fractional_second_digits: Option<SubsecondDigits>,
     time_zone: FormatTimeZone,
     fieldset: CompositeFieldSet,
     formatter: DateTimeFormatter<CompositeFieldSet>,
@@ -413,6 +416,18 @@ impl DateTimeFormat {
                 //h11/h12 -> true, h23/h24 -> false , because its h12 conversion time
                 let hour12 = matches!(hc, IcuHourCycle::H11 | IcuHourCycle::H12);
                 options.property(js_string!("hour12"), hour12, Attribute::all());
+            }
+
+            // Per Table 15, fractionalSecondDigits is only reported when neither
+            // dateStyle nor timeStyle is set; the constructor already guarantees this by
+            // rejecting explicit component options alongside a style, so the value is
+            // `None` whenever a style is present.
+            if let Some(fsd) = dtf.fractional_second_digits {
+                options.property(
+                    js_string!("fractionalSecondDigits"),
+                    fsd.digits(),
+                    Attribute::all(),
+                );
             }
 
             if let Some(ds) = dtf.date_style {
@@ -816,6 +831,7 @@ pub(crate) fn create_date_time_format(
         hour_cycle: intl_options.preferences.hour_cycle,
         date_style,
         time_style,
+        fractional_second_digits: format_options.fractional_second_digits(),
         time_zone,
         fieldset,
         formatter,

--- a/core/engine/src/builtins/intl/date_time_format/options.rs
+++ b/core/engine/src/builtins/intl/date_time_format/options.rs
@@ -207,6 +207,10 @@ impl FormatOptions {
         })
     }
 
+    pub(super) fn fractional_second_digits(&self) -> Option<SubsecondDigits> {
+        self.fractional_second_digits
+    }
+
     pub(super) fn set_date_defaults(&mut self) {
         self.year = Some(Year::Numeric);
         self.month = Some(Month::Numeric);
@@ -534,6 +538,14 @@ impl SubsecondDigits {
             2 => SubsecondDigits::S2,
             3 => SubsecondDigits::S3,
             _ => unreachable!("subSecondDigits must be previously constrained."),
+        }
+    }
+
+    pub(super) fn digits(self) -> u8 {
+        match self {
+            SubsecondDigits::S1 => 1,
+            SubsecondDigits::S2 => 2,
+            SubsecondDigits::S3 => 3,
         }
     }
 }


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

Hi boa-devs!

I have a small contribution for the "ECMA-402" effort. Please let me know if this looks good to you.
It changes the following:

- Exposes `fractionalSecondDigits` as a property inside the object returned by `resolvedOptions()`