### PR TITLE
[oscars-inetgration] refactor: add 'gc lifetime to core gc types

### DIFF
--- a/core/engine/src/builtins/function/arguments.rs
+++ b/core/engine/src/builtins/function/arguments.rs
@@ -83,7 +83,7 @@ impl UnmappedArguments {
 pub(crate) struct MappedArguments {
     #[unsafe_ignore_trace]
     binding_indices: Vec<Option<u32>>,
-    environment: Gc<DeclarativeEnvironment>,
+    environment: Gc<'static, DeclarativeEnvironment>,
 }
 
 impl JsData for MappedArguments {
@@ -215,7 +215,7 @@ impl MappedArguments {
         func: &JsObject,
         binding_indices: &[Option<u32>],
         arguments_list: &[JsValue],
-        env: &Gc<DeclarativeEnvironment>,
+        env: &Gc<'static, DeclarativeEnvironment>,
         context: &Context,
     ) -> JsObject {
         // 1. Assert: formals does not contain a rest parameter, any binding patterns, or any initializers.

--- a/core/engine/src/builtins/function/mod.rs
+++ b/core/engine/src/builtins/function/mod.rs
@@ -166,7 +166,7 @@ unsafe impl Trace for ClassFieldDefinition {
 #[derive(Debug, Trace, Finalize)]
 pub struct OrdinaryFunction {
     /// The code block containing the compiled function.
-    pub(crate) code: Gc<CodeBlock>,
+    pub(crate) code: Gc<'static, CodeBlock>,
 
     /// The `[[Environment]]` internal slot.
     pub(crate) environments: EnvironmentStack,
@@ -210,7 +210,7 @@ impl JsData for OrdinaryFunction {
 
 impl OrdinaryFunction {
     pub(crate) fn new(
-        code: Gc<CodeBlock>,
+        code: Gc<'static, CodeBlock>,
         environments: EnvironmentStack,
         script_or_module: Option<ActiveRunnable>,
         realm: Realm,
@@ -233,7 +233,10 @@ impl OrdinaryFunction {
     }
 
     /// Push a private environment to the function.
-    pub(crate) fn push_private_environment(&mut self, environment: Gc<PrivateEnvironment>) {
+    pub(crate) fn push_private_environment(
+        &mut self,
+        environment: Gc<'static, PrivateEnvironment>,
+    ) {
         self.environments.push_private(environment);
     }
 

--- a/core/engine/src/builtins/promise/mod.rs
+++ b/core/engine/src/builtins/promise/mod.rs
@@ -646,7 +646,7 @@ impl Promise {
             #[unsafe_ignore_trace]
             already_called: Rc<Cell<bool>>,
             index: usize,
-            values: Gc<GcRefCell<Vec<JsValue>>>,
+            values: Gc<'static, GcRefCell<Vec<JsValue>>>,
             capability_resolve: JsFunction,
             #[unsafe_ignore_trace]
             remaining_elements_count: Rc<Cell<i32>>,
@@ -861,7 +861,7 @@ impl Promise {
             #[unsafe_ignore_trace]
             already_called: Rc<Cell<bool>>,
             index: usize,
-            values: Gc<GcRefCell<Vec<JsValue>>>,
+            values: Gc<'static, GcRefCell<Vec<JsValue>>>,
             capability: JsFunction,
             #[unsafe_ignore_trace]
             remaining_elements: Rc<Cell<i32>>,
@@ -1222,7 +1222,7 @@ impl Promise {
             variant: KeyedVariant,
             #[unsafe_ignore_trace]
             keys: Rc<RefCell<Vec<PropertyKey>>>,
-            values: Gc<GcRefCell<Vec<JsValue>>>,
+            values: Gc<'static, GcRefCell<Vec<JsValue>>>,
             capability: JsFunction,
             #[unsafe_ignore_trace]
             remaining_elements: Rc<Cell<i32>>,
@@ -1538,7 +1538,7 @@ impl Promise {
             #[unsafe_ignore_trace]
             already_called: Rc<Cell<bool>>,
             index: usize,
-            errors: Gc<GcRefCell<Vec<JsValue>>>,
+            errors: Gc<'static, GcRefCell<Vec<JsValue>>>,
             capability_reject: JsFunction,
             #[unsafe_ignore_trace]
             remaining_elements_count: Rc<Cell<i32>>,

--- a/core/engine/src/bytecompiler/class.rs
+++ b/core/engine/src/bytecompiler/class.rs
@@ -20,11 +20,11 @@ use thin_vec::ThinVec;
 // Static class elements that are initialized at a later time in the class creation.
 enum StaticElement {
     // A static class block with it's function code.
-    StaticBlock(Gc<CodeBlock>),
+    StaticBlock(Gc<'static, CodeBlock>),
 
     // A static class field with it's function code, an optional name index and the information if the function is an anonymous function.
     StaticField {
-        code: Gc<CodeBlock>,
+        code: Gc<'static, CodeBlock>,
         name_index: StaticFieldName,
         is_anonymous_function: bool,
     },

--- a/core/engine/src/bytecompiler/function.rs
+++ b/core/engine/src/bytecompiler/function.rs
@@ -122,7 +122,7 @@ impl FunctionCompiler {
         scopes: &FunctionScopes,
         contains_direct_eval: bool,
         interner: &mut Interner,
-    ) -> Gc<CodeBlock> {
+    ) -> Gc<'static, CodeBlock> {
         self.strict = self.strict || body.strict();
 
         let length = parameters.length();

--- a/core/engine/src/bytecompiler/mod.rs
+++ b/core/engine/src/bytecompiler/mod.rs
@@ -812,7 +812,7 @@ impl<'ctx> ByteCompiler<'ctx> {
 
     #[inline]
     #[must_use]
-    pub(crate) fn push_function_to_constants(&mut self, function: Gc<CodeBlock>) -> u32 {
+    pub(crate) fn push_function_to_constants(&mut self, function: Gc<'static, CodeBlock>) -> u32 {
         let index = self.constants.len() as u32;
         self.constants.push(Constant::Function(function));
         index

--- a/core/engine/src/environments/runtime/mod.rs
+++ b/core/engine/src/environments/runtime/mod.rs
@@ -27,7 +27,7 @@ pub(crate) use self::{
 #[derive(Clone, Debug, Trace, Finalize)]
 pub(crate) struct EnvironmentNode {
     env: Environment,
-    parent: Option<Gc<EnvironmentNode>>,
+    parent: Option<Gc<'static, EnvironmentNode>>,
 }
 
 /// The environment stack holds all environments at runtime.
@@ -42,32 +42,32 @@ pub(crate) struct EnvironmentNode {
 #[derive(Clone, Debug, Trace, Finalize)]
 pub(crate) struct EnvironmentStack {
     /// The tip (most recently pushed) environment in the chain.
-    tip: Option<Gc<EnvironmentNode>>,
+    tip: Option<Gc<'static, EnvironmentNode>>,
 
     /// Number of environments in the chain (not counting global).
     #[unsafe_ignore_trace]
     depth: u32,
 
-    private_stack: ThinVec<Gc<PrivateEnvironment>>,
+    private_stack: ThinVec<Gc<'static, PrivateEnvironment>>,
 }
 
 /// Saved environment state for `pop_to_global` / `restore_from_saved`.
 /// Used by indirect `eval` and `Function.prototype.toString` recompilation.
 pub(crate) struct SavedEnvironments {
-    tip: Option<Gc<EnvironmentNode>>,
+    tip: Option<Gc<'static, EnvironmentNode>>,
     depth: u32,
 }
 
 /// A runtime environment.
 #[derive(Clone, Debug, Trace, Finalize)]
 pub(crate) enum Environment {
-    Declarative(Gc<DeclarativeEnvironment>),
+    Declarative(Gc<'static, DeclarativeEnvironment>),
     Object(JsObject),
 }
 
 impl Environment {
     /// Returns the declarative environment if it is one.
-    pub(crate) const fn as_declarative(&self) -> Option<&Gc<DeclarativeEnvironment>> {
+    pub(crate) const fn as_declarative(&self) -> Option<&Gc<'static, DeclarativeEnvironment>> {
         match self {
             Self::Declarative(env) => Some(env),
             Self::Object(_) => None,
@@ -86,7 +86,9 @@ impl EnvironmentStack {
     }
 
     /// Gets the next outer function environment.
-    pub(crate) fn outer_function_environment(&self) -> Option<(Gc<DeclarativeEnvironment>, Scope)> {
+    pub(crate) fn outer_function_environment(
+        &self,
+    ) -> Option<(Gc<'static, DeclarativeEnvironment>, Scope)> {
         for (env, _) in self.iter_from_tip() {
             if let Some(decl) = env.as_declarative()
                 && let Some(function_env) = decl.kind().as_function()
@@ -170,7 +172,7 @@ impl EnvironmentStack {
     /// [spec]: https://tc39.es/ecma262/#sec-getthisenvironment
     pub(crate) fn get_this_environment<'a>(
         &'a self,
-        global: &'a Gc<DeclarativeEnvironment>,
+        global: &'a Gc<'static, DeclarativeEnvironment>,
     ) -> &'a DeclarativeEnvironmentKind {
         for (env, _) in self.iter_from_tip() {
             if let Some(decl) = env.as_declarative().filter(|decl| decl.has_this_binding()) {
@@ -211,7 +213,7 @@ impl EnvironmentStack {
     pub(crate) fn push_lexical(
         &mut self,
         bindings_count: u32,
-        global: &Gc<DeclarativeEnvironment>,
+        global: &Gc<'static, DeclarativeEnvironment>,
     ) -> u32 {
         let (poisoned, with) = self.compute_poisoned_with(global);
 
@@ -233,7 +235,7 @@ impl EnvironmentStack {
         &mut self,
         scope: Scope,
         function_slots: FunctionSlots,
-        global: &Gc<DeclarativeEnvironment>,
+        global: &Gc<'static, DeclarativeEnvironment>,
     ) {
         let num_bindings = scope.num_bindings_non_local();
 
@@ -278,8 +280,8 @@ impl EnvironmentStack {
     /// Get the most outer environment.
     pub(crate) fn current_declarative_ref<'a>(
         &'a self,
-        global: &'a Gc<DeclarativeEnvironment>,
-    ) -> Option<&'a Gc<DeclarativeEnvironment>> {
+        global: &'a Gc<'static, DeclarativeEnvironment>,
+    ) -> Option<&'a Gc<'static, DeclarativeEnvironment>> {
         if let Some(env) = self.last() {
             env.as_declarative()
         } else {
@@ -289,7 +291,10 @@ impl EnvironmentStack {
 
     /// Mark that there may be added bindings from the current environment to the next function
     /// environment.
-    pub(crate) fn poison_until_last_function(&mut self, global: &Gc<DeclarativeEnvironment>) {
+    pub(crate) fn poison_until_last_function(
+        &mut self,
+        global: &Gc<'static, DeclarativeEnvironment>,
+    ) {
         for (env, _) in self.iter_from_tip() {
             if let Some(decl) = env.as_declarative() {
                 decl.poison();
@@ -312,7 +317,7 @@ impl EnvironmentStack {
         environment: BindingLocatorScope,
         binding_index: u32,
         value: JsValue,
-        global: &Gc<DeclarativeEnvironment>,
+        global: &Gc<'static, DeclarativeEnvironment>,
     ) {
         let env = match environment {
             BindingLocatorScope::GlobalObject | BindingLocatorScope::GlobalDeclarative => global,
@@ -335,7 +340,7 @@ impl EnvironmentStack {
         environment: BindingLocatorScope,
         binding_index: u32,
         value: JsValue,
-        global: &Gc<DeclarativeEnvironment>,
+        global: &Gc<'static, DeclarativeEnvironment>,
     ) {
         let env = match environment {
             BindingLocatorScope::GlobalObject | BindingLocatorScope::GlobalDeclarative => global,
@@ -350,7 +355,7 @@ impl EnvironmentStack {
     }
 
     /// Push a private environment to the private environment stack.
-    pub(crate) fn push_private(&mut self, environment: Gc<PrivateEnvironment>) {
+    pub(crate) fn push_private(&mut self, environment: Gc<'static, PrivateEnvironment>) {
         self.private_stack.push(environment);
     }
 
@@ -413,7 +418,7 @@ impl EnvironmentStack {
     }
 
     /// Compute the `(poisoned, with)` flags for a new environment.
-    fn compute_poisoned_with(&self, global: &Gc<DeclarativeEnvironment>) -> (bool, bool) {
+    fn compute_poisoned_with(&self, global: &Gc<'static, DeclarativeEnvironment>) -> (bool, bool) {
         let with = if let Some(env) = self.last() {
             env.as_declarative().is_none()
         } else {

--- a/core/engine/src/module/mod.rs
+++ b/core/engine/src/module/mod.rs
@@ -170,7 +170,7 @@ impl ModuleRequest {
 /// [spec]: https://tc39.es/ecma262/#sec-abstract-module-records
 #[derive(Clone, Trace, Finalize)]
 pub struct Module {
-    inner: Gc<ModuleRepr>,
+    inner: Gc<'static, ModuleRepr>,
 }
 
 impl std::fmt::Debug for Module {
@@ -382,7 +382,7 @@ impl Module {
     }
 
     /// Gets the declarative environment of this `Module`.
-    pub(crate) fn environment(&self) -> Option<Gc<DeclarativeEnvironment>> {
+    pub(crate) fn environment(&self) -> Option<Gc<'static, DeclarativeEnvironment>> {
         match self.kind() {
             ModuleKind::SourceText(src) => src.environment(),
             ModuleKind::Synthetic(syn) => syn.environment(),
@@ -808,7 +808,7 @@ fn into_js_module() {
     use std::cell::RefCell;
     use std::rc::Rc;
 
-    type ResultType = Gc<GcRefCell<JsValue>>;
+    type ResultType = Gc<'static, GcRefCell<JsValue>>;
 
     let loader = Rc::new(MapModuleLoader::default());
     let mut context = Context::builder()

--- a/core/engine/src/module/source.rs
+++ b/core/engine/src/module/source.rs
@@ -68,17 +68,17 @@ enum ModuleStatus {
         ancestor_index: usize,
     },
     PreLinked {
-        environment: Gc<DeclarativeEnvironment>,
+        environment: Gc<'static, DeclarativeEnvironment>,
         context: SourceTextContext,
         ancestor_index: usize,
     },
     Linked {
-        environment: Gc<DeclarativeEnvironment>,
+        environment: Gc<'static, DeclarativeEnvironment>,
         context: SourceTextContext,
         ancestor_index: usize,
     },
     Evaluating {
-        environment: Gc<DeclarativeEnvironment>,
+        environment: Gc<'static, DeclarativeEnvironment>,
         context: SourceTextContext,
         top_level_capability: Option<PromiseCapability>,
         cycle_root: Module,
@@ -86,7 +86,7 @@ enum ModuleStatus {
         async_evaluation_order: Option<usize>,
     },
     EvaluatingAsync {
-        environment: Gc<DeclarativeEnvironment>,
+        environment: Gc<'static, DeclarativeEnvironment>,
         context: SourceTextContext,
         top_level_capability: Option<PromiseCapability>,
         cycle_root: Module,
@@ -94,7 +94,7 @@ enum ModuleStatus {
         pending_async_dependencies: usize,
     },
     Evaluated {
-        environment: Gc<DeclarativeEnvironment>,
+        environment: Gc<'static, DeclarativeEnvironment>,
         top_level_capability: Option<PromiseCapability>,
         cycle_root: Module,
         error: Option<JsError>,
@@ -196,7 +196,7 @@ impl ModuleStatus {
     }
 
     /// Gets the declarative environment from the module status.
-    fn environment(&self) -> Option<Gc<DeclarativeEnvironment>> {
+    fn environment(&self) -> Option<Gc<'static, DeclarativeEnvironment>> {
         match self {
             ModuleStatus::Unlinked { .. } | ModuleStatus::Linking { .. } => None,
             ModuleStatus::PreLinked { environment, .. }
@@ -231,7 +231,7 @@ impl ModuleStatus {
 #[derive(Clone, Trace, Finalize)]
 #[boa_gc(unsafe_no_drop)]
 struct SourceTextContext {
-    codeblock: Gc<CodeBlock>,
+    codeblock: Gc<'static, CodeBlock>,
     environments: EnvironmentStack,
     realm: Realm,
 }
@@ -2031,7 +2031,7 @@ impl SourceTextModule {
     }
 
     /// Gets the declarative environment of this module.
-    pub(crate) fn environment(&self) -> Option<Gc<DeclarativeEnvironment>> {
+    pub(crate) fn environment(&self) -> Option<Gc<'static, DeclarativeEnvironment>> {
         self.status.borrow().environment()
     }
 }

--- a/core/engine/src/module/synthetic.rs
+++ b/core/engine/src/module/synthetic.rs
@@ -53,7 +53,7 @@ where
 /// **Undefined Behaviour**.
 #[derive(Clone, Trace, Finalize)]
 pub struct SyntheticModuleInitializer {
-    inner: Gc<dyn TraceableCallback>,
+    inner: Gc<'static, dyn TraceableCallback>,
 }
 
 impl std::fmt::Debug for SyntheticModuleInitializer {
@@ -147,11 +147,11 @@ enum ModuleStatus {
     #[default]
     Unlinked,
     Linked {
-        environment: Gc<DeclarativeEnvironment>,
-        eval_context: (EnvironmentStack, Gc<CodeBlock>),
+        environment: Gc<'static, DeclarativeEnvironment>,
+        eval_context: (EnvironmentStack, Gc<'static, CodeBlock>),
     },
     Evaluated {
-        environment: Gc<DeclarativeEnvironment>,
+        environment: Gc<'static, DeclarativeEnvironment>,
         promise: JsPromise,
     },
 }
@@ -450,7 +450,7 @@ impl SyntheticModule {
         Ok(promise)
     }
 
-    pub(crate) fn environment(&self) -> Option<Gc<DeclarativeEnvironment>> {
+    pub(crate) fn environment(&self) -> Option<Gc<'static, DeclarativeEnvironment>> {
         match &*self.state.borrow() {
             ModuleStatus::Unlinked => None,
             ModuleStatus::Linked { environment, .. }

--- a/core/engine/src/native_function/continuation.rs
+++ b/core/engine/src/native_function/continuation.rs
@@ -72,7 +72,7 @@ where
 /// **Undefined Behaviour**.
 #[derive(Clone, Trace, Finalize)]
 pub(crate) struct NativeCoroutine {
-    inner: Gc<dyn TraceableCoroutine>,
+    inner: Gc<'static, dyn TraceableCoroutine>,
 }
 
 impl std::fmt::Debug for NativeCoroutine {

--- a/core/engine/src/native_function/mod.rs
+++ b/core/engine/src/native_function/mod.rs
@@ -134,7 +134,7 @@ pub struct NativeFunction {
 #[derive(Clone)]
 enum Inner {
     PointerFn(NativeFunctionPointer),
-    Closure(Gc<dyn TraceableClosure>),
+    Closure(Gc<'static, dyn TraceableClosure>),
 }
 
 // Manual implementation because deriving `Trace` triggers the `single_use_lifetimes` lint.

--- a/core/engine/src/object/builtins/jspromise.rs
+++ b/core/engine/src/object/builtins/jspromise.rs
@@ -1427,7 +1427,7 @@ impl TryIntoJs for JsPromise {
 ///
 /// The only way to construct an instance of `JsFuture` is by calling [`JsPromise::into_js_future`].
 pub struct JsFuture {
-    inner: Gc<GcRefCell<Inner>>,
+    inner: Gc<'static, GcRefCell<Inner>>,
 }
 
 impl std::fmt::Debug for JsFuture {

--- a/core/engine/src/object/datatypes.rs
+++ b/core/engine/src/object/datatypes.rs
@@ -201,7 +201,7 @@ impl<T> JsData for Cell<Option<T>> {}
 #[cfg(feature = "intl")]
 default_impls!(icu_locale::Locale);
 
-impl<T: Trace + ?Sized> JsData for Gc<T> {}
+impl<T: Trace + ?Sized> JsData for Gc<'static, T> {}
 
 impl<T: Trace + ?Sized> JsData for WeakGc<T> {}
 

--- a/core/engine/src/object/jsobject.rs
+++ b/core/engine/src/object/jsobject.rs
@@ -60,7 +60,7 @@ impl JsData for ErasedObjectData {}
 #[derive(Trace, Finalize)]
 #[boa_gc(unsafe_no_drop)]
 pub struct JsObject<T: NativeObject = ErasedObjectData> {
-    inner: Gc<VTableObject<T>>,
+    inner: Gc<'static, VTableObject<T>>,
 }
 
 impl<T: NativeObject> Clone for JsObject<T> {
@@ -1038,11 +1038,11 @@ impl<T: NativeObject> JsObject<T> {
         self.inner.vtable
     }
 
-    pub(crate) fn inner(&self) -> &Gc<VTableObject<T>> {
+    pub(crate) fn inner(&self) -> &Gc<'static, VTableObject<T>> {
         &self.inner
     }
 
-    pub(crate) fn from_inner(inner: Gc<VTableObject<T>>) -> Self {
+    pub(crate) fn from_inner(inner: Gc<'static, VTableObject<T>>) -> Self {
         Self { inner }
     }
 
@@ -1158,9 +1158,9 @@ impl<T: NativeObject> AsRef<GcRefCell<Object<T>>> for JsObject<T> {
     }
 }
 
-impl<T: NativeObject> From<Gc<VTableObject<T>>> for JsObject<T> {
+impl<T: NativeObject> From<Gc<'static, VTableObject<T>>> for JsObject<T> {
     #[inline]
-    fn from(inner: Gc<VTableObject<T>>) -> Self {
+    fn from(inner: Gc<'static, VTableObject<T>>) -> Self {
         Self { inner }
     }
 }

--- a/core/engine/src/object/shape/shared_shape/forward_transition.rs
+++ b/core/engine/src/object/shape/shared_shape/forward_transition.rs
@@ -54,7 +54,11 @@ pub(super) struct ForwardTransition {
 
 impl ForwardTransition {
     /// Insert a property transition.
-    pub(super) fn insert_property(&self, key: TransitionKey, value: &Gc<SharedShapeInner>) {
+    pub(super) fn insert_property(
+        &self,
+        key: TransitionKey,
+        value: &Gc<'static, SharedShapeInner>,
+    ) {
         let mut this = self.inner.borrow_mut();
         let properties = this.properties.get_or_insert_with(Box::default);
 
@@ -66,7 +70,7 @@ impl ForwardTransition {
     }
 
     /// Insert a prototype transition.
-    pub(super) fn insert_prototype(&self, key: JsPrototype, value: &Gc<SharedShapeInner>) {
+    pub(super) fn insert_prototype(&self, key: JsPrototype, value: &Gc<'static, SharedShapeInner>) {
         let mut this = self.inner.borrow_mut();
         let prototypes = this.prototypes.get_or_insert_with(Box::default);
 

--- a/core/engine/src/object/shape/shared_shape/mod.rs
+++ b/core/engine/src/object/shape/shared_shape/mod.rs
@@ -110,7 +110,7 @@ struct Inner {
 /// Represents a shared object shape.
 #[derive(Debug, Trace, Finalize, Clone)]
 pub struct SharedShape {
-    inner: Gc<Inner>,
+    inner: Gc<'static, Inner>,
 }
 
 impl SharedShape {

--- a/core/engine/src/object/shape/unique_shape.rs
+++ b/core/engine/src/object/shape/unique_shape.rs
@@ -30,7 +30,7 @@ struct Inner {
 /// Cloning this does a shallow clone.
 #[derive(Default, Debug, Clone, Trace, Finalize)]
 pub(crate) struct UniqueShape {
-    inner: Gc<Inner>,
+    inner: Gc<'static, Inner>,
 }
 
 impl UniqueShape {

--- a/core/engine/src/realm.rs
+++ b/core/engine/src/realm.rs
@@ -30,7 +30,7 @@ use rustc_hash::FxHashMap;
 /// In the specification these are called Realm Records.
 #[derive(Clone, Trace, Finalize)]
 pub struct Realm {
-    inner: Gc<Inner>,
+    inner: Gc<'static, Inner>,
 }
 
 impl Eq for Realm {}
@@ -57,7 +57,7 @@ struct Inner {
     intrinsics: Intrinsics,
 
     /// The global declarative environment of this realm.
-    environment: Gc<DeclarativeEnvironment>,
+    environment: Gc<'static, DeclarativeEnvironment>,
 
     /// The global scope of this realm.
     /// This is directly related to the global declarative environment.
@@ -162,7 +162,7 @@ impl Realm {
             .cloned()
     }
 
-    pub(crate) fn environment(&self) -> &Gc<DeclarativeEnvironment> {
+    pub(crate) fn environment(&self) -> &Gc<'static, DeclarativeEnvironment> {
         &self.inner.environment
     }
 

--- a/core/engine/src/script.rs
+++ b/core/engine/src/script.rs
@@ -30,7 +30,7 @@ use crate::{
 /// [spec]: https://tc39.es/ecma262/#sec-script-records
 #[derive(Clone, Trace, Finalize)]
 pub struct Script {
-    inner: Gc<Inner>,
+    inner: Gc<'static, Inner>,
 }
 
 impl std::fmt::Debug for Script {
@@ -46,7 +46,7 @@ impl std::fmt::Debug for Script {
 #[derive(Trace, Debug, Finalize)]
 enum ScriptPhase {
     Ast(#[unsafe_ignore_trace] boa_ast::Script),
-    Codeblock(Gc<CodeBlock>),
+    Codeblock(Gc<'static, CodeBlock>),
 }
 
 #[derive(Trace, Finalize)]
@@ -118,7 +118,7 @@ impl Script {
     /// Compiles the codeblock of this script.
     ///
     /// This is a no-op if this has been called previously.
-    pub fn codeblock(&self, context: &mut Context) -> JsResult<Gc<CodeBlock>> {
+    pub fn codeblock(&self, context: &mut Context) -> JsResult<Gc<'static, CodeBlock>> {
         let cb = {
             let phase = self.inner.phase.borrow();
             let source = match &*phase {

--- a/core/engine/src/vm/call_frame/mod.rs
+++ b/core/engine/src/vm/call_frame/mod.rs
@@ -46,7 +46,7 @@ pub struct CallFrameLocation {
 /// A `CallFrame` holds the state of a function call.
 #[derive(Clone, Debug, Finalize, Trace)]
 pub struct CallFrame {
-    pub(crate) code_block: Gc<CodeBlock>,
+    pub(crate) code_block: Gc<'static, CodeBlock>,
     pub(crate) pc: u32,
     /// The frame pointer, points to the start of this frame's data in the stack
     /// (i.e., the `this` value position).
@@ -87,7 +87,7 @@ impl CallFrame {
     /// Retrieves the [`CodeBlock`] of this call frame.
     #[inline]
     #[must_use]
-    pub const fn code_block(&self) -> &Gc<CodeBlock> {
+    pub const fn code_block(&self) -> &Gc<'static, CodeBlock> {
         &self.code_block
     }
 
@@ -136,7 +136,7 @@ impl CallFrame {
 
     /// Creates a new `CallFrame` with the provided `CodeBlock`.
     pub(crate) fn new(
-        code_block: Gc<CodeBlock>,
+        code_block: Gc<'static, CodeBlock>,
         active_runnable: Option<ActiveRunnable>,
         environments: EnvironmentStack,
         realm: Realm,

--- a/core/engine/src/vm/code_block.rs
+++ b/core/engine/src/vm/code_block.rs
@@ -100,7 +100,7 @@ impl Handler {
 pub(crate) enum Constant {
     /// Property field names and private names `[[description]]`s.
     String(JsString),
-    Function(Gc<CodeBlock>),
+    Function(Gc<'static, CodeBlock>),
     BigInt(#[unsafe_ignore_trace] JsBigInt),
 
     /// Declarative or function scope.
@@ -324,13 +324,13 @@ impl CodeBlock {
         panic!("expected string constant at index {index}")
     }
 
-    /// Get the function ([`Gc<CodeBlock>`]) constant from the [`CodeBlock`].
+    /// Get the function ([`Gc<'static, CodeBlock>`]) constant from the [`CodeBlock`].
     ///
     /// # Panics
     ///
     /// If the type of the [`Constant`] is not [`Constant::Function`].
     /// Or `index` is greater or equal to length of `constants`.
-    pub(crate) fn constant_function(&self, index: usize) -> Gc<Self> {
+    pub(crate) fn constant_function(&self, index: usize) -> Gc<'static, Self> {
         if let Some(Constant::Function(value)) = self.constants.get(index) {
             return value.clone();
         }
@@ -1092,7 +1092,7 @@ impl Display for CodeBlock {
 ///
 /// This is slower than direct object template construction that is done in [`create_function_object_fast`].
 pub(crate) fn create_function_object(
-    code: Gc<CodeBlock>,
+    code: Gc<'static, CodeBlock>,
     prototype: JsObject,
     context: &mut Context,
 ) -> JsObject {
@@ -1163,7 +1163,10 @@ pub(crate) fn create_function_object(
 /// This is preferred over [`create_function_object`] if prototype is [`None`],
 /// because it constructs the function from a pre-initialized object template,
 /// with all the properties and prototype set.
-pub(crate) fn create_function_object_fast(code: Gc<CodeBlock>, context: &mut Context) -> JsObject {
+pub(crate) fn create_function_object_fast(
+    code: Gc<'static, CodeBlock>,
+    context: &mut Context,
+) -> JsObject {
     let name: JsValue = code.name().clone().into();
     let length: JsValue = code.length.into();
 

--- a/core/engine/src/vm/inline_cache/tests.rs
+++ b/core/engine/src/vm/inline_cache/tests.rs
@@ -316,7 +316,7 @@ fn set_internal_method() {
     assert_eq!(context.slot().index, slot.index);
 }
 
-fn get_codeblock(value: &JsValue) -> Option<(JsObject, Gc<CodeBlock>)> {
+fn get_codeblock(value: &JsValue) -> Option<(JsObject, Gc<'static, CodeBlock>)> {
     let object = value.as_object()?.clone();
     let code = object.downcast_ref::<OrdinaryFunction>()?.code.clone();
 

--- a/core/gc/src/boa_allocator.rs
+++ b/core/gc/src/boa_allocator.rs
@@ -1,4 +1,7 @@
-use super::*;
+use super::{
+    Cell, EphemeronBox, ErasedEphemeronBox, ErasedWeakMapBox, Gc, GcBox, GcRefCell, NonNull,
+    NonTraceable, RawWeakMap, RefCell, Trace, Tracer, WeakGc, WeakMap, WeakMapBox, mem,
+};
 
 pub(crate) type GcErasedPointer = NonNull<GcBox<NonTraceable>>;
 pub(crate) type EphemeronPointer = NonNull<dyn ErasedEphemeronBox>;

--- a/core/gc/src/internals/ephemeron_box.rs
+++ b/core/gc/src/internals/ephemeron_box.rs
@@ -16,7 +16,7 @@ struct Data<K: Trace + ?Sized + 'static, V: Trace + 'static> {
 
 impl<K: Trace + ?Sized, V: Trace> EphemeronBox<K, V> {
     /// Creates a new `EphemeronBox` that tracks `key` and has `value` as its inner data.
-    pub(crate) fn new(key: &Gc<K>, value: V) -> Self {
+    pub(crate) fn new(key: &Gc<'_, K>, value: V) -> Self {
         Self {
             header: GcHeader::new(),
             data: UnsafeCell::new(Some(Data {
@@ -88,7 +88,7 @@ impl<K: Trace + ?Sized, V: Trace> EphemeronBox<K, V> {
     ///
     /// The caller must ensure there are no live mutable references to the ephemeron box's data
     /// before calling this method.
-    pub(crate) unsafe fn set(&self, key: &Gc<K>, value: V) {
+    pub(crate) unsafe fn set(&self, key: &Gc<'_, K>, value: V) {
         // SAFETY: The caller must ensure setting the key and value of the ephemeron box is safe.
         unsafe {
             *self.data.get() = Some(Data {

--- a/core/gc/src/pointers/ephemeron.rs
+++ b/core/gc/src/pointers/ephemeron.rs
@@ -15,7 +15,7 @@ use std::{ops::Deref, ptr::NonNull};
 #[derive(Debug)]
 pub struct EphemeronValueRef<'a, K: Trace + ?Sized + 'static, V> {
     // Only required to maintain the reference `&V` alive.
-    _key: Gc<K>,
+    _key: Gc<'a, K>,
     value: &'a V,
 }
 
@@ -45,7 +45,7 @@ pub struct Ephemeron<K: Trace + ?Sized + 'static, V: Trace + 'static> {
 impl<K: Trace + ?Sized, V: Trace> Ephemeron<K, V> {
     /// Creates a new `Ephemeron`.
     #[must_use]
-    pub fn new(key: &Gc<K>, value: V) -> Self {
+    pub fn new(key: &Gc<'_, K>, value: V) -> Self {
         let inner_ptr = Allocator::alloc_ephemeron(EphemeronBox::new(key, value));
         Self { inner_ptr }
     }
@@ -53,7 +53,7 @@ impl<K: Trace + ?Sized, V: Trace> Ephemeron<K, V> {
     /// Gets the stored key of this `Ephemeron`, or `None` if the key was already garbage collected.
     #[inline]
     #[must_use]
-    pub fn key(&self) -> Option<Gc<K>> {
+    pub fn key(&self) -> Option<Gc<'static, K>> {
         // SAFETY: this is safe because `Ephemeron` is tracked to always point to a valid pointer
         // `inner_ptr`.
         let key_ptr = unsafe { self.inner_ptr.as_ref().key_ptr() }?;

--- a/core/gc/src/pointers/gc.rs
+++ b/core/gc/src/pointers/gc.rs
@@ -49,15 +49,15 @@ impl Drop for NonTraceable {
 
 /// A type erased [`Gc<T>`] pointer type.
 #[repr(transparent)]
-pub struct GcErased {
-    inner: Gc<NonTraceable>,
+pub struct GcErased<'gc> {
+    inner: Gc<'gc, NonTraceable>,
 }
 
-impl GcErased {
+impl<'gc> GcErased<'gc> {
     /// Convert a [`Gc<T>`] into a type erased [`GcErased`].
     #[inline]
     #[must_use]
-    pub fn new<T: Trace>(gc: Gc<T>) -> Self {
+    pub fn new<T: Trace>(gc: Gc<'gc, T>) -> Self {
         let inner_ptr = gc.inner_ptr;
         std::mem::forget(gc);
 
@@ -79,21 +79,25 @@ impl GcErased {
     #[inline]
     #[must_use]
     pub fn type_id(&self) -> TypeId {
-        Gc::type_id(&self.inner)
+        self.inner.vtable().type_id()
     }
 
     /// Returns true if the inner type is the same as `T`.
     #[inline]
     #[must_use]
     pub fn is<T: Trace + 'static>(&self) -> bool {
-        Gc::is::<T>(&self.inner)
+        self.type_id() == TypeId::of::<T>()
     }
 
-    /// Returns [`Some`] `Gc<T>` if it is of type `T`, or [`None`] if it isn’t.
+    /// Returns [`Some`] `Gc<T>` if it is of type `T`, or [`None`] if it isn't.
     #[inline]
     #[must_use]
-    pub fn downcast<T: Trace + 'static>(self) -> Option<Gc<T>> {
-        Gc::downcast::<T>(self.inner)
+    pub fn downcast<T: Trace + 'static>(self) -> Option<Gc<'gc, T>> {
+        if !self.is::<T>() {
+            return None;
+        }
+        // SAFETY: verified the type above
+        Some(unsafe { Gc::cast_unchecked::<T>(self.inner) })
     }
 
     /// Downcast the inner value of type `T`.
@@ -103,7 +107,7 @@ impl GcErased {
     /// The caller must ensure that the cast is valid.
     #[inline]
     #[must_use]
-    pub unsafe fn downcast_unchecked<T: Trace + 'static>(self) -> Gc<T> {
+    pub unsafe fn downcast_unchecked<T: Trace + 'static>(self) -> Gc<'gc, T> {
         // SAFETY: It's the callers responsibility to make sure this is valid.
         unsafe { Gc::cast_unchecked::<T>(self.inner) }
     }
@@ -115,13 +119,13 @@ impl GcErased {
     /// The caller must ensure that the cast is valid.
     #[inline]
     #[must_use]
-    pub unsafe fn downcast_ref_unchecked<T: Trace + 'static>(&self) -> &Gc<T> {
+    pub unsafe fn downcast_ref_unchecked<T: Trace + 'static>(&self) -> &Gc<'gc, T> {
         // SAFETY: It's the callers responsibility to make sure this is valid.
         unsafe { Gc::cast_ref_unchecked::<T>(&self.inner) }
     }
 }
 
-impl Debug for GcErased {
+impl Debug for GcErased<'_> {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("GcErased")
@@ -130,19 +134,19 @@ impl Debug for GcErased {
     }
 }
 
-impl Finalize for GcErased {
+impl Finalize for GcErased<'_> {
     fn finalize(&self) {}
 }
 
 // SAFETY: We only have one transparent field in GcErased that needs trace,
 //         so this is safe.
-unsafe impl Trace for GcErased {
+unsafe impl Trace for GcErased<'_> {
     custom_trace!(this, mark, {
         mark(&this.inner);
     });
 }
 
-impl Clone for GcErased {
+impl Clone for GcErased<'_> {
     #[inline]
     fn clone(&self) -> Self {
         Self {
@@ -152,12 +156,14 @@ impl Clone for GcErased {
 }
 
 /// A garbage-collected pointer type over an immutable value.
-pub struct Gc<T: Trace + ?Sized + 'static> {
+pub struct Gc<'gc, T: Trace + ?Sized + 'static> {
     pub(crate) inner_ptr: NonNull<GcBox<T>>,
-    pub(crate) marker: PhantomData<Rc<T>>,
+    // `Rc<T>` makes `Gc` invariant over `T` and non-`Send`/non-`Sync`,
+    // `&'gc ()` brands the pointer to a specific gc arena lifetime
+    pub(crate) marker: PhantomData<(Rc<T>, PhantomData<&'gc ()>)>,
 }
 
-impl<T: Trace + ?Sized> Gc<T> {
+impl<'gc, T: Trace + ?Sized + 'static> Gc<'gc, T> {
     /// Constructs a new `Gc<T>` with the given value.
     #[must_use]
     pub fn new(value: T) -> Self
@@ -217,7 +223,7 @@ impl<T: Trace + ?Sized> Gc<T> {
 
     /// Returns `true` if the two `Gc`s point to the same allocation.
     #[must_use]
-    pub fn ptr_eq<U: Trace + ?Sized>(this: &Self, other: &Gc<U>) -> bool {
+    pub fn ptr_eq<U: Trace + ?Sized + 'static>(this: &Self, other: &Gc<'_, U>) -> bool {
         std::ptr::addr_eq(this.inner(), other.inner())
     }
 
@@ -259,7 +265,7 @@ impl<T: Trace + ?Sized> Gc<T> {
     /// Returns [`Some`] reference to the inner value if it is of type `T`, or [`None`] if it isn’t.
     #[inline]
     #[must_use]
-    pub fn downcast<U: Trace + 'static>(this: Self) -> Option<Gc<U>> {
+    pub fn downcast<U: Trace + 'static>(this: Self) -> Option<Gc<'gc, U>> {
         if !Gc::is::<U>(&this) {
             return None;
         }
@@ -275,7 +281,7 @@ impl<T: Trace + ?Sized> Gc<T> {
     /// The caller must ensure that the cast is valid.
     #[inline]
     #[must_use]
-    pub unsafe fn cast_unchecked<U: Trace + 'static>(this: Self) -> Gc<U> {
+    pub unsafe fn cast_unchecked<U: Trace + 'static>(this: Self) -> Gc<'gc, U> {
         let inner_ptr = this.inner_ptr.cast::<U>();
         core::mem::forget(this); // Prevents double free.
         Gc {
@@ -291,14 +297,14 @@ impl<T: Trace + ?Sized> Gc<T> {
     /// The caller must ensure that the cast is valid.
     #[inline]
     #[must_use]
-    pub unsafe fn cast_ref_unchecked<U: Trace + 'static>(this: &Self) -> &Gc<U> {
+    pub unsafe fn cast_ref_unchecked<U: Trace + 'static>(this: &Self) -> &Gc<'gc, U> {
         // SAFETY: Casting a Gc<T> to a Gc<U> of any type is safe, as long as you don’t actually access it as a U.
         //         The correct functions for T will still be called during tracing, finalization, and dropping.
-        unsafe { &(*(&raw const *this).cast::<Gc<U>>()) }
+        unsafe { &(*(&raw const *this).cast::<Gc<'_, U>>()) }
     }
 }
 
-impl<T: Trace + ?Sized> Gc<T> {
+impl<T: Trace + ?Sized + 'static> Gc<'_, T> {
     pub(crate) fn vtable(&self) -> &'static VTable {
         // SAFETY: The inner pointer is valid at all times.
         unsafe { self.inner_ptr.as_ref() }.vtable
@@ -317,7 +323,7 @@ impl<T: Trace + ?Sized> Gc<T> {
     }
 }
 
-impl<T: Trace + ?Sized> Finalize for Gc<T> {
+impl<T: Trace + ?Sized + 'static> Finalize for Gc<'_, T> {
     fn finalize(&self) {
         // SAFETY: inner_ptr should be alive when calling finalize.
         // We don't call inner_ptr() to avoid overhead of calling finalizer_safe().
@@ -329,7 +335,7 @@ impl<T: Trace + ?Sized> Finalize for Gc<T> {
 
 // SAFETY: `Gc` maintains it's own rootedness and implements all methods of
 // Trace. It is not possible to root an already rooted `Gc` and vice versa.
-unsafe impl<T: Trace + ?Sized> Trace for Gc<T> {
+unsafe impl<T: Trace + ?Sized + 'static> Trace for Gc<'_, T> {
     unsafe fn trace(&self, tracer: &mut Tracer) {
         tracer.enqueue(self.as_erased_pointer());
     }
@@ -343,7 +349,7 @@ unsafe impl<T: Trace + ?Sized> Trace for Gc<T> {
     }
 }
 
-impl<T: Trace + ?Sized> Clone for Gc<T> {
+impl<T: Trace + ?Sized + 'static> Clone for Gc<'_, T> {
     fn clone(&self) -> Self {
         let ptr = self.inner_ptr();
         // SAFETY: though `ptr` doesn't come from a `into_raw` call, it essentially does the same,
@@ -356,7 +362,7 @@ impl<T: Trace + ?Sized> Clone for Gc<T> {
     }
 }
 
-impl<T: Trace + ?Sized> Deref for Gc<T> {
+impl<T: Trace + ?Sized + 'static> Deref for Gc<'_, T> {
     type Target = T;
 
     fn deref(&self) -> &T {
@@ -364,7 +370,7 @@ impl<T: Trace + ?Sized> Deref for Gc<T> {
     }
 }
 
-impl<T: Trace + ?Sized> Drop for Gc<T> {
+impl<T: Trace + ?Sized + 'static> Drop for Gc<'_, T> {
     fn drop(&mut self) {
         if finalizer_safe() {
             Finalize::finalize(self);
@@ -372,24 +378,24 @@ impl<T: Trace + ?Sized> Drop for Gc<T> {
     }
 }
 
-impl<T: Trace + Default> Default for Gc<T> {
+impl<T: Trace + Default + 'static> Default for Gc<'_, T> {
     fn default() -> Self {
         Self::new(Default::default())
     }
 }
 
 #[allow(clippy::inline_always)]
-impl<T: Trace + ?Sized + PartialEq> PartialEq for Gc<T> {
+impl<T: Trace + ?Sized + PartialEq + 'static> PartialEq for Gc<'_, T> {
     #[inline(always)]
     fn eq(&self, other: &Self) -> bool {
         **self == **other
     }
 }
 
-impl<T: Trace + ?Sized + Eq> Eq for Gc<T> {}
+impl<T: Trace + ?Sized + Eq + 'static> Eq for Gc<'_, T> {}
 
 #[allow(clippy::inline_always)]
-impl<T: Trace + ?Sized + PartialOrd> PartialOrd for Gc<T> {
+impl<T: Trace + ?Sized + PartialOrd + 'static> PartialOrd for Gc<'_, T> {
     #[inline(always)]
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         (**self).partial_cmp(&**other)
@@ -416,43 +422,43 @@ impl<T: Trace + ?Sized + PartialOrd> PartialOrd for Gc<T> {
     }
 }
 
-impl<T: Trace + ?Sized + Ord> Ord for Gc<T> {
+impl<T: Trace + ?Sized + Ord + 'static> Ord for Gc<'_, T> {
     fn cmp(&self, other: &Self) -> Ordering {
         (**self).cmp(&**other)
     }
 }
 
-impl<T: Trace + ?Sized + Hash> Hash for Gc<T> {
+impl<T: Trace + ?Sized + Hash + 'static> Hash for Gc<'_, T> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         (**self).hash(state);
     }
 }
 
-impl<T: Trace + ?Sized + Display> Display for Gc<T> {
+impl<T: Trace + ?Sized + Display + 'static> Display for Gc<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         Display::fmt(&**self, f)
     }
 }
 
-impl<T: Trace + ?Sized + Debug> Debug for Gc<T> {
+impl<T: Trace + ?Sized + Debug + 'static> Debug for Gc<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         Debug::fmt(&**self, f)
     }
 }
 
-impl<T: Trace + ?Sized> fmt::Pointer for Gc<T> {
+impl<T: Trace + ?Sized + 'static> fmt::Pointer for Gc<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Pointer::fmt(&self.inner(), f)
     }
 }
 
-impl<T: Trace + ?Sized> std::borrow::Borrow<T> for Gc<T> {
+impl<T: Trace + ?Sized + 'static> std::borrow::Borrow<T> for Gc<'_, T> {
     fn borrow(&self) -> &T {
         self
     }
 }
 
-impl<T: Trace + ?Sized> AsRef<T> for Gc<T> {
+impl<T: Trace + ?Sized + 'static> AsRef<T> for Gc<'_, T> {
     fn as_ref(&self) -> &T {
         self
     }

--- a/core/gc/src/pointers/weak.rs
+++ b/core/gc/src/pointers/weak.rs
@@ -15,7 +15,7 @@ impl<T: Trace + ?Sized> WeakGc<T> {
     /// Creates a new weak pointer for a garbage collected value.
     #[inline]
     #[must_use]
-    pub fn new(value: &Gc<T>) -> Self {
+    pub fn new(value: &Gc<'_, T>) -> Self {
         Self {
             inner: Ephemeron::new(value, ()),
         }
@@ -25,7 +25,7 @@ impl<T: Trace + ?Sized> WeakGc<T> {
     /// if the value was already garbage collected.
     #[inline]
     #[must_use]
-    pub fn upgrade(&self) -> Option<Gc<T>> {
+    pub fn upgrade(&self) -> Option<Gc<'static, T>> {
         self.inner.key()
     }
 

--- a/core/gc/src/pointers/weak_map.rs
+++ b/core/gc/src/pointers/weak_map.rs
@@ -12,7 +12,7 @@ use std::{fmt, hash::BuildHasher, marker::PhantomData};
 /// A map that holds weak references to its keys and is traced by the garbage collector.
 #[derive(Clone, Debug, Default, Finalize)]
 pub struct WeakMap<K: Trace + ?Sized + 'static, V: Trace + 'static> {
-    pub(crate) inner: Gc<GcRefCell<RawWeakMap<K, V>>>,
+    pub(crate) inner: Gc<'static, GcRefCell<RawWeakMap<K, V>>>,
 }
 
 unsafe impl<K: Trace + ?Sized + 'static, V: Trace + 'static> Trace for WeakMap<K, V> {
@@ -21,7 +21,7 @@ unsafe impl<K: Trace + ?Sized + 'static, V: Trace + 'static> Trace for WeakMap<K
     });
 }
 
-impl<K: Trace + ?Sized, V: Trace> WeakMap<K, V> {
+impl<K: Trace + ?Sized + 'static, V: Trace + 'static> WeakMap<K, V> {
     /// Creates a new `WeakMap`.
     #[must_use]
     #[inline]
@@ -31,28 +31,28 @@ impl<K: Trace + ?Sized, V: Trace> WeakMap<K, V> {
 
     /// Inserts a key-value pair into the map.
     #[inline]
-    pub fn insert(&mut self, key: &Gc<K>, value: V) {
+    pub fn insert(&mut self, key: &Gc<'_, K>, value: V) {
         self.inner.borrow_mut().insert(key, value);
     }
 
     /// Removes a key from the map, returning `true` if the key was previously in
     /// the map.
     #[inline]
-    pub fn remove(&mut self, key: &Gc<K>) -> bool {
+    pub fn remove(&mut self, key: &Gc<'_, K>) -> bool {
         self.inner.borrow_mut().remove(key)
     }
 
     /// Returns `true` if the map contains a value for the specified key.
     #[must_use]
     #[inline]
-    pub fn contains_key(&self, key: &Gc<K>) -> bool {
+    pub fn contains_key(&self, key: &Gc<'_, K>) -> bool {
         self.inner.borrow().contains_key(key)
     }
 
     /// Returns a reference to the ephemeron corresponding to the key.
     #[must_use]
     #[inline]
-    pub fn get<'a>(&'a self, key: &Gc<K>) -> Option<GcRef<'a, Ephemeron<K, V>>> {
+    pub fn get<'a>(&'a self, key: &Gc<'_, K>) -> Option<GcRef<'a, Ephemeron<K, V>>> {
         GcRef::try_map(self.inner.borrow(), |inner| inner.get(key))
     }
 }
@@ -277,7 +277,7 @@ where
     }
 
     /// Returns the ephemeron corresponding to the supplied key.
-    pub(crate) fn get(&self, k: &Gc<K>) -> Option<&Ephemeron<K, V>> {
+    pub(crate) fn get(&self, k: &Gc<'_, K>) -> Option<&Ephemeron<K, V>> {
         if self.table.is_empty() {
             None
         } else {
@@ -287,7 +287,7 @@ where
     }
 
     /// Returns `true` if the map contains a value for the specified key.
-    pub(crate) fn contains_key(&self, k: &Gc<K>) -> bool {
+    pub(crate) fn contains_key(&self, k: &Gc<'_, K>) -> bool {
         self.get(k).is_some()
     }
 
@@ -297,7 +297,7 @@ where
     ///
     /// If the map did have this key present, the value is updated, and the old
     /// value is returned. The key is not updated.
-    pub(crate) fn insert(&mut self, k: &Gc<K>, v: V) -> Option<Ephemeron<K, V>> {
+    pub(crate) fn insert(&mut self, k: &Gc<'_, K>, v: V) -> Option<Ephemeron<K, V>> {
         let hash = make_hash_from_gc(&self.hash_builder, k);
         let hasher = make_hasher(&self.hash_builder);
         let entry = self.table.entry(hash, equivalent_key(k), hasher);
@@ -315,7 +315,7 @@ where
 
     /// Removes a key from the map, returning `true` if the key
     /// was previously in the map. Keeps the allocated memory for reuse.
-    pub(crate) fn remove(&mut self, k: &Gc<K>) -> bool {
+    pub(crate) fn remove(&mut self, k: &Gc<'_, K>) -> bool {
         let hash = make_hash_from_gc(&self.hash_builder, k);
         if let Ok(entry) = self.table.find_entry(hash, equivalent_key(k)) {
             entry.remove();
@@ -424,7 +424,7 @@ where
     state.finish()
 }
 
-fn make_hash_from_gc<K, S>(hash_builder: &S, gc: &Gc<K>) -> u64
+fn make_hash_from_gc<K, S>(hash_builder: &S, gc: &Gc<'_, K>) -> u64
 where
     S: BuildHasher,
     K: Trace + ?Sized + 'static,
@@ -435,7 +435,7 @@ where
     state.finish()
 }
 
-fn equivalent_key<K, V>(k: &Gc<K>) -> impl Fn(&Ephemeron<K, V>) -> bool + '_
+fn equivalent_key<'a, K, V>(k: &'a Gc<'a, K>) -> impl Fn(&Ephemeron<K, V>) -> bool + 'a
 where
     K: Trace + ?Sized + 'static,
     V: Trace + 'static,

--- a/core/gc/src/test/allocation.rs
+++ b/core/gc/src/test/allocation.rs
@@ -41,7 +41,7 @@ mod miri {
             #[derive(Debug, Finalize, Trace)]
             struct S {
                 i: usize,
-                next: Option<Gc<S>>,
+                next: Option<Gc<'static, S>>,
             }
 
             const SIZE: usize = size_of::<GcBox<S>>();

--- a/core/gc/src/test/erased.rs
+++ b/core/gc/src/test/erased.rs
@@ -33,7 +33,7 @@ mod miri {
         #[derive(Debug, Trace, Finalize)]
         struct List {
             value: i32,
-            next: Option<GcErased>,
+            next: Option<GcErased<'static>>,
         }
 
         run_test(|| {

--- a/core/gc/src/test/weak.rs
+++ b/core/gc/src/test/weak.rs
@@ -148,7 +148,7 @@ mod miri {
         }
         #[derive(Trace, Finalize, Clone)]
         struct TestCell {
-            inner: Gc<InnerCell>,
+            inner: Gc<'static, InnerCell>,
         }
         run_test(|| {
             let root = TestCell {
@@ -182,7 +182,7 @@ mod miri {
     fn eph_self_referential_chain() {
         #[derive(Trace, Finalize, Clone)]
         struct TestCell {
-            inner: Gc<GcRefCell<Option<Ephemeron<u8, TestCell>>>>,
+            inner: Gc<'static, GcRefCell<Option<Ephemeron<u8, TestCell>>>>,
         }
         run_test(|| {
             let root = Gc::new(GcRefCell::new(None));
@@ -301,7 +301,7 @@ mod miri {
         type Inner = GcRefCell<(Option<TestCell>, Option<TestCell>)>;
         #[derive(Trace, Finalize, Clone)]
         struct TestCell {
-            inner: Gc<Inner>,
+            inner: Gc<'static, Inner>,
         }
         run_test(|| {
             let root = TestCell {

--- a/core/runtime/src/console/tests.rs
+++ b/core/runtime/src/console/tests.rs
@@ -116,7 +116,7 @@ fn console_log_cyclic() {
 /// A logger that records all log messages.
 #[derive(Clone, Debug, Default, boa_engine::Trace, boa_engine::Finalize)]
 pub(crate) struct RecordingLogger {
-    pub log: Gc<GcRefCell<String>>,
+    pub log: Gc<'static, GcRefCell<String>>,
 }
 
 impl Logger for RecordingLogger {

--- a/tests/macros/tests/gcd_callback.rs
+++ b/tests/macros/tests/gcd_callback.rs
@@ -8,7 +8,7 @@ use boa_gc::Gc;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-fn callback_from_js(ContextData(r): ContextData<Gc<AtomicUsize>>, result: usize) {
+fn callback_from_js(ContextData(r): ContextData<Gc<'static, AtomicUsize>>, result: usize) {
     r.store(result, Ordering::Relaxed);
 }
 

--- a/tests/wpt/src/logger/mod.rs
+++ b/tests/wpt/src/logger/mod.rs
@@ -35,7 +35,7 @@ struct RecordingLoggerInner {
 #[derive(Clone, Trace, Finalize, JsData)]
 pub(crate) struct RecordingLogger {
     /// Also send logs to this logger.
-    tee: Gc<Box<dyn Logger>>,
+    tee: Gc<'static, Box<dyn Logger>>,
 
     #[unsafe_ignore_trace]
     inner: Rc<RefCell<RecordingLoggerInner>>,


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->
adding the `'gc` lifetime to core `boa_gc` types (like `Gc`, `GcErased`, `WeakMap`) to make sure Gc pointers are safely tied to the lifetime of the arena they belong to.

to keep this PR small and easy to review, I've used a temporary `'static` lifetime for all the `Gc` pointers. I'll replace these placeholders with the real arena lifetimes in a follow up PR when updating to `MutationContext`

