### PR TITLE
fix(parser): parse default async arrow exports

### DIFF
--- a/core/parser/src/parser/statement/declaration/export.rs
+++ b/core/parser/src/parser/statement/declaration/export.rs
@@ -184,17 +184,27 @@ where
                         }
                     }
                     TokenKind::Keyword((Keyword::Async, false)) => {
-                        let next_token = cursor.peek(2, interner).or_abrupt()?;
-                        if next_token.kind() == &TokenKind::Punctuator(Punctuator::Mul) {
-                            AstExportDeclaration::DefaultAsyncGeneratorDeclaration(
-                                AsyncGeneratorDeclaration::new(false, true, true)
-                                    .parse(cursor, interner)?,
-                            )
+                        let next_token = cursor.peek(1, interner).or_abrupt()?;
+                        if next_token.kind() == &TokenKind::Keyword((Keyword::Function, false)) {
+                            let following_token = cursor.peek(2, interner).or_abrupt()?;
+                            if following_token.kind() == &TokenKind::Punctuator(Punctuator::Mul) {
+                                AstExportDeclaration::DefaultAsyncGeneratorDeclaration(
+                                    AsyncGeneratorDeclaration::new(false, true, true)
+                                        .parse(cursor, interner)?,
+                                )
+                            } else {
+                                AstExportDeclaration::DefaultAsyncFunctionDeclaration(
+                                    AsyncFunctionDeclaration::new(false, true, true)
+                                        .parse(cursor, interner)?,
+                                )
+                            }
                         } else {
-                            AstExportDeclaration::DefaultAsyncFunctionDeclaration(
-                                AsyncFunctionDeclaration::new(false, true, true)
-                                    .parse(cursor, interner)?,
-                            )
+                            let expr = AssignmentExpression::new(true, false, true)
+                                .parse(cursor, interner)?;
+
+                            cursor.expect_semicolon("default expression export", interner)?;
+
+                            AstExportDeclaration::DefaultAssignmentExpression(expr)
                         }
                     }
                     TokenKind::Keyword((Keyword::Class, false)) => {

--- a/core/parser/src/parser/statement/declaration/tests.rs
+++ b/core/parser/src/parser/statement/declaration/tests.rs
@@ -663,6 +663,22 @@ fn import_non_string_attribute_value() {
     );
 }
 
+/// Checks async arrow functions in default exports.
+#[test]
+fn default_export_async_arrow_function() {
+    let scope = boa_ast::scope::Scope::new_global();
+
+    for source in [
+        "export default async () => 1;",
+        "export default async x => x;",
+        "export default async (a, b) => a + b;",
+    ] {
+        Parser::new(Source::from_bytes(source))
+            .parse_module(&scope, &mut Interner::default())
+            .expect("async arrow function should parse as a default export");
+    }
+}
+
 /// Checks `using` declaration parsing.
 #[test]
 fn using_declaration() {


### PR DESCRIPTION
Fixes #5442.

## Summary

- distinguish async function declarations from async arrow expressions after `export default`
- parse async arrow functions through the default assignment-expression path
- add regression coverage for parenthesized, unparenthesized, and multi-parameter forms

## Testing

- `cargo test -p boa_parser`
- `cargo clippy -p boa_parser --all-targets -- -D warnings`
- `cargo fmt --all -- --check`