### PR TITLE
Add Arc<AtomicBool> interrupt flag

### DIFF
--- a/core/engine/src/context/mod.rs
+++ b/core/engine/src/context/mod.rs
@@ -1,6 +1,8 @@
 //! The ECMAScript context.
 
-use std::{cell::Cell, path::Path, rc::Rc};
+use std::{cell::Cell, path::Path, rc::Rc, sync::Arc};
+
+use portable_atomic::AtomicBool;
 
 use boa_ast::StatementList;
 use boa_interner::Interner;
@@ -590,6 +592,21 @@ impl Context {
     #[inline]
     pub fn runtime_limits_mut(&mut self) -> &mut RuntimeLimits {
         &mut self.vm.runtime_limits
+    }
+
+    /// Returns a clone of the context's interrupt flag.
+    ///
+    /// Setting the flag to `true` with [`AtomicBool::store`] from any thread will
+    /// interrupt the currently executing bytecode at the next loop iteration or
+    /// function call, throwing a non-catchable runtime limit error that terminates
+    /// the evaluation.
+    ///
+    /// The flag is sticky: once set, it stays `true` until explicitly cleared. Reset
+    /// it with `flag.store(false, Ordering::Relaxed)` before evaluating again.
+    #[inline]
+    #[must_use]
+    pub fn interrupt_flag(&self) -> Arc<AtomicBool> {
+        self.vm.interrupt.clone()
     }
 
     /// Returns `true` if this context can be suspended by an `Atomics.wait` call.

--- a/core/engine/src/vm/mod.rs
+++ b/core/engine/src/vm/mod.rs
@@ -13,8 +13,9 @@ use crate::{
     script::Script,
 };
 use boa_gc::{Finalize, Gc, Trace, custom_trace};
+use portable_atomic::AtomicBool;
 use shadow_stack::ShadowStack;
-use std::{future::Future, ops::ControlFlow, pin::Pin, task};
+use std::{future::Future, ops::ControlFlow, pin::Pin, sync::Arc, sync::atomic::Ordering, task};
 
 #[cfg(feature = "trace")]
 use crate::sys::time::Instant;
@@ -86,6 +87,12 @@ pub struct Vm {
     pub(crate) pending_exception: Option<JsError>,
     pub(crate) environments: EnvironmentStack,
     pub(crate) runtime_limits: RuntimeLimits,
+
+    /// Flag used to interrupt the currently executing bytecode.
+    ///
+    /// When set to `true` from another thread, the next loop iteration or function
+    /// call throws a non-catchable runtime limit error, terminating the evaluation.
+    pub(crate) interrupt: Arc<AtomicBool>,
 
     /// This is used to assign a native (rust) function as the active function,
     /// because we don't push a frame for them.
@@ -425,6 +432,7 @@ impl Vm {
             environments: EnvironmentStack::new(realm.environment().clone()),
             pending_exception: None,
             runtime_limits: RuntimeLimits::default(),
+            interrupt: Arc::new(AtomicBool::new(false)),
             native_active_function: None,
             realm,
             shadow_stack: ShadowStack::default(),
@@ -866,6 +874,13 @@ impl Context {
 
     /// Checks if we haven't exceeded the defined runtime limits.
     pub(crate) fn check_runtime_limits(&self) -> JsResult<()> {
+        // Must throw if the execution has been interrupted by an external request.
+        if self.vm.interrupt.load(Ordering::Relaxed) {
+            return Err(JsNativeError::runtime_limit()
+                .with_message("execution was interrupted by an external request")
+                .into());
+        }
+
         // Must throw if the number of recursive calls exceeds the defined limit.
         if self.vm.runtime_limits.recursion_limit() <= self.vm.frames.len() {
             return Err(JsNativeError::runtime_limit()

--- a/core/engine/src/vm/opcode/iteration/loop_ops.rs
+++ b/core/engine/src/vm/opcode/iteration/loop_ops.rs
@@ -1,5 +1,6 @@
 use crate::JsNativeError;
 use crate::{Context, JsResult, vm::opcode::Operation};
+use std::sync::atomic::Ordering;
 
 /// `IncrementLoopIteration` implements the Opcode Operation for `Opcode::IncrementLoopIteration`.
 ///
@@ -11,6 +12,13 @@ pub(crate) struct IncrementLoopIteration;
 impl IncrementLoopIteration {
     #[inline(always)]
     pub(crate) fn operation((): (), context: &mut Context) -> JsResult<()> {
+        // Must throw if the execution has been interrupted by an external request.
+        if context.vm.interrupt.load(Ordering::Relaxed) {
+            return Err(JsNativeError::runtime_limit()
+                .with_message("execution was interrupted by an external request")
+                .into());
+        }
+
         let max = context.vm.runtime_limits.loop_iteration_limit();
         let frame = context.vm.frame_mut();
         let previous_iteration_count = frame.loop_iteration_count;

--- a/core/engine/src/vm/tests.rs
+++ b/core/engine/src/vm/tests.rs
@@ -345,6 +345,51 @@ fn loop_runtime_limit() {
 }
 
 #[test]
+fn interrupt() {
+    use std::sync::atomic::Ordering;
+
+    run_test_actions([
+        // Setting the flag interrupts a tight loop.
+        TestAction::inspect_context(|context| {
+            context.interrupt_flag().store(true, Ordering::Relaxed);
+        }),
+        TestAction::assert_native_error(
+            indoc! {r#"
+                while (1) { }
+            "#},
+            JsNativeErrorKind::RuntimeLimit,
+            "execution was interrupted by an external request",
+        ),
+        // A function call is also an interrupt point.
+        TestAction::inspect_context(|context| {
+            context.interrupt_flag().store(true, Ordering::Relaxed);
+        }),
+        TestAction::assert_native_error(
+            indoc! {r#"
+                function f() { return 42; }
+                f()
+            "#},
+            JsNativeErrorKind::RuntimeLimit,
+            "execution was interrupted by an external request",
+        ),
+        // Clearing the flag lets evaluation proceed.
+        TestAction::inspect_context(|context| {
+            context.interrupt_flag().store(false, Ordering::Relaxed);
+        }),
+        TestAction::assert_eq(
+            indoc! {r#"
+                let result = 0;
+                for (let i = 0; i < 10; ++i) {
+                    result += i;
+                }
+                result
+            "#},
+            45,
+        ),
+    ]);
+}
+
+#[test]
 fn recursion_runtime_limit() {
     run_test_actions([
         TestAction::run(indoc! {r#"


### PR DESCRIPTION
This Pull Request improves situation outlined in #3442.

It adds an atomic boolean flag that is consulted along existing frame/loop limits. It can be used to interrupt Boa running in a standalone thread from the outside, e.g. after it exhausts a time limit.

This is a stopgap before a better solution for the issue is available.