### PR TITLE
Add console.exception() as alias for console.error()

### DIFF
--- a/core/runtime/src/console/mod.rs
+++ b/core/runtime/src/console/mod.rs
@@ -397,6 +397,11 @@ impl Console {
             0,
         )
         .function(
+            console_method(Self::error, state.clone(), logger.clone()),
+            js_string!("exception"),
+            0,
+        )
+        .function(
             console_method(Self::info, state.clone(), logger.clone()),
             js_string!("info"),
             0,

--- a/core/runtime/src/console/tests.rs
+++ b/core/runtime/src/console/tests.rs
@@ -841,6 +841,26 @@ fn console_table_map_ignores_properties_filter() {
     assert!(logs.contains("Values"));
 }
 
+/// exception should be an alias for error.
+#[test]
+fn console_exception_is_alias_for_error() {
+    let mut context = Context::default();
+    let logger = RecordingLogger::default();
+    Console::register_with_logger(logger.clone(), &mut context).unwrap();
+
+    run_test_actions_with(
+        [
+            TestAction::run(indoc! {r#"
+                console.exception("hello world");
+            "#}),
+        ],
+        &mut context,
+    );
+
+    let logs = logger.log.borrow().clone();
+    assert_eq!(logs, "hello world\n");
+}
+
 /// Set should ignore the properties filter and keep its fixed column layout.
 #[test]
 fn console_table_set_ignores_properties_filter() {

--- a/core/runtime/src/console/tests.rs
+++ b/core/runtime/src/console/tests.rs
@@ -849,11 +849,9 @@ fn console_exception_is_alias_for_error() {
     Console::register_with_logger(logger.clone(), &mut context).unwrap();
 
     run_test_actions_with(
-        [
-            TestAction::run(indoc! {r#"
+        [TestAction::run(indoc! {r#"
                 console.exception("hello world");
-            "#}),
-        ],
+            "#})],
         &mut context,
     );
 


### PR DESCRIPTION
## Summary

Adds `console.exception()` as an alias for `console.error()`, aligning with the WHATWG Console specification ([console.spec.whatwg.org](https://console.spec.whatwg.org/#assert)).

The spec defines `console.exception()` as identical to `console.error()` — same signature, behavior, and security considerations.

## Changes

- Registered `console.exception` in `Console::make_console()` as an alias for `Self::error` (same pattern as `dirxml` → `dir`)
- Added `console_exception_is_alias_for_error` test

## Motivation

Closes #307 (partially — `profile()`, `profileEnd()`, `timeStamp()` are marked `not_planned` by maintainers).

`console.exception()` is widely supported in browser environments (Chrome, Firefox, Safari) and is commonly used to log errors with stack trace information.