### PR TITLE
perf: fuse relational if/ternary conditions into a compare-branch 

### DIFF
--- a/core/engine/src/bytecompiler/expression/mod.rs
+++ b/core/engine/src/bytecompiler/expression/mod.rs
@@ -52,9 +52,8 @@ impl ByteCompiler<'_> {
     }
 
     fn compile_conditional(&mut self, op: &Conditional, dst: &Register) {
-        self.compile_expr(op.condition(), dst);
-        self.if_else(
-            dst,
+        self.compile_if_else(
+            op.condition(),
             |compiler| compiler.compile_expr(op.if_true(), dst),
             |compiler| compiler.compile_expr(op.if_false(), dst),
         );

--- a/core/engine/src/bytecompiler/mod.rs
+++ b/core/engine/src/bytecompiler/mod.rs
@@ -1174,6 +1174,33 @@ impl<'ctx> ByteCompiler<'ctx> {
         self.patch_jump(jump_to_end);
     }
 
+    /// Generates the `if`-`else` pattern directly from a condition expression,
+    /// fusing a relational condition into the branch when possible.
+    ///
+    /// For a relational condition (`<`, `<=`, `>`, `>=`) this emits a single
+    /// fused comparison+branch opcode (e.g. `if (a < b)` becomes one
+    /// `JumpIfNotLessThan`) instead of computing a boolean into a register with
+    /// `LessThan` and then testing it with `JumpIfFalse` — saving a dispatch and
+    /// a register. Non-relational conditions fall back to compiling the
+    /// condition into a temporary register followed by `JumpIfFalse`.
+    pub(crate) fn compile_if_else(
+        &mut self,
+        condition: &Expression,
+        true_case: impl FnOnce(&mut ByteCompiler<'_>),
+        false_case: impl FnOnce(&mut ByteCompiler<'_>),
+    ) {
+        let jump_false = self.compile_condition_and_branch(condition, None);
+
+        // if true, jump to end to avoid running the code for the `else`
+        true_case(self);
+        let jump_to_end = self.jump();
+
+        // if false, we should be already at the end so no need to do anything.
+        self.patch_jump(jump_false);
+        false_case(self);
+        self.patch_jump(jump_to_end);
+    }
+
     pub(crate) fn jump_if_false(&mut self, value: &Register) -> Label {
         let index = self.next_opcode_location();
         self.bytecode
@@ -1194,7 +1221,10 @@ impl<'ctx> ByteCompiler<'ctx> {
         condition: &Expression,
         hoisted: Option<&HoistedOperand>,
     ) -> Label {
-        if let Expression::Binary(binary) = condition
+        // `flatten()` strips outer parentheses so that conditions like
+        // `(a < b)` (common in ternaries and hand-parenthesized code) still
+        // reach the fused comparison+branch path.
+        if let Expression::Binary(binary) = condition.flatten()
             && let BinaryOp::Relational(op) = binary.op()
             && let Some(label) = self.try_fused_comparison_branch(op, binary, hoisted)
         {

--- a/core/engine/src/bytecompiler/statement/if.rs
+++ b/core/engine/src/bytecompiler/statement/if.rs
@@ -3,10 +3,8 @@ use boa_ast::statement::If;
 
 impl ByteCompiler<'_> {
     pub(crate) fn compile_if(&mut self, node: &If, use_expr: bool) {
-        let value = self.register_allocator.alloc();
-        self.compile_expr(node.cond(), &value);
-        self.if_else_with_dealloc(
-            value,
+        self.compile_if_else(
+            node.cond(),
             |compiler| {
                 compiler.compile_stmt(node.body(), use_expr, true);
             },

--- a/tests/insta-bytecode/scripts/if-ternary-branch.js
+++ b/tests/insta-bytecode/scripts/if-ternary-branch.js
@@ -18,7 +18,7 @@ if (a < b) {
 
 // Parenthesized ternary with `>` -> fused `JumpIfNotGreaterThan`
 // (also exercises `Expression::flatten` stripping the parentheses).
-r = (a > b) ? 10 : 20;
+r = a > b ? 10 : 20;
 
 // Non-relational condition -> `JumpIfFalse` fallback is preserved.
 if (r) {

--- a/tests/insta-bytecode/scripts/if-ternary-branch.js
+++ b/tests/insta-bytecode/scripts/if-ternary-branch.js
@@ -1,0 +1,28 @@
+// Relational conditions in `if` statements and ternary expressions should
+// compile to a single fused compare-and-branch opcode (e.g. `JumpIfNotLessThan`)
+// instead of computing a boolean into a register (`LessThan`) and then testing
+// it (`JumpIfFalse`). See `compile_if_else` / `compile_condition_and_branch`.
+//
+// `a`/`b` are identifiers (not literals) so constant folding leaves the
+// relational comparisons in place.
+let a = 1;
+let b = 2;
+let r = 0;
+
+// `if`/`else` with `<` -> fused `JumpIfNotLessThan`.
+if (a < b) {
+  r = 1;
+} else {
+  r = 2;
+}
+
+// Parenthesized ternary with `>` -> fused `JumpIfNotGreaterThan`
+// (also exercises `Expression::flatten` stripping the parentheses).
+r = (a > b) ? 10 : 20;
+
+// Non-relational condition -> `JumpIfFalse` fallback is preserved.
+if (r) {
+  r = 3;
+}
+
+r;

--- a/tests/insta-bytecode/src/snapshots/insta_bytecode__compile_bytecode@if-ternary-branch.js.snap
+++ b/tests/insta-bytecode/src/snapshots/insta_bytecode__compile_bytecode@if-ternary-branch.js.snap
@@ -1,0 +1,53 @@
+---
+source: tests/insta-bytecode/src/lib.rs
+expression: output
+input_file: tests/insta-bytecode/scripts/if-ternary-branch.js
+---
+-------------------------- Compiled Output: '<main>' ---------------------------
+Location     Handler      Opcode                            Operands
+  000000                    StoreOne                          dst:r01
+  000005                    PutLexicalValue                   src:r01, binding_index:0
+  00000e                    StoreInt8                         value:2, dst:r01
+  000014                    PutLexicalValue                   src:r01, binding_index:1
+  00001d                    StoreZero                         dst:r01
+  000022                    PutLexicalValue                   src:r01, binding_index:2
+  00002b                    GetName                           dst:r01, binding_index:0
+  000034                    GetName                           dst:r02, binding_index:1
+  00003d                    JumpIfNotLessThan                 lhs:r01, rhs:r02, address:00005d
+  00004a                    StoreOne                          dst:r01
+  00004f                    SetName                           src:r01, binding_index:2
+  000058                    Jump                              address:00006c
+  00005d                    StoreInt8                         value:2, dst:r01
+  000063                    SetName                           src:r01, binding_index:2
+  00006c                    GetName                           dst:r02, binding_index:0
+  000075                    GetName                           dst:r03, binding_index:1
+  00007e                    JumpIfNotGreaterThan              lhs:r02, rhs:r03, address:000096
+  00008b                    StoreInt8                         value:10, dst:r01
+  000091                    Jump                              address:00009c
+  000096                    StoreInt8                         value:20, dst:r01
+  00009c                    SetName                           src:r01, binding_index:2
+  0000a5                    GetName                           dst:r01, binding_index:2
+  0000ae                    JumpIfFalse                       value:r01, address:0000cb
+  0000b7                    StoreInt8                         value:3, dst:r01
+  0000bd                    SetName                           src:r01, binding_index:2
+  0000c6                    Jump                              address:0000cb
+  0000cb                    GetName                           dst:r01, binding_index:2
+  0000d4                    SetAccumulator                    src:r01
+  0000d9                    CheckReturn                       
+  0000da                    Return                            
+
+Register Count: 4, Flags: CodeBlockFlags(HAS_PROTOTYPE_PROPERTY)
+Constants:
+    0000: [STRING] "a"
+    0001: [STRING] "b"
+    0002: [STRING] "r"
+Bindings:
+    0000: a, scope: GlobalDeclarative
+    0001: b, scope: GlobalDeclarative
+    0002: r, scope: GlobalDeclarative
+Handlers: <empty>
+Source Map:
+    0000: 74..93: (14, 3)
+    0001: 93..108: (16, 3)
+    0002: 108..183: (21, 1)
+    0003: 183..198: (25, 3)


### PR DESCRIPTION
`if (a < b)` and `cond ? x : y` previously compiled the relational operator into a boolean in a scratch register (e.g. `LessThan`) and then tested it with `JumpIfFalse` — two dispatches plus a throwaway register. Route them through the existing `compile_condition_and_branch` helper (already used by `for`/`while`/`do-while` loops) so a relational condition emits a single fused `JumpIfNot{Less,Greater}Than[OrEqual]` opcode instead.

Also `flatten()` the condition first, so parenthesized forms like `(a < b) ? x : y` and `while ((i < n))` reach the fused path too. Non-relational conditions keep the previous `compile_expr` + `JumpIfFalse` fallback. Reuses opcodes already proven for loops; all boa_engine tests pass.
