### PR TITLE
feat(engine): support symbol unregister tokens in FinalizationRegistry

### DIFF
--- a/core/engine/src/builtins/finalization_registry/mod.rs
+++ b/core/engine/src/builtins/finalization_registry/mod.rs
@@ -21,7 +21,7 @@ use crate::{
     string::StaticJsStrings,
 };
 
-use super::{BuiltInConstructor, BuiltInObject, IntrinsicObject, builder::BuiltInBuilder};
+use super::{BuiltInConstructor, BuiltInObject, IntrinsicObject, builder::BuiltInBuilder, symbol};
 
 #[cfg(test)]
 mod tests;
@@ -51,7 +51,35 @@ impl Finalize for CleanupSignaler {
 pub(crate) struct RegistryCell {
     target: Ephemeron<ErasedVTableObject, CleanupSignaler>,
     held_value: JsValue,
-    unregister_token: Option<WeakGc<ErasedVTableObject>>,
+    unregister_token: Option<UnregisterToken>,
+}
+
+/// The `[[UnregisterToken]]` field of a [`RegistryCell`].
+#[derive(Trace, Finalize)]
+enum UnregisterToken {
+    /// An object token, held weakly.
+    Object(WeakGc<ErasedVTableObject>),
+    /// A non-registered symbol token.
+    ///
+    /// Symbols are reference counted instead of garbage collected, so the symbol is held
+    /// strongly; this is not observable from ECMAScript code, since a cell never exposes
+    /// its unregister token.
+    Symbol(JsSymbol),
+}
+
+impl UnregisterToken {
+    /// Checks if this token is the [`SameValue`][spec] as `token`.
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-samevalue
+    fn same_value(&self, token: &JsValue) -> bool {
+        match (self, token.variant()) {
+            (UnregisterToken::Object(weak), JsVariant::Object(obj)) => weak
+                .upgrade()
+                .is_some_and(|tok| Gc::ptr_eq(&tok, obj.inner())),
+            (UnregisterToken::Symbol(sym), JsVariant::Symbol(other)) => *sym == other,
+            _ => false,
+        }
+    }
 }
 
 /// Boa's implementation of ECMAScript's [`FinalizationRegistry`] builtin object.
@@ -243,22 +271,24 @@ impl FinalizationRegistry {
 
         // 5. If CanBeHeldWeakly(unregisterToken) is false, then
         //
-        // // [`CanBeHeldWeakly ( v )`](https://tc39.es/ecma262/#sec-canbeheldweakly)
+        // [`CanBeHeldWeakly ( v )`](https://tc39.es/ecma262/#sec-canbeheldweakly)
         //
         // 1. If v is an Object, return true.
         // 2. If v is a Symbol and KeyForSymbol(v) is undefined, return true.
         // 3. Return false.
-        //
-        // TODO: support Symbols
         let unregister_token = match unregister_token.variant() {
-            JsVariant::Object(obj) => Some(WeakGc::new(obj.inner())),
+            JsVariant::Object(obj) => Some(UnregisterToken::Object(WeakGc::new(obj.inner()))),
+            JsVariant::Symbol(sym) if !symbol::is_registered_symbol(&sym) => {
+                Some(UnregisterToken::Symbol(sym))
+            }
             // b. Set unregisterToken to empty.
             JsVariant::Undefined => None,
             // a. If unregisterToken is not undefined, throw a TypeError exception.
             _ => {
                 return Err(js_error!(
                     TypeError: "FinalizationRegistry.prototype.register: \
-                        `unregisterToken` must be an Object, a Symbol, or undefined",
+                        `unregisterToken` must be an Object, a non-registered Symbol, \
+                        or undefined",
                 ));
             }
         };
@@ -299,25 +329,25 @@ impl FinalizationRegistry {
                 )
             })?;
 
-        // 3. If CanBeHeldWeakly(unregisterToken) is false, throw a TypeError exception.\
+        // 3. If CanBeHeldWeakly(unregisterToken) is false, throw a TypeError exception.
         //
-        // // [`CanBeHeldWeakly ( v )`](https://tc39.es/ecma262/#sec-canbeheldweakly)
+        // [`CanBeHeldWeakly ( v )`](https://tc39.es/ecma262/#sec-canbeheldweakly)
         //
         // 1. If v is an Object, return true.
         // 2. If v is a Symbol and KeyForSymbol(v) is undefined, return true.
         // 3. Return false.
-        //
-        // TODO: support Symbols
-        let unregister_token = args.get_or_undefined(0).as_object();
-        let unregister_token = unregister_token
-            .as_ref()
-            .map(JsObject::inner)
-            .ok_or_else(|| {
-                js_error!(
-                    TypeError: "FinalizationRegistry.prototype.unregister: \
-                                `unregisterToken` must be an Object or a Symbol.",
-                )
-            })?;
+        let unregister_token = args.get_or_undefined(0);
+        let can_be_held_weakly = match unregister_token.variant() {
+            JsVariant::Object(_) => true,
+            JsVariant::Symbol(sym) => !symbol::is_registered_symbol(&sym),
+            _ => false,
+        };
+        if !can_be_held_weakly {
+            return Err(js_error!(
+                TypeError: "FinalizationRegistry.prototype.unregister: \
+                            `unregisterToken` must be an Object or a non-registered Symbol.",
+            ));
+        }
 
         // 4. Let removed be false.
         let mut removed = false;
@@ -328,8 +358,7 @@ impl FinalizationRegistry {
 
             // a. If cell.[[UnregisterToken]] is not empty and SameValue(cell.[[UnregisterToken]], unregisterToken) is true, then
             if let Some(tok) = cell.unregister_token.as_ref()
-                && let Some(tok) = tok.upgrade()
-                && Gc::ptr_eq(&tok, unregister_token)
+                && tok.same_value(unregister_token)
             {
                 // i. Remove cell from finalizationRegistry.[[Cells]].
                 let cell = registry.cells.swap_remove(i);

--- a/core/engine/src/builtins/finalization_registry/tests.rs
+++ b/core/engine/src/builtins/finalization_registry/tests.rs
@@ -2,7 +2,7 @@ mod miri {
 
     use indoc::indoc;
 
-    use crate::{TestAction, run_test_actions};
+    use crate::{JsNativeErrorKind, TestAction, run_test_actions};
 
     #[test]
     fn finalization_registry_simple() {
@@ -63,6 +63,50 @@ mod miri {
             TestAction::inspect_context(|ctx| ctx.run_jobs().unwrap()),
             // Registry should handover the held value as argument
             TestAction::assert_eq("counter", 5),
+        ]);
+    }
+
+    #[test]
+    fn finalization_registry_symbol_unregister_token() {
+        run_test_actions([
+            TestAction::run(indoc! {r#"
+            let counter = 0;
+            const registry = new FinalizationRegistry(() => {
+                counter++;
+            });
+            const token = Symbol("token");
+
+            {
+                let array = ["foo"];
+                registry.register(array, undefined, token);
+            }
+        "#}),
+            // An unrelated symbol should not unregister the cell
+            TestAction::assert_eq("registry.unregister(Symbol('token'))", false),
+            TestAction::assert_eq("registry.unregister(token)", true),
+            TestAction::inspect_context(|_| boa_gc::force_collect()),
+            TestAction::inspect_context(|ctx| ctx.run_jobs().unwrap()),
+            // Callback shouldn't run
+            TestAction::assert_eq("counter", 0),
+        ]);
+    }
+
+    #[test]
+    fn finalization_registry_registered_symbol_unregister_token_throws() {
+        run_test_actions([
+            TestAction::run("const registry = new FinalizationRegistry(() => {});"),
+            TestAction::assert_native_error(
+                "registry.register({}, undefined, Symbol.for('token'))",
+                JsNativeErrorKind::Type,
+                "FinalizationRegistry.prototype.register: `unregisterToken` must be \
+                an Object, a non-registered Symbol, or undefined",
+            ),
+            TestAction::assert_native_error(
+                "registry.unregister(Symbol.for('token'))",
+                JsNativeErrorKind::Type,
+                "FinalizationRegistry.prototype.unregister: `unregisterToken` must be \
+                an Object or a non-registered Symbol.",
+            ),
         ]);
     }
 

--- a/core/engine/src/builtins/symbol/mod.rs
+++ b/core/engine/src/builtins/symbol/mod.rs
@@ -86,6 +86,20 @@ impl GlobalSymbolRegistry {
 
         None
     }
+
+    fn contains(&self, sym: &JsSymbol) -> bool {
+        self.symbols.contains_key(sym)
+    }
+}
+
+/// Checks if `sym` is a `Symbol` registered in the global symbol registry.
+///
+/// Equivalent to checking if the abstract operation [`KeyForSymbol ( sym )`][spec] returns
+/// a string.
+///
+/// [spec]: https://tc39.es/ecma262/#sec-keyforsymbol
+pub(crate) fn is_registered_symbol(sym: &JsSymbol) -> bool {
+    GLOBAL_SYMBOL_REGISTRY.contains(sym)
 }
 
 /// The internal representation of a `Symbol` object.


### PR DESCRIPTION
This PR implements the symbol branch of the [`CanBeHeldWeakly`](https://tc39.es/ecma262/#sec-canbeheldweakly) abstract operation for `FinalizationRegistry.prototype.register` and `FinalizationRegistry.prototype.unregister`, resolving the `TODO: support Symbols` markers for unregister token validation.

Closes #5253

## Changes

- `unregisterToken` in `register` now accepts non-registered symbols. Symbols registered in the global symbol registry (created via `Symbol.for`) throw a `TypeError`, since `KeyForSymbol` returns a string for them.
- `unregister` validates its argument with the same `CanBeHeldWeakly` semantics and matches symbol tokens by `SameValue`.
- `RegistryCell.unregister_token` is now an `UnregisterToken` enum: object tokens keep the existing `WeakGc` weak-holding behavior, while symbol tokens store the `JsSymbol` directly. Symbols are reference counted rather than garbage collected, and a cell never exposes its token, so this is not observable from ECMAScript code.
- Added a `pub(crate) fn is_registered_symbol` helper next to the global symbol registry, usable by future `CanBeHeldWeakly` call sites (`WeakMap`/`WeakSet`/`WeakRef`).

## Out of scope

Symbol **targets** in `register` and symbol keys for `WeakMap`/`WeakSet`/`WeakRef` need actual weak symbol support, so the `symbols-as-weakmap-keys` test262 feature stays in the ignore list for now. When run directly, `test/built-ins/FinalizationRegistry/prototype/unregister/unregister-symbol-token.js` now passes in both strict and non-strict modes.

## Testing

- New unit tests covering: unregistering via a symbol token, unrelated symbol tokens not matching, and `TypeError` for registered symbols in both methods.
- `cargo test -p boa_engine` passes (1092 tests).
- `cargo clippy --all-features` and `cargo fmt --check` are clean.

Example from the issue now behaves per spec:
```js
const registry = new FinalizationRegistry(heldValue => {});

registry.register({}, "val", Symbol("local")); // ok
registry.unregister(Symbol.for("global"));     // TypeError
registry.register({}, "val", Symbol.for("global")); // TypeError
```