### PR TITLE
ci: skip scheduled and release workflows on forks

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   analyze:
     name: Analyze
+    if: github.repository == 'boa-dev/boa'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   build:
+    if: github.repository == 'boa-dev/boa'
     permissions:
       contents: write
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ permissions:
 jobs:
   publish:
     name: Publish crates
+    if: github.repository == 'boa-dev/boa'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -50,6 +51,7 @@ jobs:
 
   npm_publish:
     name: Publish NPM package (wasm)
+    if: github.repository == 'boa-dev/boa'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -93,6 +95,7 @@ jobs:
 
   release-binaries:
     name: Publish binaries
+    if: github.repository == 'boa-dev/boa'
     permissions:
       contents: write
     needs: publish

--- a/.github/workflows/security_audit.yml
+++ b/.github/workflows/security_audit.yml
@@ -7,6 +7,7 @@ permissions:
   contents: read
 jobs:
   audit:
+    if: github.repository == 'boa-dev/boa'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:

--- a/.github/workflows/test262_release.yml
+++ b/.github/workflows/test262_release.yml
@@ -18,6 +18,7 @@ concurrency:
 jobs:
   update_test262_results:
     name: Update Test262 Results
+    if: github.repository == 'boa-dev/boa'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:


### PR DESCRIPTION
## Summary
- Add `if: github.repository == 'boa-dev/boa'` to Security audit, Nightly Build, Update Test262 Results, CodeQL, and Publish Release jobs
- Prevents forks with Actions enabled from running workflows that require upstream secrets (`DATA_PAT`, registry tokens) or write permissions, which currently fail and spam contributors with notifications

## Test plan
- [ ] Confirm jobs still run on `boa-dev/boa` (condition evaluates true)
- [ ] On a fork with Actions enabled, these workflows should show as skipped rather than failed

Made with [Cursor](https://cursor.com)