### PR TITLE
[oscars-integration]  Thread MutationContext through buitlin standard library objects

### DIFF
--- a/cli/src/debug/limits.rs
+++ b/cli/src/debug/limits.rs
@@ -64,48 +64,72 @@ fn set_backtrace(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResu
 }
 
 pub(super) fn create_object(context: &mut Context) -> JsObject {
-    let get_loop =
-        FunctionObjectBuilder::new(context.realm(), NativeFunction::from_fn_ptr(get_loop))
-            .name(js_string!("get loop"))
-            .length(0)
-            .build();
-    let set_loop =
-        FunctionObjectBuilder::new(context.realm(), NativeFunction::from_fn_ptr(set_loop))
-            .name(js_string!("set loop"))
-            .length(1)
-            .build();
+    let get_loop = FunctionObjectBuilder::new(
+        context.realm(),
+        context.gc_collector(),
+        NativeFunction::from_fn_ptr(get_loop),
+    )
+    .name(js_string!("get loop"))
+    .length(0)
+    .build();
+    let set_loop = FunctionObjectBuilder::new(
+        context.realm(),
+        context.gc_collector(),
+        NativeFunction::from_fn_ptr(set_loop),
+    )
+    .name(js_string!("set loop"))
+    .length(1)
+    .build();
 
-    let get_stack =
-        FunctionObjectBuilder::new(context.realm(), NativeFunction::from_fn_ptr(get_stack))
-            .name(js_string!("get stack"))
-            .length(0)
-            .build();
-    let set_stack =
-        FunctionObjectBuilder::new(context.realm(), NativeFunction::from_fn_ptr(set_stack))
-            .name(js_string!("set stack"))
-            .length(1)
-            .build();
+    let get_stack = FunctionObjectBuilder::new(
+        context.realm(),
+        context.gc_collector(),
+        NativeFunction::from_fn_ptr(get_stack),
+    )
+    .name(js_string!("get stack"))
+    .length(0)
+    .build();
+    let set_stack = FunctionObjectBuilder::new(
+        context.realm(),
+        context.gc_collector(),
+        NativeFunction::from_fn_ptr(set_stack),
+    )
+    .name(js_string!("set stack"))
+    .length(1)
+    .build();
 
-    let get_recursion =
-        FunctionObjectBuilder::new(context.realm(), NativeFunction::from_fn_ptr(get_recursion))
-            .name(js_string!("get recursion"))
-            .length(0)
-            .build();
-    let set_recursion =
-        FunctionObjectBuilder::new(context.realm(), NativeFunction::from_fn_ptr(set_recursion))
-            .name(js_string!("set recursion"))
-            .length(1)
-            .build();
-    let get_backtrace =
-        FunctionObjectBuilder::new(context.realm(), NativeFunction::from_fn_ptr(get_backtrace))
-            .name(js_string!("get backtrace"))
-            .length(0)
-            .build();
-    let set_backtrace =
-        FunctionObjectBuilder::new(context.realm(), NativeFunction::from_fn_ptr(set_backtrace))
-            .name(js_string!("set backtrace"))
-            .length(1)
-            .build();
+    let get_recursion = FunctionObjectBuilder::new(
+        context.realm(),
+        context.gc_collector(),
+        NativeFunction::from_fn_ptr(get_recursion),
+    )
+    .name(js_string!("get recursion"))
+    .length(0)
+    .build();
+    let set_recursion = FunctionObjectBuilder::new(
+        context.realm(),
+        context.gc_collector(),
+        NativeFunction::from_fn_ptr(set_recursion),
+    )
+    .name(js_string!("set recursion"))
+    .length(1)
+    .build();
+    let get_backtrace = FunctionObjectBuilder::new(
+        context.realm(),
+        context.gc_collector(),
+        NativeFunction::from_fn_ptr(get_backtrace),
+    )
+    .name(js_string!("get backtrace"))
+    .length(0)
+    .build();
+    let set_backtrace = FunctionObjectBuilder::new(
+        context.realm(),
+        context.gc_collector(),
+        NativeFunction::from_fn_ptr(set_backtrace),
+    )
+    .name(js_string!("set backtrace"))
+    .length(1)
+    .build();
 
     ObjectInitializer::new(context)
         .accessor(

--- a/cli/src/debug/optimizer.rs
+++ b/cli/src/debug/optimizer.rs
@@ -38,6 +38,7 @@ fn set_statistics(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsRes
 pub(super) fn create_object(context: &mut Context) -> JsObject {
     let get_constant_folding = FunctionObjectBuilder::new(
         context.realm(),
+        context.gc_collector(),
         NativeFunction::from_fn_ptr(get_constant_folding),
     )
     .name("get constantFolding")
@@ -45,22 +46,29 @@ pub(super) fn create_object(context: &mut Context) -> JsObject {
     .build();
     let set_constant_folding = FunctionObjectBuilder::new(
         context.realm(),
+        context.gc_collector(),
         NativeFunction::from_fn_ptr(set_constant_folding),
     )
     .name("set constantFolding")
     .length(1)
     .build();
 
-    let get_statistics =
-        FunctionObjectBuilder::new(context.realm(), NativeFunction::from_fn_ptr(get_statistics))
-            .name("get statistics")
-            .length(0)
-            .build();
-    let set_statistics =
-        FunctionObjectBuilder::new(context.realm(), NativeFunction::from_fn_ptr(set_statistics))
-            .name("set statistics")
-            .length(1)
-            .build();
+    let get_statistics = FunctionObjectBuilder::new(
+        context.realm(),
+        context.gc_collector(),
+        NativeFunction::from_fn_ptr(get_statistics),
+    )
+    .name("get statistics")
+    .length(0)
+    .build();
+    let set_statistics = FunctionObjectBuilder::new(
+        context.realm(),
+        context.gc_collector(),
+        NativeFunction::from_fn_ptr(set_statistics),
+    )
+    .name("set statistics")
+    .length(1)
+    .build();
     ObjectInitializer::new(context)
         .accessor(
             js_string!("constantFolding"),

--- a/core/engine/benches/full.rs
+++ b/core/engine/benches/full.rs
@@ -18,7 +18,7 @@ static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
 fn create_realm(c: &mut Criterion) {
     c.bench_function("Create Realm", move |b| {
-        let root_shape = RootShape::default();
+        let root_shape = RootShape::new(&unsafe { boa_gc::MutationContext::global() });
         b.iter(|| {
             Realm::create(&DefaultHooks, &root_shape, &unsafe {
                 boa_gc::MutationContext::global()

--- a/core/engine/src/builtins/array/array_iterator.rs
+++ b/core/engine/src/builtins/array/array_iterator.rs
@@ -37,8 +37,8 @@ pub(crate) struct ArrayIterator {
 }
 
 impl IntrinsicObject for ArrayIterator {
-    fn init(realm: &Realm) {
-        BuiltInBuilder::with_intrinsic::<Self>(realm)
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
+        BuiltInBuilder::with_intrinsic::<Self>(realm, mc)
             .prototype(realm.intrinsics().constructors().iterator().prototype())
             .static_method(Self::next, js_string!("next"), 0)
             .static_property(
@@ -78,6 +78,7 @@ impl ArrayIterator {
         context: &Context,
     ) -> JsValue {
         let array_iterator = JsObject::from_proto_and_data_with_shared_shape(
+            context.gc_collector(),
             context.root_shape(),
             context.intrinsics().objects().iterator_prototypes().array(),
             Self::new(array, kind),

--- a/core/engine/src/builtins/array/mod.rs
+++ b/core/engine/src/builtins/array/mod.rs
@@ -76,11 +76,11 @@ impl JsData for Array {
 }
 
 impl IntrinsicObject for Array {
-    fn init(realm: &Realm) {
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
         let symbol_iterator = JsSymbol::iterator();
         let symbol_unscopables = JsSymbol::unscopables();
 
-        let get_species = BuiltInBuilder::callable(realm, Self::get_species)
+        let get_species = BuiltInBuilder::callable(realm, Self::get_species, mc)
             .name(js_string!("get [Symbol.species]"))
             .build();
 
@@ -88,6 +88,7 @@ impl IntrinsicObject for Array {
             realm,
             realm.intrinsics().objects().array_prototype_values().into(),
             Self::values,
+            mc,
         )
         .name(js_string!("values"))
         .build();
@@ -100,13 +101,14 @@ impl IntrinsicObject for Array {
                 .array_prototype_to_string()
                 .into(),
             Self::to_string,
+            mc,
         )
         .name(js_string!("toString"))
         .build();
 
-        let unscopables_object = Self::unscopables_object();
+        let unscopables_object = Self::unscopables_object(mc);
 
-        let builder = BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        let builder = BuiltInBuilder::from_standard_constructor::<Self>(realm, mc)
             // Static Methods
             .static_method(Self::from, js_string!("from"), 1)
             .static_method(Self::is_array, js_string!("isArray"), 1)
@@ -333,11 +335,11 @@ impl Array {
 
         // Fast path:
         if prototype.is_none() {
-            return Ok(context
-                .intrinsics()
-                .templates()
-                .array()
-                .create(Array, vec![JsValue::new(length)]));
+            return Ok(context.intrinsics().templates().array().create(
+                context.gc_collector(),
+                Array,
+                vec![JsValue::new(length)],
+            ));
         }
 
         // 7. Return A.
@@ -355,16 +357,20 @@ impl Array {
             .array()
             .has_prototype(&prototype)
         {
-            return Ok(context
-                .intrinsics()
-                .templates()
-                .array()
-                .create(Array, vec![JsValue::new(length)]));
+            return Ok(context.intrinsics().templates().array().create(
+                context.gc_collector(),
+                Array,
+                vec![JsValue::new(length)],
+            ));
         }
 
-        let array =
-            JsObject::from_proto_and_data_with_shared_shape(context.root_shape(), prototype, Array)
-                .upcast();
+        let array = JsObject::from_proto_and_data_with_shared_shape(
+            context.gc_collector(),
+            context.root_shape(),
+            prototype,
+            Array,
+        )
+        .upcast();
 
         // 6. Perform ! OrdinaryDefineOwnProperty(A, "length", PropertyDescriptor { [[Value]]: 𝔽(length), [[Writable]]: true, [[Enumerable]]: false, [[Configurable]]: false }).
         ordinary_define_own_property(
@@ -408,6 +414,7 @@ impl Array {
             .templates()
             .array()
             .create_with_indexed_properties(
+                context.gc_collector(),
                 Array,
                 vec![JsValue::new(length)],
                 IndexedProperties::from_dense_js_value(elements),
@@ -3283,9 +3290,9 @@ impl Array {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-array.prototype-@@unscopables
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/@@unscopables
-    pub(crate) fn unscopables_object() -> JsObject {
+    pub(crate) fn unscopables_object(mc: &boa_gc::MutationContext<'static, '_>) -> JsObject {
         // 1. Let unscopableList be OrdinaryObjectCreate(null).
-        let unscopable_list = JsObject::with_null_proto();
+        let unscopable_list = JsObject::with_null_proto(mc);
         let true_prop = PropertyDescriptor::builder()
             .value(true)
             .writable(true)
@@ -3294,37 +3301,37 @@ impl Array {
         {
             let mut obj = unscopable_list.borrow_mut();
             // 2. Perform ! CreateDataPropertyOrThrow(unscopableList, "at", true).
-            obj.insert(js_string!("at"), true_prop.clone());
+            obj.insert(mc, js_string!("at"), true_prop.clone());
             // 3. Perform ! CreateDataPropertyOrThrow(unscopableList, "copyWithin", true).
-            obj.insert(js_string!("copyWithin"), true_prop.clone());
+            obj.insert(mc, js_string!("copyWithin"), true_prop.clone());
             // 4. Perform ! CreateDataPropertyOrThrow(unscopableList, "entries", true).
-            obj.insert(js_string!("entries"), true_prop.clone());
+            obj.insert(mc, js_string!("entries"), true_prop.clone());
             // 5. Perform ! CreateDataPropertyOrThrow(unscopableList, "fill", true).
-            obj.insert(js_string!("fill"), true_prop.clone());
+            obj.insert(mc, js_string!("fill"), true_prop.clone());
             // 6. Perform ! CreateDataPropertyOrThrow(unscopableList, "find", true).
-            obj.insert(js_string!("find"), true_prop.clone());
+            obj.insert(mc, js_string!("find"), true_prop.clone());
             // 7. Perform ! CreateDataPropertyOrThrow(unscopableList, "findIndex", true).
-            obj.insert(js_string!("findIndex"), true_prop.clone());
+            obj.insert(mc, js_string!("findIndex"), true_prop.clone());
             // 8. Perform ! CreateDataPropertyOrThrow(unscopableList, "findLast", true).
-            obj.insert(js_string!("findLast"), true_prop.clone());
+            obj.insert(mc, js_string!("findLast"), true_prop.clone());
             // 9. Perform ! CreateDataPropertyOrThrow(unscopableList, "findLastIndex", true).
-            obj.insert(js_string!("findLastIndex"), true_prop.clone());
+            obj.insert(mc, js_string!("findLastIndex"), true_prop.clone());
             // 10. Perform ! CreateDataPropertyOrThrow(unscopableList, "flat", true).
-            obj.insert(js_string!("flat"), true_prop.clone());
+            obj.insert(mc, js_string!("flat"), true_prop.clone());
             // 11. Perform ! CreateDataPropertyOrThrow(unscopableList, "flatMap", true).
-            obj.insert(js_string!("flatMap"), true_prop.clone());
+            obj.insert(mc, js_string!("flatMap"), true_prop.clone());
             // 12. Perform ! CreateDataPropertyOrThrow(unscopableList, "includes", true).
-            obj.insert(js_string!("includes"), true_prop.clone());
+            obj.insert(mc, js_string!("includes"), true_prop.clone());
             // 13. Perform ! CreateDataPropertyOrThrow(unscopableList, "keys", true).
-            obj.insert(js_string!("keys"), true_prop.clone());
+            obj.insert(mc, js_string!("keys"), true_prop.clone());
             // 14. Perform ! CreateDataPropertyOrThrow(unscopableList, "toReversed", true).
-            obj.insert(js_string!("toReversed"), true_prop.clone());
+            obj.insert(mc, js_string!("toReversed"), true_prop.clone());
             // 15. Perform ! CreateDataPropertyOrThrow(unscopableList, "toSorted", true).
-            obj.insert(js_string!("toSorted"), true_prop.clone());
+            obj.insert(mc, js_string!("toSorted"), true_prop.clone());
             // 16. Perform ! CreateDataPropertyOrThrow(unscopableList, "toSpliced", true).
-            obj.insert(js_string!("toSpliced"), true_prop.clone());
+            obj.insert(mc, js_string!("toSpliced"), true_prop.clone());
             // 17. Perform ! CreateDataPropertyOrThrow(unscopableList, "values", true).
-            obj.insert(js_string!("values"), true_prop);
+            obj.insert(mc, js_string!("values"), true_prop);
         }
 
         // 13. Return unscopableList.

--- a/core/engine/src/builtins/array_buffer/mod.rs
+++ b/core/engine/src/builtins/array_buffer/mod.rs
@@ -327,31 +327,31 @@ impl ArrayBuffer {
 }
 
 impl IntrinsicObject for ArrayBuffer {
-    fn init(realm: &Realm) {
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
         let flag_attributes = Attribute::CONFIGURABLE | Attribute::NON_ENUMERABLE;
 
-        let get_species = BuiltInBuilder::callable(realm, Self::get_species)
+        let get_species = BuiltInBuilder::callable(realm, Self::get_species, mc)
             .name(js_string!("get [Symbol.species]"))
             .build();
 
-        let get_byte_length = BuiltInBuilder::callable(realm, Self::get_byte_length)
+        let get_byte_length = BuiltInBuilder::callable(realm, Self::get_byte_length, mc)
             .name(js_string!("get byteLength"))
             .build();
 
-        let get_resizable = BuiltInBuilder::callable(realm, Self::get_resizable)
+        let get_resizable = BuiltInBuilder::callable(realm, Self::get_resizable, mc)
             .name(js_string!("get resizable"))
             .build();
 
-        let get_max_byte_length = BuiltInBuilder::callable(realm, Self::get_max_byte_length)
+        let get_max_byte_length = BuiltInBuilder::callable(realm, Self::get_max_byte_length, mc)
             .name(js_string!("get maxByteLength"))
             .build();
 
         #[cfg(feature = "experimental")]
-        let get_detached = BuiltInBuilder::callable(realm, Self::get_detached)
+        let get_detached = BuiltInBuilder::callable(realm, Self::get_detached, mc)
             .name(js_string!("get detached"))
             .build();
 
-        let builder = BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        let builder = BuiltInBuilder::from_standard_constructor::<Self>(realm, mc)
             .static_accessor(
                 JsSymbol::species(),
                 Some(get_species),
@@ -848,6 +848,7 @@ impl ArrayBuffer {
             .prototype();
 
         Ok(JsObject::from_proto_and_data_with_shared_shape(
+            context.gc_collector(),
             context.root_shape(),
             prototype,
             ArrayBuffer {
@@ -899,6 +900,7 @@ impl ArrayBuffer {
         let block = create_byte_data_block(byte_len, max_byte_len, context)?;
 
         let obj = JsObject::new(
+            context.gc_collector(),
             context.root_shape(),
             prototype,
             Self {

--- a/core/engine/src/builtins/array_buffer/shared.rs
+++ b/core/engine/src/builtins/array_buffer/shared.rs
@@ -96,26 +96,26 @@ impl SharedArrayBuffer {
 }
 
 impl IntrinsicObject for SharedArrayBuffer {
-    fn init(realm: &Realm) {
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
         let flag_attributes = Attribute::CONFIGURABLE | Attribute::NON_ENUMERABLE;
 
-        let get_species = BuiltInBuilder::callable(realm, Self::get_species)
+        let get_species = BuiltInBuilder::callable(realm, Self::get_species, mc)
             .name(js_string!("get [Symbol.species]"))
             .build();
 
-        let get_byte_length = BuiltInBuilder::callable(realm, Self::get_byte_length)
+        let get_byte_length = BuiltInBuilder::callable(realm, Self::get_byte_length, mc)
             .name(js_string!("get byteLength"))
             .build();
 
-        let get_growable = BuiltInBuilder::callable(realm, Self::get_growable)
+        let get_growable = BuiltInBuilder::callable(realm, Self::get_growable, mc)
             .name(js_string!("get growable"))
             .build();
 
-        let get_max_byte_length = BuiltInBuilder::callable(realm, Self::get_max_byte_length)
+        let get_max_byte_length = BuiltInBuilder::callable(realm, Self::get_max_byte_length, mc)
             .name(js_string!("get maxByteLength"))
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, mc)
             .static_accessor(
                 JsSymbol::species(),
                 Some(get_species),
@@ -537,6 +537,7 @@ impl SharedArrayBuffer {
         // 10. Else,
         //     a. Set obj.[[ArrayBufferByteLength]] to byteLength.
         let obj = JsObject::new(
+            context.gc_collector(),
             context.root_shape(),
             prototype,
             Self {

--- a/core/engine/src/builtins/async_function/mod.rs
+++ b/core/engine/src/builtins/async_function/mod.rs
@@ -24,8 +24,8 @@ use super::{BuiltInBuilder, BuiltInConstructor, IntrinsicObject};
 pub struct AsyncFunction;
 
 impl IntrinsicObject for AsyncFunction {
-    fn init(realm: &Realm) {
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, mc)
             .prototype(realm.intrinsics().constructors().function().constructor())
             .inherits(Some(
                 realm.intrinsics().constructors().function().prototype(),

--- a/core/engine/src/builtins/async_generator/mod.rs
+++ b/core/engine/src/builtins/async_generator/mod.rs
@@ -70,8 +70,8 @@ pub struct AsyncGenerator {
 }
 
 impl IntrinsicObject for AsyncGenerator {
-    fn init(realm: &Realm) {
-        BuiltInBuilder::with_intrinsic::<Self>(realm)
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
+        BuiltInBuilder::with_intrinsic::<Self>(realm, mc)
             .prototype(
                 realm
                     .intrinsics()
@@ -580,6 +580,7 @@ impl AsyncGenerator {
         // 12. Let onFulfilled be CreateBuiltinFunction(fulfilledClosure, 1, "", « »).
         let on_fulfilled = FunctionObjectBuilder::new(
             context.realm(),
+            context.gc_collector(),
             NativeFunction::from_copy_closure_with_captures(
                 |_this, args, generator, context| {
                     // a. Assert: generator.[[AsyncGeneratorState]] is draining-queue.
@@ -611,6 +612,7 @@ impl AsyncGenerator {
         // 14. Let onRejected be CreateBuiltinFunction(rejectedClosure, 1, "", « »).
         let on_rejected = FunctionObjectBuilder::new(
             context.realm(),
+            context.gc_collector(),
             NativeFunction::from_copy_closure_with_captures(
                 |_this, args, generator, context| {
                     // a. Assert: generator.[[AsyncGeneratorState]] is draining-queue.

--- a/core/engine/src/builtins/async_generator_function/mod.rs
+++ b/core/engine/src/builtins/async_generator_function/mod.rs
@@ -24,8 +24,8 @@ use super::{BuiltInBuilder, BuiltInConstructor, IntrinsicObject};
 pub struct AsyncGeneratorFunction;
 
 impl IntrinsicObject for AsyncGeneratorFunction {
-    fn init(realm: &Realm) {
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, mc)
             .inherits(Some(
                 realm.intrinsics().constructors().function().prototype(),
             ))

--- a/core/engine/src/builtins/atomics/mod.rs
+++ b/core/engine/src/builtins/atomics/mod.rs
@@ -39,8 +39,8 @@ use super::{
 pub(crate) struct Atomics;
 
 impl IntrinsicObject for Atomics {
-    fn init(realm: &Realm) {
-        let builder = BuiltInBuilder::with_intrinsic::<Self>(realm)
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
+        let builder = BuiltInBuilder::with_intrinsic::<Self>(realm, mc)
             .static_property(
                 JsSymbol::to_string_tag(),
                 Self::NAME,
@@ -494,7 +494,11 @@ impl Atomics {
                 .intrinsics()
                 .templates()
                 .wait_async()
-                .create(OrdinaryObject, vec![is_async.into(), value])
+                .create(
+                    context.gc_collector(),
+                    OrdinaryObject,
+                    vec![is_async.into(), value],
+                )
                 .into())
         } else {
             let result = unsafe {

--- a/core/engine/src/builtins/bigint/mod.rs
+++ b/core/engine/src/builtins/bigint/mod.rs
@@ -37,8 +37,8 @@ mod tests;
 pub struct BigInt;
 
 impl IntrinsicObject for BigInt {
-    fn init(realm: &Realm) {
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, mc)
             .method(Self::to_string, js_string!("toString"), 0)
             .method(Self::to_locale_string, js_string!("toLocaleString"), 0)
             .method(Self::value_of, js_string!("valueOf"), 0)

--- a/core/engine/src/builtins/boolean/mod.rs
+++ b/core/engine/src/builtins/boolean/mod.rs
@@ -30,8 +30,8 @@ use super::{BuiltInBuilder, BuiltInConstructor, IntrinsicObject};
 pub(crate) struct Boolean;
 
 impl IntrinsicObject for Boolean {
-    fn init(realm: &Realm) {
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, mc)
             .method(Self::to_string, js_string!("toString"), 0)
             .method(Self::value_of, js_string!("valueOf"), 0)
             .build();
@@ -69,8 +69,12 @@ impl BuiltInConstructor for Boolean {
         }
         let prototype =
             get_prototype_from_constructor(new_target, StandardConstructors::boolean, context)?;
-        let boolean =
-            JsObject::from_proto_and_data_with_shared_shape(context.root_shape(), prototype, data);
+        let boolean = JsObject::from_proto_and_data_with_shared_shape(
+            context.gc_collector(),
+            context.root_shape(),
+            prototype,
+            data,
+        );
 
         Ok(boolean.into())
     }

--- a/core/engine/src/builtins/builder.rs
+++ b/core/engine/src/builtins/builder.rs
@@ -60,12 +60,13 @@ pub(crate) struct OrdinaryObject;
 
 /// Applies the pending builder data to the object.
 pub(crate) trait ApplyToObject {
-    fn apply_to(self, object: &JsObject);
+    fn apply_to(self, mc: &boa_gc::MutationContext<'static, '_>, object: &JsObject);
 }
 
 impl ApplyToObject for Constructor {
-    fn apply_to(self, object: &JsObject) {
+    fn apply_to(self, mc: &boa_gc::MutationContext<'static, '_>, object: &JsObject) {
         object.insert(
+            mc,
             PROTOTYPE,
             PropertyDescriptor::builder()
                 .value(self.prototype.clone())
@@ -76,8 +77,9 @@ impl ApplyToObject for Constructor {
 
         {
             let mut prototype = self.prototype.borrow_mut();
-            prototype.set_prototype(self.inherits);
+            prototype.set_prototype(mc, self.inherits);
             prototype.insert(
+                mc,
                 CONSTRUCTOR,
                 PropertyDescriptor::builder()
                     .value(object.clone())
@@ -90,15 +92,15 @@ impl ApplyToObject for Constructor {
 }
 
 impl ApplyToObject for ConstructorNoProto {
-    fn apply_to(self, _: &JsObject) {}
+    fn apply_to(self, _: &boa_gc::MutationContext<'static, '_>, _: &JsObject) {}
 }
 
 impl ApplyToObject for OrdinaryFunction {
-    fn apply_to(self, _: &JsObject) {}
+    fn apply_to(self, _: &boa_gc::MutationContext<'static, '_>, _: &JsObject) {}
 }
 
 impl<S: ApplyToObject + IsConstructor> ApplyToObject for Callable<S> {
-    fn apply_to(self, object: &JsObject) {
+    fn apply_to(self, mc: &boa_gc::MutationContext<'static, '_>, object: &JsObject) {
         {
             let mut function = object
                 .downcast_mut::<NativeFunctionObject>()
@@ -108,6 +110,7 @@ impl<S: ApplyToObject + IsConstructor> ApplyToObject for Callable<S> {
             function.realm = Some(self.realm);
         }
         object.insert(
+            mc,
             StaticJsStrings::LENGTH,
             PropertyDescriptor::builder()
                 .value(self.length)
@@ -116,6 +119,7 @@ impl<S: ApplyToObject + IsConstructor> ApplyToObject for Callable<S> {
                 .configurable(true),
         );
         object.insert(
+            mc,
             js_string!("name"),
             PropertyDescriptor::builder()
                 .value(self.name)
@@ -124,22 +128,22 @@ impl<S: ApplyToObject + IsConstructor> ApplyToObject for Callable<S> {
                 .configurable(true),
         );
 
-        self.kind.apply_to(object);
+        self.kind.apply_to(mc, object);
     }
 }
 
 impl ApplyToObject for OrdinaryObject {
-    fn apply_to(self, _: &JsObject) {}
+    fn apply_to(self, _: &boa_gc::MutationContext<'static, '_>, _: &JsObject) {}
 }
 
 /// Builder for creating built-in objects, like `Array`.
 ///
 /// The marker `ObjectType` restricts the methods that can be called depending on the
 /// type of object that is being constructed.
-#[derive(Debug)]
 #[must_use = "You need to call the `build` method in order for this to correctly assign the inner data"]
 pub(crate) struct BuiltInBuilder<'ctx, Kind> {
     realm: &'ctx Realm,
+    mc: &'ctx boa_gc::MutationContext<'static, 'ctx>,
     object: JsObject,
     kind: Kind,
     prototype: JsObject,
@@ -148,9 +152,11 @@ pub(crate) struct BuiltInBuilder<'ctx, Kind> {
 impl<'ctx> BuiltInBuilder<'ctx, OrdinaryObject> {
     pub(crate) fn with_intrinsic<I: IntrinsicObject>(
         realm: &'ctx Realm,
+        mc: &'ctx boa_gc::MutationContext<'static, 'ctx>,
     ) -> BuiltInBuilder<'ctx, OrdinaryObject> {
         BuiltInBuilder {
             realm,
+            mc,
             object: I::get(realm.intrinsics()),
             kind: OrdinaryObject,
             prototype: realm.intrinsics().constructors().object().prototype(),
@@ -160,6 +166,7 @@ impl<'ctx> BuiltInBuilder<'ctx, OrdinaryObject> {
 
 pub(crate) struct BuiltInConstructorWithPrototype<'ctx> {
     realm: &'ctx Realm,
+    mc: &'ctx boa_gc::MutationContext<'static, 'ctx>,
     function: NativeFunctionPointer,
     name: JsString,
     length: usize,
@@ -222,7 +229,7 @@ impl BuiltInConstructorWithPrototype<'_> {
         B: Into<FunctionBinding>,
     {
         let binding = binding.into();
-        let function = BuiltInBuilder::callable(self.realm, function)
+        let function = BuiltInBuilder::callable(self.realm, function, self.mc)
             .name(binding.name)
             .length(length)
             .build();
@@ -302,7 +309,7 @@ impl BuiltInConstructorWithPrototype<'_> {
         B: Into<FunctionBinding>,
     {
         let binding = binding.into();
-        let function = BuiltInBuilder::callable(self.realm, function)
+        let function = BuiltInBuilder::callable(self.realm, function, self.mc)
             .name(binding.name)
             .length(length)
             .build();
@@ -490,6 +497,7 @@ impl BuiltInConstructorWithPrototype<'_> {
 
 pub(crate) struct BuiltInCallable<'ctx> {
     realm: &'ctx Realm,
+    mc: &'ctx boa_gc::MutationContext<'static, 'ctx>,
     function: NativeFunctionPointer,
     name: JsString,
     length: usize,
@@ -515,6 +523,7 @@ impl BuiltInCallable<'_> {
 
     pub(crate) fn build(self) -> JsFunction {
         let object = self.realm.intrinsics().templates().function().create(
+            self.mc,
             NativeFunctionObject {
                 f: NativeFunction::from_fn_ptr(self.function),
                 name: self.name.clone(),
@@ -532,9 +541,11 @@ impl<'ctx> BuiltInBuilder<'ctx, OrdinaryObject> {
     pub(crate) fn callable(
         realm: &'ctx Realm,
         function: NativeFunctionPointer,
+        mc: &'ctx boa_gc::MutationContext<'static, 'ctx>,
     ) -> BuiltInCallable<'ctx> {
         BuiltInCallable {
             realm,
+            mc,
             function,
             length: 0,
             name: js_string!(),
@@ -544,9 +555,11 @@ impl<'ctx> BuiltInBuilder<'ctx, OrdinaryObject> {
     pub(crate) fn callable_with_intrinsic<I: IntrinsicObject>(
         realm: &'ctx Realm,
         function: NativeFunctionPointer,
+        mc: &'ctx boa_gc::MutationContext<'static, 'ctx>,
     ) -> BuiltInBuilder<'ctx, Callable<OrdinaryFunction>> {
         BuiltInBuilder {
             realm,
+            mc,
             object: I::get(realm.intrinsics()),
             kind: Callable {
                 function,
@@ -563,9 +576,11 @@ impl<'ctx> BuiltInBuilder<'ctx, OrdinaryObject> {
         realm: &'ctx Realm,
         object: JsObject,
         function: NativeFunctionPointer,
+        mc: &'ctx boa_gc::MutationContext<'static, 'ctx>,
     ) -> BuiltInBuilder<'ctx, Callable<OrdinaryFunction>> {
         BuiltInBuilder {
             realm,
+            mc,
             object,
             kind: Callable {
                 function,
@@ -586,10 +601,12 @@ impl<'ctx> BuiltInBuilder<'ctx, Callable<Constructor>> {
     /// (less reallocations).
     pub(crate) fn from_standard_constructor<SC: BuiltInConstructor>(
         realm: &'ctx Realm,
+        mc: &'ctx boa_gc::MutationContext<'static, 'ctx>,
     ) -> BuiltInConstructorWithPrototype<'ctx> {
         let constructor = SC::STANDARD_CONSTRUCTOR(realm.intrinsics().constructors());
         BuiltInConstructorWithPrototype {
             realm,
+            mc,
             function: SC::constructor,
             name: js_string!(SC::NAME),
             length: SC::CONSTRUCTOR_ARGUMENTS,
@@ -634,12 +651,13 @@ impl<T> BuiltInBuilder<'_, T> {
         B: Into<FunctionBinding>,
     {
         let binding = binding.into();
-        let function = BuiltInBuilder::callable(self.realm, function)
+        let function = BuiltInBuilder::callable(self.realm, function, self.mc)
             .name(binding.name)
             .length(length)
             .build();
 
         self.object.insert(
+            self.mc,
             binding.binding,
             PropertyDescriptor::builder()
                 .value(function)
@@ -661,7 +679,7 @@ impl<T> BuiltInBuilder<'_, T> {
             .writable(attribute.writable())
             .enumerable(attribute.enumerable())
             .configurable(attribute.configurable());
-        self.object.insert(key, property);
+        self.object.insert(self.mc, key, property);
         self
     }
 
@@ -690,7 +708,7 @@ impl<T> BuiltInBuilder<'_, T> {
 
         let key = key.into();
 
-        self.object.insert(key, property);
+        self.object.insert(self.mc, key, property);
 
         self
     }
@@ -726,9 +744,9 @@ impl<FnTyp> BuiltInBuilder<'_, Callable<FnTyp>> {
 impl BuiltInBuilder<'_, OrdinaryObject> {
     /// Build the builtin object.
     pub(crate) fn build(self) -> JsObject {
-        self.kind.apply_to(&self.object);
+        self.kind.apply_to(self.mc, &self.object);
 
-        self.object.set_prototype(Some(self.prototype));
+        self.object.set_prototype(self.mc, Some(self.prototype));
 
         self.object
     }
@@ -737,9 +755,9 @@ impl BuiltInBuilder<'_, OrdinaryObject> {
 impl<FnTyp: ApplyToObject + IsConstructor> BuiltInBuilder<'_, Callable<FnTyp>> {
     /// Build the builtin callable.
     pub(crate) fn build(self) -> JsFunction {
-        self.kind.apply_to(&self.object);
+        self.kind.apply_to(self.mc, &self.object);
 
-        self.object.set_prototype(Some(self.prototype));
+        self.object.set_prototype(self.mc, Some(self.prototype));
 
         JsFunction::from_object_unchecked(self.object)
     }

--- a/core/engine/src/builtins/dataview/mod.rs
+++ b/core/engine/src/builtins/dataview/mod.rs
@@ -94,22 +94,22 @@ impl DataView {
 }
 
 impl IntrinsicObject for DataView {
-    fn init(realm: &Realm) {
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
         let flag_attributes = Attribute::CONFIGURABLE | Attribute::NON_ENUMERABLE;
 
-        let get_buffer = BuiltInBuilder::callable(realm, Self::get_buffer)
+        let get_buffer = BuiltInBuilder::callable(realm, Self::get_buffer, mc)
             .name(js_string!("get buffer"))
             .build();
 
-        let get_byte_length = BuiltInBuilder::callable(realm, Self::get_byte_length)
+        let get_byte_length = BuiltInBuilder::callable(realm, Self::get_byte_length, mc)
             .name(js_string!("get byteLength"))
             .build();
 
-        let get_byte_offset = BuiltInBuilder::callable(realm, Self::get_byte_offset)
+        let get_byte_offset = BuiltInBuilder::callable(realm, Self::get_byte_offset, mc)
             .name(js_string!("get byteOffset"))
             .build();
 
-        let builder = BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        let builder = BuiltInBuilder::from_standard_constructor::<Self>(realm, mc)
             .accessor(
                 js_string!("buffer"),
                 Some(get_buffer),
@@ -295,6 +295,7 @@ impl BuiltInConstructor for DataView {
         }
 
         let obj = JsObject::from_proto_and_data_with_shared_shape(
+            context.gc_collector(),
             context.root_shape(),
             prototype,
             Self {

--- a/core/engine/src/builtins/date/mod.rs
+++ b/core/engine/src/builtins/date/mod.rs
@@ -83,18 +83,18 @@ impl Date {
 }
 
 impl IntrinsicObject for Date {
-    fn init(realm: &Realm) {
-        let to_utc_string = BuiltInBuilder::callable(realm, Self::to_utc_string)
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
+        let to_utc_string = BuiltInBuilder::callable(realm, Self::to_utc_string, mc)
             .name(js_string!("toUTCString"))
             .length(0)
             .build();
 
-        let to_primitive = BuiltInBuilder::callable(realm, Self::to_primitive)
+        let to_primitive = BuiltInBuilder::callable(realm, Self::to_primitive, mc)
             .name(js_string!("[Symbol.toPrimitive]"))
             .length(1)
             .build();
 
-        let builder = BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        let builder = BuiltInBuilder::from_standard_constructor::<Self>(realm, mc)
             .static_method(Self::now, js_string!("now"), 0)
             .static_method(Self::parse, js_string!("parse"), 1)
             .static_method(Self::utc, js_string!("UTC"), 7)
@@ -335,8 +335,12 @@ impl BuiltInConstructor for Date {
             get_prototype_from_constructor(new_target, StandardConstructors::date, context)?;
 
         // 7. Set O.[[DateValue]] to dv.
-        let obj =
-            JsObject::from_proto_and_data_with_shared_shape(context.root_shape(), prototype, dv);
+        let obj = JsObject::from_proto_and_data_with_shared_shape(
+            context.gc_collector(),
+            context.root_shape(),
+            prototype,
+            dv,
+        );
 
         // 8. Return O.
         Ok(obj.into())

--- a/core/engine/src/builtins/error/aggregate.rs
+++ b/core/engine/src/builtins/error/aggregate.rs
@@ -27,9 +27,9 @@ use super::{Error, ErrorKind};
 pub(crate) struct AggregateError;
 
 impl IntrinsicObject for AggregateError {
-    fn init(realm: &Realm) {
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
         let attribute = Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE;
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, mc)
             .prototype(realm.intrinsics().constructors().error().constructor())
             .inherits(Some(realm.intrinsics().constructors().error().prototype()))
             .property(js_string!("name"), Self::NAME, attribute)
@@ -86,6 +86,7 @@ impl BuiltInConstructor for AggregateError {
             context,
         )?;
         let o = JsObject::from_proto_and_data_with_shared_shape(
+            context.gc_collector(),
             context.root_shape(),
             prototype,
             Error::with_caller_position(ErrorKind::Aggregate, context),

--- a/core/engine/src/builtins/error/eval.rs
+++ b/core/engine/src/builtins/error/eval.rs
@@ -29,9 +29,9 @@ use super::{Error, ErrorKind};
 pub(crate) struct EvalError;
 
 impl IntrinsicObject for EvalError {
-    fn init(realm: &Realm) {
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
         let attribute = Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE;
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, mc)
             .prototype(realm.intrinsics().constructors().error().constructor())
             .inherits(Some(realm.intrinsics().constructors().error().prototype()))
             .property(js_string!("name"), Self::NAME, attribute)

--- a/core/engine/src/builtins/error/mod.rs
+++ b/core/engine/src/builtins/error/mod.rs
@@ -179,20 +179,20 @@ impl Error {
 }
 
 impl IntrinsicObject for Error {
-    fn init(realm: &Realm) {
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
         let property_attribute =
             Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE;
         let accessor_attribute = Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE;
 
-        let get_stack = BuiltInBuilder::callable(realm, Self::get_stack)
+        let get_stack = BuiltInBuilder::callable(realm, Self::get_stack, mc)
             .name(js_string!("get stack"))
             .build();
 
-        let set_stack = BuiltInBuilder::callable(realm, Self::set_stack)
+        let set_stack = BuiltInBuilder::callable(realm, Self::set_stack, mc)
             .name(js_string!("set stack"))
             .build();
 
-        let builder = BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        let builder = BuiltInBuilder::from_standard_constructor::<Self>(realm, mc)
             .property(js_string!("name"), Self::NAME, property_attribute)
             .property(js_string!("message"), js_string!(), property_attribute)
             .method(Self::to_string, js_string!("toString"), 0)
@@ -248,6 +248,7 @@ impl BuiltInConstructor for Error {
         let prototype =
             get_prototype_from_constructor(new_target, StandardConstructors::error, context)?;
         let o = JsObject::from_proto_and_data_with_shared_shape(
+            context.gc_collector(),
             context.root_shape(),
             prototype,
             Error::with_caller_position(ErrorKind::Error, context),
@@ -468,6 +469,7 @@ impl Error {
 
         let prototype = get_prototype_from_constructor(new_target, constructor_fn, context)?;
         let o = JsObject::from_proto_and_data_with_shared_shape(
+            context.gc_collector(),
             context.root_shape(),
             prototype,
             Error::with_caller_position(error_kind, context),

--- a/core/engine/src/builtins/error/range.rs
+++ b/core/engine/src/builtins/error/range.rs
@@ -27,9 +27,9 @@ use super::{Error, ErrorKind};
 pub(crate) struct RangeError;
 
 impl IntrinsicObject for RangeError {
-    fn init(realm: &Realm) {
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
         let attribute = Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE;
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, mc)
             .prototype(realm.intrinsics().constructors().error().constructor())
             .inherits(Some(realm.intrinsics().constructors().error().prototype()))
             .property(js_string!("name"), Self::NAME, attribute)

--- a/core/engine/src/builtins/error/reference.rs
+++ b/core/engine/src/builtins/error/reference.rs
@@ -26,9 +26,9 @@ use super::{Error, ErrorKind};
 pub(crate) struct ReferenceError;
 
 impl IntrinsicObject for ReferenceError {
-    fn init(realm: &Realm) {
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
         let attribute = Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE;
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, mc)
             .prototype(realm.intrinsics().constructors().error().constructor())
             .inherits(Some(realm.intrinsics().constructors().error().prototype()))
             .property(js_string!("name"), Self::NAME, attribute)

--- a/core/engine/src/builtins/error/syntax.rs
+++ b/core/engine/src/builtins/error/syntax.rs
@@ -29,9 +29,9 @@ use super::{Error, ErrorKind};
 pub(crate) struct SyntaxError;
 
 impl IntrinsicObject for SyntaxError {
-    fn init(realm: &Realm) {
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
         let attribute = Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE;
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, mc)
             .prototype(realm.intrinsics().constructors().error().constructor())
             .inherits(Some(realm.intrinsics().constructors().error().prototype()))
             .property(js_string!("name"), Self::NAME, attribute)

--- a/core/engine/src/builtins/error/type.rs
+++ b/core/engine/src/builtins/error/type.rs
@@ -35,9 +35,9 @@ use super::{Error, ErrorKind};
 pub(crate) struct TypeError;
 
 impl IntrinsicObject for TypeError {
-    fn init(realm: &Realm) {
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
         let attribute = Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE;
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, mc)
             .prototype(realm.intrinsics().constructors().error().constructor())
             .inherits(Some(realm.intrinsics().constructors().error().prototype()))
             .property(js_string!("name"), Self::NAME, attribute)
@@ -82,8 +82,8 @@ impl BuiltInConstructor for TypeError {
 pub(crate) struct ThrowTypeError;
 
 impl IntrinsicObject for ThrowTypeError {
-    fn init(realm: &Realm) {
-        let obj = BuiltInBuilder::with_intrinsic::<Self>(realm)
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
+        let obj = BuiltInBuilder::with_intrinsic::<Self>(realm, mc)
             .prototype(realm.intrinsics().constructors().function().prototype())
             .static_property(StaticJsStrings::LENGTH, 0, Attribute::empty())
             .static_property(js_string!("name"), js_string!(), Attribute::empty())

--- a/core/engine/src/builtins/error/uri.rs
+++ b/core/engine/src/builtins/error/uri.rs
@@ -28,9 +28,9 @@ use super::{Error, ErrorKind};
 pub(crate) struct UriError;
 
 impl IntrinsicObject for UriError {
-    fn init(realm: &Realm) {
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
         let attribute = Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE;
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, mc)
             .prototype(realm.intrinsics().constructors().error().constructor())
             .inherits(Some(realm.intrinsics().constructors().error().prototype()))
             .property(js_string!("name"), Self::NAME, attribute)

--- a/core/engine/src/builtins/escape/mod.rs
+++ b/core/engine/src/builtins/escape/mod.rs
@@ -22,8 +22,8 @@ use super::{BuiltInBuilder, BuiltInObject, IntrinsicObject};
 pub(crate) struct Escape;
 
 impl IntrinsicObject for Escape {
-    fn init(realm: &Realm) {
-        BuiltInBuilder::callable_with_intrinsic::<Self>(realm, escape)
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
+        BuiltInBuilder::callable_with_intrinsic::<Self>(realm, escape, mc)
             .name(Self::NAME)
             .length(1)
             .build();
@@ -94,8 +94,8 @@ fn escape(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsVa
 pub(crate) struct Unescape;
 
 impl IntrinsicObject for Unescape {
-    fn init(realm: &Realm) {
-        BuiltInBuilder::callable_with_intrinsic::<Self>(realm, unescape)
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
+        BuiltInBuilder::callable_with_intrinsic::<Self>(realm, unescape, mc)
             .name(Self::NAME)
             .length(1)
             .build();

--- a/core/engine/src/builtins/eval/mod.rs
+++ b/core/engine/src/builtins/eval/mod.rs
@@ -36,8 +36,8 @@ use super::{BuiltInBuilder, IntrinsicObject};
 pub(crate) struct Eval;
 
 impl IntrinsicObject for Eval {
-    fn init(realm: &Realm) {
-        BuiltInBuilder::callable_with_intrinsic::<Self>(realm, Self::eval)
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
+        BuiltInBuilder::callable_with_intrinsic::<Self>(realm, Self::eval, mc)
             .name(Self::NAME)
             .length(1)
             .build();

--- a/core/engine/src/builtins/eval/mod.rs
+++ b/core/engine/src/builtins/eval/mod.rs
@@ -284,7 +284,7 @@ impl Eval {
             false,
             false,
             context.interner_mut(),
-            &mc,
+            mc,
             in_with,
             spanned_source_text,
             // TODO: Could give more information from previous shadow stack.

--- a/core/engine/src/builtins/finalization_registry/mod.rs
+++ b/core/engine/src/builtins/finalization_registry/mod.rs
@@ -74,8 +74,8 @@ impl IntrinsicObject for FinalizationRegistry {
         Self::STANDARD_CONSTRUCTOR(intrinsics.constructors()).constructor()
     }
 
-    fn init(realm: &Realm) {
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, mc)
             .property(
                 JsSymbol::to_string_tag(),
                 js_string!("FinalizationRegistry"),
@@ -149,6 +149,7 @@ impl BuiltInConstructor for FinalizationRegistry {
         let (sender, receiver) = async_channel::bounded(1);
 
         let registry = JsObject::new_unique(
+            context.gc_collector(),
             prototype,
             FinalizationRegistry {
                 realm,

--- a/core/engine/src/builtins/function/arguments.rs
+++ b/core/engine/src/builtins/function/arguments.rs
@@ -47,6 +47,7 @@ impl UnmappedArguments {
             .templates()
             .unmapped_arguments()
             .create(
+                context.gc_collector(),
                 Self,
                 vec![
                     // 4. Perform DefinePropertyOrThrow(obj, "length", PropertyDescriptor { [[Value]]: 𝔽(len),
@@ -244,6 +245,7 @@ impl MappedArguments {
 
         // 11. Set obj.[[ParameterMap]] to map.
         let obj = context.intrinsics().templates().mapped_arguments().create(
+            context.gc_collector(),
             map,
             vec![
                 // 16. Perform ! DefinePropertyOrThrow(obj, "length", PropertyDescriptor { [[Value]]: 𝔽(len),

--- a/core/engine/src/builtins/function/bound.rs
+++ b/core/engine/src/builtins/function/bound.rs
@@ -66,6 +66,7 @@ impl BoundFunction {
         // 9. Set obj.[[BoundArguments]] to boundArgs.
         // 10. Return obj.
         Ok(JsObject::from_proto_and_data_with_shared_shape(
+            context.gc_collector(),
             context.root_shape(),
             proto,
             Self {

--- a/core/engine/src/builtins/function/mod.rs
+++ b/core/engine/src/builtins/function/mod.rs
@@ -308,15 +308,15 @@ impl OrdinaryFunction {
 pub struct BuiltInFunctionObject;
 
 impl IntrinsicObject for BuiltInFunctionObject {
-    fn init(realm: &Realm) {
-        let has_instance = BuiltInBuilder::callable(realm, Self::has_instance)
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
+        let has_instance = BuiltInBuilder::callable(realm, Self::has_instance, mc)
             .name(js_string!("[Symbol.hasInstance]"))
             .length(1)
             .build();
 
         let throw_type_error = realm.intrinsics().objects().throw_type_error();
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, mc)
             .method(Self::apply, js_string!("apply"), 2)
             .method(Self::bind, js_string!("bind"), 1)
             .method(Self::call, js_string!("call"), 1)
@@ -338,12 +338,15 @@ impl IntrinsicObject for BuiltInFunctionObject {
 
         let prototype = realm.intrinsics().constructors().function().prototype();
 
-        BuiltInBuilder::callable_with_object(realm, prototype.clone(), Self::prototype)
+        BuiltInBuilder::callable_with_object(realm, prototype.clone(), Self::prototype, mc)
             .name(js_string!())
             .length(0)
             .build();
 
-        prototype.set_prototype(Some(realm.intrinsics().constructors().object().prototype()));
+        prototype.set_prototype(
+            mc,
+            Some(realm.intrinsics().constructors().object().prototype()),
+        );
     }
 
     fn get(intrinsics: &Intrinsics) -> JsObject {
@@ -1146,6 +1149,7 @@ fn function_construct(
         let prototype =
             get_prototype_from_constructor(&new_target, StandardConstructors::object, context)?;
         let this = JsObject::from_proto_and_data_with_shared_shape(
+            context.gc_collector(),
             context.root_shape(),
             prototype,
             OrdinaryObject,

--- a/core/engine/src/builtins/function/mod.rs
+++ b/core/engine/src/builtins/function/mod.rs
@@ -677,7 +677,7 @@ impl BuiltInFunctionObject {
                 function.scopes(),
                 function.contains_direct_eval(),
                 context.interner_mut(),
-                &mc,
+                mc,
             );
 
         let saved = context.vm.frame_mut().environments.pop_to_global();

--- a/core/engine/src/builtins/function/tests.rs
+++ b/core/engine/src/builtins/function/tests.rs
@@ -133,7 +133,7 @@ fn closure_capture_clone() {
     run_test_actions([
         TestAction::inspect_context(|ctx| {
             let string = js_string!("Hello");
-            let object = JsObject::with_object_proto(ctx.intrinsics());
+            let object = JsObject::with_object_proto(ctx.gc_collector(), ctx.intrinsics());
             object
                 .define_property_or_throw(
                     js_string!("key"),
@@ -148,6 +148,7 @@ fn closure_capture_clone() {
 
             let func = FunctionObjectBuilder::new(
                 ctx.realm(),
+                ctx.gc_collector(),
                 NativeFunction::from_copy_closure_with_captures(
                     |_, _, captures, context| {
                         let (string, object) = &captures;

--- a/core/engine/src/builtins/generator/mod.rs
+++ b/core/engine/src/builtins/generator/mod.rs
@@ -154,8 +154,8 @@ pub struct Generator {
 }
 
 impl IntrinsicObject for Generator {
-    fn init(realm: &Realm) {
-        BuiltInBuilder::with_intrinsic::<Self>(realm)
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
+        BuiltInBuilder::with_intrinsic::<Self>(realm, mc)
             .prototype(realm.intrinsics().constructors().iterator().prototype())
             .static_method(Self::next, js_string!("next"), 1)
             .static_method(Self::r#return, js_string!("return"), 1)

--- a/core/engine/src/builtins/generator_function/mod.rs
+++ b/core/engine/src/builtins/generator_function/mod.rs
@@ -29,8 +29,8 @@ use super::{BuiltInBuilder, BuiltInConstructor, IntrinsicObject};
 pub struct GeneratorFunction;
 
 impl IntrinsicObject for GeneratorFunction {
-    fn init(realm: &Realm) {
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, mc)
             .inherits(Some(
                 realm.intrinsics().constructors().function().prototype(),
             ))

--- a/core/engine/src/builtins/intl/collator/mod.rs
+++ b/core/engine/src/builtins/intl/collator/mod.rs
@@ -69,12 +69,12 @@ impl Service for Collator {
 }
 
 impl IntrinsicObject for Collator {
-    fn init(realm: &Realm) {
-        let compare = BuiltInBuilder::callable(realm, Self::compare)
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
+        let compare = BuiltInBuilder::callable(realm, Self::compare, mc)
             .name(js_string!("get compare"))
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, mc)
             .static_method(
                 Self::supported_locales_of,
                 js_string!("supportedLocalesOf"),
@@ -274,6 +274,7 @@ impl BuiltInConstructor for Collator {
         let prototype =
             get_prototype_from_constructor(new_target, StandardConstructors::collator, context)?;
         let collator = JsObject::from_proto_and_data_with_shared_shape(
+            context.gc_collector(),
             context.root_shape(),
             prototype,
             Self {
@@ -354,6 +355,7 @@ impl Collator {
         } else {
             let bound_compare = FunctionObjectBuilder::new(
                 context.realm(),
+                context.gc_collector(),
                 // 10.3.3.1. Collator Compare Functions
                 // https://tc39.es/ecma402/#sec-collator-compare-functions
                 NativeFunction::from_copy_closure_with_captures(
@@ -423,11 +425,11 @@ impl Collator {
             })?;
 
         // 3. Let options be OrdinaryObjectCreate(%Object.prototype%).
-        let options = context
-            .intrinsics()
-            .templates()
-            .ordinary_object()
-            .create(OrdinaryObject, vec![]);
+        let options = context.intrinsics().templates().ordinary_object().create(
+            context.gc_collector(),
+            OrdinaryObject,
+            vec![],
+        );
 
         // 4. For each row of Table 4, except the header row, in table order, do
         //     a. Let p be the Property value of the current row.

--- a/core/engine/src/builtins/intl/date_time_format/mod.rs
+++ b/core/engine/src/builtins/intl/date_time_format/mod.rs
@@ -101,13 +101,13 @@ impl Service for DateTimeFormat {
 }
 
 impl IntrinsicObject for DateTimeFormat {
-    fn init(realm: &Realm) {
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
         use crate::JsSymbol;
-        let get_format = BuiltInBuilder::callable(realm, Self::get_format)
+        let get_format = BuiltInBuilder::callable(realm, Self::get_format, mc)
             .name(js_string!("get format"))
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, mc)
             .static_method(
                 Self::supported_locales_of,
                 js_string!("supportedLocalesOf"),
@@ -189,7 +189,8 @@ impl BuiltInConstructor for DateTimeFormat {
             StandardConstructors::date_time_format,
             context,
         )?;
-        let date_time_format = JsObject::from_proto_and_data(prototype, dtf);
+        let date_time_format =
+            JsObject::from_proto_and_data(context.gc_collector(), prototype, dtf);
 
         // 3. If the implementation supports the normative optional constructor mode of 4.3 Note 1, then
         //     a. Let this be the this value.
@@ -259,6 +260,7 @@ impl DateTimeFormat {
             // a. Let F be a new built-in function object as defined in DateTime Format Functions (11.5.4).
             let bound_format = FunctionObjectBuilder::new(
                 context.realm(),
+                context.gc_collector(),
                 NativeFunction::from_copy_closure_with_captures(
                     |_, args, dtf, context| {
                         // 1. Let dtf be F.[[DateTimeFormat]].

--- a/core/engine/src/builtins/intl/list_format/mod.rs
+++ b/core/engine/src/builtins/intl/list_format/mod.rs
@@ -53,8 +53,8 @@ impl Service for ListFormat {
 }
 
 impl IntrinsicObject for ListFormat {
-    fn init(realm: &Realm) {
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, mc)
             .static_method(
                 Self::supported_locales_of,
                 js_string!("supportedLocalesOf"),
@@ -116,7 +116,7 @@ impl BuiltInConstructor for ListFormat {
         let requested_locales = canonicalize_locale_list(locales, context)?;
 
         // 4. Set options to ? GetOptionsObject(options).
-        let options = get_options_object(options)?;
+        let options = get_options_object(options, context.gc_collector())?;
 
         // 5. Let opt be a new Record.
         // 6. Let matcher be ? GetOption(options, "localeMatcher", string, « "lookup", "best fit" », "best fit").
@@ -173,6 +173,7 @@ impl BuiltInConstructor for ListFormat {
         let prototype =
             get_prototype_from_constructor(new_target, StandardConstructors::list_format, context)?;
         let list_format = JsObject::from_proto_and_data_with_shared_shape(
+            context.gc_collector(),
             context.root_shape(),
             prototype,
             Self {
@@ -380,11 +381,11 @@ impl ListFormat {
         // 4. For each Record { [[Type]], [[Value]] } part in parts, do
         for (n, part) in parts.0.into_iter().enumerate() {
             // a. Let O be OrdinaryObjectCreate(%Object.prototype%).
-            let o = context
-                .intrinsics()
-                .templates()
-                .ordinary_object()
-                .create(OrdinaryObject, vec![]);
+            let o = context.intrinsics().templates().ordinary_object().create(
+                context.gc_collector(),
+                OrdinaryObject,
+                vec![],
+            );
 
             // b. Perform ! CreateDataPropertyOrThrow(O, "type", part.[[Type]]).
             o.create_data_property_or_throw(js_string!("type"), js_string!(part.typ()), context)
@@ -429,11 +430,11 @@ impl ListFormat {
             })?;
 
         // 3. Let options be OrdinaryObjectCreate(%Object.prototype%).
-        let options = context
-            .intrinsics()
-            .templates()
-            .ordinary_object()
-            .create(OrdinaryObject, vec![]);
+        let options = context.intrinsics().templates().ordinary_object().create(
+            context.gc_collector(),
+            OrdinaryObject,
+            vec![],
+        );
 
         // 4. For each row of Table 11, except the header row, in table order, do
         //     a. Let p be the Property value of the current row.

--- a/core/engine/src/builtins/intl/locale/mod.rs
+++ b/core/engine/src/builtins/intl/locale/mod.rs
@@ -29,52 +29,52 @@ use super::options::coerce_options_to_object;
 pub(crate) struct Locale;
 
 impl IntrinsicObject for Locale {
-    fn init(realm: &Realm) {
-        let base_name = BuiltInBuilder::callable(realm, Self::base_name)
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
+        let base_name = BuiltInBuilder::callable(realm, Self::base_name, mc)
             .name(js_string!("get baseName"))
             .build();
 
-        let calendar = BuiltInBuilder::callable(realm, Self::calendar)
+        let calendar = BuiltInBuilder::callable(realm, Self::calendar, mc)
             .name(js_string!("get calendar"))
             .build();
 
-        let case_first = BuiltInBuilder::callable(realm, Self::case_first)
+        let case_first = BuiltInBuilder::callable(realm, Self::case_first, mc)
             .name(js_string!("get caseFirst"))
             .build();
 
-        let collation = BuiltInBuilder::callable(realm, Self::collation)
+        let collation = BuiltInBuilder::callable(realm, Self::collation, mc)
             .name(js_string!("get collation"))
             .build();
 
-        let hour_cycle = BuiltInBuilder::callable(realm, Self::hour_cycle)
+        let hour_cycle = BuiltInBuilder::callable(realm, Self::hour_cycle, mc)
             .name(js_string!("get hourCycle"))
             .build();
 
-        let numeric = BuiltInBuilder::callable(realm, Self::numeric)
+        let numeric = BuiltInBuilder::callable(realm, Self::numeric, mc)
             .name(js_string!("get numeric"))
             .build();
 
-        let numbering_system = BuiltInBuilder::callable(realm, Self::numbering_system)
+        let numbering_system = BuiltInBuilder::callable(realm, Self::numbering_system, mc)
             .name(js_string!("get numberingSystem"))
             .build();
 
-        let language = BuiltInBuilder::callable(realm, Self::language)
+        let language = BuiltInBuilder::callable(realm, Self::language, mc)
             .name(js_string!("get language"))
             .build();
 
-        let script = BuiltInBuilder::callable(realm, Self::script)
+        let script = BuiltInBuilder::callable(realm, Self::script, mc)
             .name(js_string!("get script"))
             .build();
 
-        let region = BuiltInBuilder::callable(realm, Self::region)
+        let region = BuiltInBuilder::callable(realm, Self::region, mc)
             .name(js_string!("get region"))
             .build();
 
-        let variants = BuiltInBuilder::callable(realm, Self::variants)
+        let variants = BuiltInBuilder::callable(realm, Self::variants, mc)
             .name(js_string!("get variants"))
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, mc)
             .property(
                 JsSymbol::to_string_tag(),
                 js_string!("Intl.Locale"),
@@ -325,8 +325,12 @@ impl BuiltInConstructor for Locale {
             .locale_canonicalizer()?
             .canonicalize(&mut tag);
 
-        let locale =
-            JsObject::from_proto_and_data_with_shared_shape(context.root_shape(), prototype, tag);
+        let locale = JsObject::from_proto_and_data_with_shared_shape(
+            context.gc_collector(),
+            context.root_shape(),
+            prototype,
+            tag,
+        );
 
         // 39. Return locale.
         Ok(locale.into())
@@ -369,10 +373,13 @@ impl Locale {
 
         // 4. Return ! Construct(%Locale%, maximal).
         let prototype = context.intrinsics().constructors().locale().prototype();
-        Ok(
-            JsObject::from_proto_and_data_with_shared_shape(context.root_shape(), prototype, loc)
-                .into(),
+        Ok(JsObject::from_proto_and_data_with_shared_shape(
+            context.gc_collector(),
+            context.root_shape(),
+            prototype,
+            loc,
         )
+        .into())
     }
 
     /// [`Intl.Locale.prototype.minimize ( )`][spec]
@@ -410,10 +417,13 @@ impl Locale {
 
         // 4. Return ! Construct(%Locale%, minimal).
         let prototype = context.intrinsics().constructors().locale().prototype();
-        Ok(
-            JsObject::from_proto_and_data_with_shared_shape(context.root_shape(), prototype, loc)
-                .into(),
+        Ok(JsObject::from_proto_and_data_with_shared_shape(
+            context.gc_collector(),
+            context.root_shape(),
+            prototype,
+            loc,
         )
+        .into())
     }
 
     /// [`Intl.Locale.prototype.toString ( )`][spec].

--- a/core/engine/src/builtins/intl/mod.rs
+++ b/core/engine/src/builtins/intl/mod.rs
@@ -119,8 +119,8 @@ impl Intl {
 }
 
 impl IntrinsicObject for Intl {
-    fn init(realm: &Realm) {
-        BuiltInBuilder::with_intrinsic::<Self>(realm)
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
+        BuiltInBuilder::with_intrinsic::<Self>(realm, mc)
             .static_property(
                 JsSymbol::to_string_tag(),
                 Self::NAME,

--- a/core/engine/src/builtins/intl/number_format/mod.rs
+++ b/core/engine/src/builtins/intl/number_format/mod.rs
@@ -162,12 +162,12 @@ impl Service for NumberFormat {
 }
 
 impl IntrinsicObject for NumberFormat {
-    fn init(realm: &Realm) {
-        let get_format = BuiltInBuilder::callable(realm, Self::get_format)
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
+        let get_format = BuiltInBuilder::callable(realm, Self::get_format, mc)
             .name(js_string!("get format"))
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, mc)
             .static_method(
                 Self::supported_locales_of,
                 js_string!("supportedLocalesOf"),
@@ -242,6 +242,7 @@ impl BuiltInConstructor for NumberFormat {
         let number_format = Self::new(locales, options, context)?;
 
         let number_format = JsObject::from_proto_and_data_with_shared_shape(
+            context.gc_collector(),
             context.root_shape(),
             prototype,
             number_format,
@@ -605,6 +606,7 @@ impl NumberFormat {
             //     c. Set nf.[[BoundFormat]] to F.
             let bound_format = FunctionObjectBuilder::new(
                 context.realm(),
+                context.gc_collector(),
                 // Number Format Functions
                 // <https://tc39.es/ecma402/#sec-number-format-functions>
                 NativeFunction::from_copy_closure_with_captures(

--- a/core/engine/src/builtins/intl/options.rs
+++ b/core/engine/src/builtins/intl/options.rs
@@ -153,6 +153,7 @@ pub(super) fn coerce_options_to_object(
     if options.is_undefined() {
         // a. Return OrdinaryObjectCreate(null).
         return Ok(JsObject::from_proto_and_data_with_shared_shape(
+            context.gc_collector(),
             context.root_shape(),
             None,
             OrdinaryObject,

--- a/core/engine/src/builtins/intl/plural_rules/mod.rs
+++ b/core/engine/src/builtins/intl/plural_rules/mod.rs
@@ -47,8 +47,8 @@ impl Service for PluralRules {
 }
 
 impl IntrinsicObject for PluralRules {
-    fn init(realm: &Realm) {
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, mc)
             .static_method(
                 Self::supported_locales_of,
                 js_string!("supportedLocalesOf"),
@@ -151,6 +151,7 @@ impl BuiltInConstructor for PluralRules {
 
         // 12. Return pluralRules.
         Ok(JsObject::from_proto_and_data_with_shared_shape(
+            context.gc_collector(),
             context.root_shape(),
             proto,
             Self {

--- a/core/engine/src/builtins/intl/segmenter/iterator.rs
+++ b/core/engine/src/builtins/intl/segmenter/iterator.rs
@@ -59,8 +59,8 @@ pub(crate) struct SegmentIterator {
 }
 
 impl IntrinsicObject for SegmentIterator {
-    fn init(realm: &Realm) {
-        BuiltInBuilder::with_intrinsic::<Self>(realm)
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
+        BuiltInBuilder::with_intrinsic::<Self>(realm, mc)
             .static_property(
                 JsSymbol::to_string_tag(),
                 js_string!("Segmenter String Iterator"),
@@ -87,6 +87,7 @@ impl SegmentIterator {
         // 5. Set iterator.[[IteratedStringNextSegmentCodeUnitIndex]] to 0.
         // 6. Return iterator.
         JsObject::from_proto_and_data_with_shared_shape(
+            context.gc_collector(),
             context.root_shape(),
             context
                 .intrinsics()

--- a/core/engine/src/builtins/intl/segmenter/mod.rs
+++ b/core/engine/src/builtins/intl/segmenter/mod.rs
@@ -103,8 +103,8 @@ impl Service for Segmenter {
 }
 
 impl IntrinsicObject for Segmenter {
-    fn init(realm: &Realm) {
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, mc)
             .static_method(
                 Self::supported_locales_of,
                 js_string!("supportedLocalesOf"),
@@ -155,7 +155,7 @@ impl BuiltInConstructor for Segmenter {
         let requested_locales = canonicalize_locale_list(locales, context)?;
 
         // 5. Set options to ? GetOptionsObject(options).
-        let options = get_options_object(options)?;
+        let options = get_options_object(options, context.gc_collector())?;
 
         // 6. Let opt be a new Record.
         // 7. Let matcher be ? GetOption(options, "localeMatcher", string, « "lookup", "best fit" », "best fit").
@@ -214,8 +214,12 @@ impl BuiltInConstructor for Segmenter {
         let proto =
             get_prototype_from_constructor(new_target, StandardConstructors::segmenter, context)?;
 
-        let segmenter =
-            JsObject::from_proto_and_data_with_shared_shape(context.root_shape(), proto, segmenter);
+        let segmenter = JsObject::from_proto_and_data_with_shared_shape(
+            context.gc_collector(),
+            context.root_shape(),
+            proto,
+            segmenter,
+        );
 
         // 14. Return segmenter.
         Ok(segmenter.into())

--- a/core/engine/src/builtins/intl/segmenter/segments.rs
+++ b/core/engine/src/builtins/intl/segmenter/segments.rs
@@ -19,8 +19,8 @@ pub(crate) struct Segments {
 }
 
 impl IntrinsicObject for Segments {
-    fn init(realm: &Realm) {
-        BuiltInBuilder::with_intrinsic::<Self>(realm)
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
+        BuiltInBuilder::with_intrinsic::<Self>(realm, mc)
             .static_method(Self::containing, js_string!("containing"), 1)
             .static_method(Self::iterator, JsSymbol::iterator(), 0)
             .build();
@@ -42,6 +42,7 @@ impl Segments {
         // 4. Set segments.[[SegmentsString]] to string.
         // 5. Return segments.
         JsObject::from_proto_and_data_with_shared_shape(
+            context.gc_collector(),
             context.root_shape(),
             context.intrinsics().objects().segments_prototype(),
             Self { segmenter, string },

--- a/core/engine/src/builtins/iterable/async_from_sync_iterator.rs
+++ b/core/engine/src/builtins/iterable/async_from_sync_iterator.rs
@@ -26,8 +26,8 @@ pub(crate) struct AsyncFromSyncIterator {
 }
 
 impl IntrinsicObject for AsyncFromSyncIterator {
-    fn init(realm: &Realm) {
-        BuiltInBuilder::with_intrinsic::<Self>(realm)
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
+        BuiltInBuilder::with_intrinsic::<Self>(realm, mc)
             .prototype(
                 realm
                     .intrinsics()
@@ -63,6 +63,7 @@ impl AsyncFromSyncIterator {
         // 1. Let asyncIterator be OrdinaryObjectCreate(%AsyncFromSyncIteratorPrototype%, « [[SyncIteratorRecord]] »).
         // 2. Set asyncIterator.[[SyncIteratorRecord]] to syncIteratorRecord.
         let async_iterator = JsObject::from_proto_and_data_with_shared_shape(
+            context.gc_collector(),
             context.root_shape(),
             context
                 .intrinsics()
@@ -82,7 +83,7 @@ impl AsyncFromSyncIterator {
 
         // 4. Let iteratorRecord be the Iterator Record { [[Iterator]]: asyncIterator, [[NextMethod]]: nextMethod, [[Done]]: false }.
         // 5. Return iteratorRecord.
-        IteratorRecord::new(async_iterator, next_method)
+        IteratorRecord::new(async_iterator, next_method, context.gc_collector())
     }
 
     /// `%AsyncFromSyncIteratorPrototype%.next ( [ value ] )`
@@ -362,6 +363,7 @@ impl AsyncFromSyncIterator {
         // 10. Let onFulfilled be CreateBuiltinFunction(unwrap, 1, "", « »).
         let on_fulfilled = FunctionObjectBuilder::new(
             context.realm(),
+            context.gc_collector(),
             NativeFunction::from_copy_closure(move |_this, args, context| {
                 // a. Return CreateIterResultObject(value, done).
                 Ok(create_iter_result_object(
@@ -393,6 +395,7 @@ impl AsyncFromSyncIterator {
             Some(
                 FunctionObjectBuilder::new(
                     context.realm(),
+                    context.gc_collector(),
                     NativeFunction::from_copy_closure_with_captures(
                         |_this, args, iter, context| {
                             // i. Return ? IteratorClose(syncIteratorRecord, ThrowCompletion(error)).

--- a/core/engine/src/builtins/iterable/iterator_constructor.rs
+++ b/core/engine/src/builtins/iterable/iterator_constructor.rs
@@ -40,9 +40,9 @@ use super::{iterator_helper::IteratorHelper, wrap_for_valid_iterator::WrapForVal
 pub(crate) struct IteratorConstructor;
 
 impl IntrinsicObject for IteratorConstructor {
-    fn init(realm: &Realm) {
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
         let iterator_prototype = realm.intrinsics().constructors().iterator().prototype();
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, mc)
             .inherits(Some(iterator_prototype.clone()))
             // Static methods
             .static_method(Self::from, js_string!("from"), 1)
@@ -101,6 +101,7 @@ impl BuiltInConstructor for IteratorConstructor {
 
         // Create an ordinary object (Iterator instances have no internal data slots).
         Ok(JsObject::from_proto_and_data_with_shared_shape(
+            context.gc_collector(),
             context.root_shape(),
             prototype,
             OrdinaryObject,
@@ -141,6 +142,7 @@ impl IteratorConstructor {
         // 5. Set wrapper.[[Iterated]] to iteratorRecord.
         // 6. Return wrapper.
         let wrapper = JsObject::from_proto_and_data_with_shared_shape(
+            context.gc_collector(),
             context.root_shape(),
             context
                 .intrinsics()

--- a/core/engine/src/builtins/iterable/iterator_helper/mod.rs
+++ b/core/engine/src/builtins/iterable/iterator_helper/mod.rs
@@ -75,8 +75,8 @@ pub(crate) struct IteratorHelper {
 }
 
 impl IntrinsicObject for IteratorHelper {
-    fn init(realm: &Realm) {
-        BuiltInBuilder::with_intrinsic::<Self>(realm)
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
+        BuiltInBuilder::with_intrinsic::<Self>(realm, mc)
             .prototype(realm.intrinsics().constructors().iterator().prototype())
             .static_method(Self::next, js_string!("next"), 0)
             .static_method(Self::r#return, js_string!("return"), 0)
@@ -296,6 +296,7 @@ impl IteratorHelper {
         //     ).
         // ii. Set result.[[UnderlyingIterators]] to « iterated ».
         JsObject::from_proto_and_data_with_shared_shape(
+            context.gc_collector(),
             context.root_shape(),
             context
                 .intrinsics()

--- a/core/engine/src/builtins/iterable/iterator_prototype.rs
+++ b/core/engine/src/builtins/iterable/iterator_prototype.rs
@@ -26,20 +26,20 @@ use crate::{
 pub(crate) struct Iterator;
 
 impl IntrinsicObject for Iterator {
-    fn init(realm: &Realm) {
-        let get_constructor = BuiltInBuilder::callable(realm, Self::get_constructor)
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
+        let get_constructor = BuiltInBuilder::callable(realm, Self::get_constructor, mc)
             .name(js_string!("get constructor"))
             .build();
-        let set_constructor = BuiltInBuilder::callable(realm, Self::set_constructor)
+        let set_constructor = BuiltInBuilder::callable(realm, Self::set_constructor, mc)
             .name(js_string!("set constructor"))
             .build();
-        let get_to_string_tag = BuiltInBuilder::callable(realm, Self::get_to_string_tag)
+        let get_to_string_tag = BuiltInBuilder::callable(realm, Self::get_to_string_tag, mc)
             .name(js_string!("get [Symbol.toStringTag]"))
             .build();
-        let set_to_string_tag = BuiltInBuilder::callable(realm, Self::set_to_string_tag)
+        let set_to_string_tag = BuiltInBuilder::callable(realm, Self::set_to_string_tag, mc)
             .name(js_string!("set [Symbol.toStringTag]"))
             .build();
-        let builder = BuiltInBuilder::with_intrinsic::<Self>(realm)
+        let builder = BuiltInBuilder::with_intrinsic::<Self>(realm, mc)
             .static_method(|v, _, _| Ok(v.clone()), JsSymbol::iterator(), 0)
             .static_method(Self::map, js_string!("map"), 1)
             .static_method(Self::filter, js_string!("filter"), 1)
@@ -217,7 +217,7 @@ impl Iterator {
             .ok_or_else(|| js_error!(TypeError: "Iterator.prototype.map called on non-object"))?;
 
         // 3. Let iterated be the Iterator Record { [[Iterator]]: O, [[NextMethod]]: undefined, [[Done]]: false }.
-        let iterated = IteratorRecord::new(o, JsValue::undefined());
+        let iterated = IteratorRecord::new(o, JsValue::undefined(), context.gc_collector());
 
         // 4. If IsCallable(mapper) is false, then
         //    a. Let error be ThrowCompletion(a newly created TypeError object).
@@ -255,7 +255,7 @@ impl Iterator {
         )?;
 
         // 3. Let iterated be the Iterator Record { [[Iterator]]: O, [[NextMethod]]: undefined, [[Done]]: false }.
-        let iterated = IteratorRecord::new(o, JsValue::undefined());
+        let iterated = IteratorRecord::new(o, JsValue::undefined(), context.gc_collector());
 
         // 4. If IsCallable(predicate) is false, then
         //    a. Let error be ThrowCompletion(a newly created TypeError object).
@@ -295,7 +295,7 @@ impl Iterator {
             .ok_or_else(|| js_error!(TypeError: "Iterator.prototype.take called on non-object"))?;
 
         // 3. Let iterated be the Iterator Record { [[Iterator]]: O, [[NextMethod]]: undefined, [[Done]]: false }.
-        let iterated = IteratorRecord::new(o, JsValue::undefined());
+        let iterated = IteratorRecord::new(o, JsValue::undefined(), context.gc_collector());
 
         // 4. Let numLimit be Completion(ToNumber(limit)).
         // 5. IfAbruptCloseIterator(numLimit, iterated).
@@ -356,7 +356,7 @@ impl Iterator {
             .ok_or_else(|| js_error!(TypeError: "Iterator.prototype.drop called on non-object"))?;
 
         // 3. Let iterated be the Iterator Record { [[Iterator]]: O, [[NextMethod]]: undefined, [[Done]]: false }.
-        let iterated = IteratorRecord::new(o.clone(), JsValue::undefined());
+        let iterated = IteratorRecord::new(o.clone(), JsValue::undefined(), context.gc_collector());
 
         // 4. Let numLimit be Completion(ToNumber(limit)).
         // 5. IfAbruptCloseIterator(numLimit, iterated).
@@ -416,7 +416,7 @@ impl Iterator {
         )?;
 
         // 3. Let iterated be the Iterator Record { [[Iterator]]: O, [[NextMethod]]: undefined, [[Done]]: false }.
-        let iterated = IteratorRecord::new(o, JsValue::undefined());
+        let iterated = IteratorRecord::new(o, JsValue::undefined(), context.gc_collector());
 
         // 4. If IsCallable(mapper) is false, then
         //    a. Let error be ThrowCompletion(a newly created TypeError object).
@@ -454,7 +454,8 @@ impl Iterator {
         )?;
 
         // 3. Let iterated be the Iterator Record { [[Iterator]]: O, [[NextMethod]]: undefined, [[Done]]: false }.
-        let iterated = IteratorRecord::new(obj.clone(), JsValue::undefined());
+        let iterated =
+            IteratorRecord::new(obj.clone(), JsValue::undefined(), context.gc_collector());
 
         let search_element = args.get_or_undefined(0);
 
@@ -525,7 +526,7 @@ impl Iterator {
         )?;
 
         // 3. Let iterated be the Iterator Record { [[Iterator]]: O, [[NextMethod]]: undefined, [[Done]]: false }.
-        let iterated = IteratorRecord::new(o, JsValue::undefined());
+        let iterated = IteratorRecord::new(o, JsValue::undefined(), context.gc_collector());
 
         // 4. If IsCallable(reducer) is false, then
         let Some(reducer) = args.get_or_undefined(0).as_callable() else {
@@ -620,7 +621,7 @@ impl Iterator {
         )?;
 
         // 3. Let iterated be the Iterator Record { [[Iterator]]: O, [[NextMethod]]: undefined, [[Done]]: false }.
-        let iterated = IteratorRecord::new(o, JsValue::undefined());
+        let iterated = IteratorRecord::new(o, JsValue::undefined(), context.gc_collector());
 
         // 4. If IsCallable(fn) is false, then
         let Some(func) = args.get_or_undefined(0).as_callable() else {
@@ -676,7 +677,7 @@ impl Iterator {
             .ok_or_else(|| js_error!(TypeError: "Iterator.prototype.some called on non-object"))?;
 
         // 3. Let iterated be the Iterator Record { [[Iterator]]: O, [[NextMethod]]: undefined, [[Done]]: false }.
-        let iterated = IteratorRecord::new(o, JsValue::undefined());
+        let iterated = IteratorRecord::new(o, JsValue::undefined(), context.gc_collector());
 
         // 4. If IsCallable(predicate) is false, then
         let Some(predicate) = args.get_or_undefined(0).as_callable() else {
@@ -735,7 +736,7 @@ impl Iterator {
             .ok_or_else(|| js_error!(TypeError: "Iterator.prototype.every called on non-object"))?;
 
         // 3. Let iterated be the Iterator Record { [[Iterator]]: O, [[NextMethod]]: undefined, [[Done]]: false }.
-        let iterated = IteratorRecord::new(o, JsValue::undefined());
+        let iterated = IteratorRecord::new(o, JsValue::undefined(), context.gc_collector());
 
         // 4. If IsCallable(predicate) is false, then
         let Some(predicate) = args.get_or_undefined(0).as_callable() else {
@@ -795,7 +796,7 @@ impl Iterator {
             .ok_or_else(|| js_error!(TypeError: "Iterator.prototype.find called on non-object"))?;
 
         // 3. Let iterated be the Iterator Record { [[Iterator]]: O, [[NextMethod]]: undefined, [[Done]]: false }.
-        let iterated = IteratorRecord::new(o, JsValue::undefined());
+        let iterated = IteratorRecord::new(o, JsValue::undefined(), context.gc_collector());
 
         // 4. If IsCallable(predicate) is false, then
         let Some(predicate) = args.get_or_undefined(0).as_callable() else {

--- a/core/engine/src/builtins/iterable/mod.rs
+++ b/core/engine/src/builtins/iterable/mod.rs
@@ -99,18 +99,18 @@ impl Default for IteratorPrototypes {
 impl IteratorPrototypes {
     pub(crate) fn uninit_in(mc: &boa_gc::MutationContext<'static, '_>) -> Self {
         Self {
-            iterator: JsObject::with_null_proto_in(mc),
-            async_iterator: JsObject::with_null_proto_in(mc),
-            async_from_sync_iterator: JsObject::with_null_proto_in(mc),
-            array: JsObject::with_null_proto_in(mc),
-            set: JsObject::with_null_proto_in(mc),
-            string: JsObject::with_null_proto_in(mc),
-            regexp_string: JsObject::with_null_proto_in(mc),
-            map: JsObject::with_null_proto_in(mc),
+            iterator: JsObject::with_null_proto(mc),
+            async_iterator: JsObject::with_null_proto(mc),
+            async_from_sync_iterator: JsObject::with_null_proto(mc),
+            array: JsObject::with_null_proto(mc),
+            set: JsObject::with_null_proto(mc),
+            string: JsObject::with_null_proto(mc),
+            regexp_string: JsObject::with_null_proto(mc),
+            map: JsObject::with_null_proto(mc),
             #[cfg(feature = "intl")]
-            segment: JsObject::with_null_proto_in(mc),
-            iterator_helper: JsObject::with_null_proto_in(mc),
-            wrap_for_valid_iterator: JsObject::with_null_proto_in(mc),
+            segment: JsObject::with_null_proto(mc),
+            iterator_helper: JsObject::with_null_proto(mc),
+            wrap_for_valid_iterator: JsObject::with_null_proto(mc),
         }
     }
     /// Returns the `ArrayIteratorPrototype` object.
@@ -194,8 +194,8 @@ impl IteratorPrototypes {
 pub(crate) struct AsyncIterator;
 
 impl IntrinsicObject for AsyncIterator {
-    fn init(realm: &Realm) {
-        BuiltInBuilder::with_intrinsic::<Self>(realm)
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
+        BuiltInBuilder::with_intrinsic::<Self>(realm, mc)
             .static_method(|v, _, _| Ok(v.clone()), JsSymbol::async_iterator(), 0)
             .build();
     }
@@ -213,11 +213,11 @@ pub fn create_iter_result_object(value: JsValue, done: bool, context: &mut Conte
     // 2. Let obj be ! OrdinaryObjectCreate(%Object.prototype%).
     // 3. Perform ! CreateDataPropertyOrThrow(obj, "value", value).
     // 4. Perform ! CreateDataPropertyOrThrow(obj, "done", done).
-    let obj = context
-        .intrinsics()
-        .templates()
-        .iterator_result()
-        .create(OrdinaryObject, vec![value, done.into()]);
+    let obj = context.intrinsics().templates().iterator_result().create(
+        context.gc_collector(),
+        OrdinaryObject,
+        vec![value, done.into()],
+    );
 
     // 5. Return obj.
     obj.into()
@@ -255,7 +255,11 @@ impl JsValue {
         let next_method = iterator_obj.get(js_string!("next"), context)?;
         // 4. Let iteratorRecord be the Iterator Record { [[Iterator]]: iterator, [[NextMethod]]: nextMethod, [[Done]]: false }.
         // 5. Return iteratorRecord.
-        Ok(IteratorRecord::new(iterator_obj.clone(), next_method))
+        Ok(IteratorRecord::new(
+            iterator_obj.clone(),
+            next_method,
+            context.gc_collector(),
+        ))
     }
 
     /// `GetIterator ( obj, kind )`
@@ -404,13 +408,17 @@ impl IteratorRecord {
     /// Creates a new `IteratorRecord` with the given iterator object, next method and `done` flag.
     #[inline]
     #[must_use]
-    pub fn new(iterator: JsObject, next_method: JsValue) -> Self {
+    pub fn new(
+        iterator: JsObject,
+        next_method: JsValue,
+        mc: &boa_gc::MutationContext<'static, '_>,
+    ) -> Self {
         Self {
             iterator,
             next_method,
             done: false,
             last_result: IteratorResult {
-                object: JsObject::with_null_proto(),
+                object: JsObject::with_null_proto(mc),
             },
         }
     }
@@ -698,7 +706,11 @@ pub(crate) fn get_iterator_direct(
     let next_method = obj.get(js_string!("next"), context)?;
     // 2. Let iteratorRecord be the Iterator Record { [[Iterator]]: obj, [[NextMethod]]: nextMethod, [[Done]]: false }.
     // 3. Return iteratorRecord.
-    Ok(IteratorRecord::new(obj.clone(), next_method))
+    Ok(IteratorRecord::new(
+        obj.clone(),
+        next_method,
+        context.gc_collector(),
+    ))
 }
 
 /// `GetIteratorFlattenable ( obj, stringHandling )`

--- a/core/engine/src/builtins/iterable/wrap_for_valid_iterator.rs
+++ b/core/engine/src/builtins/iterable/wrap_for_valid_iterator.rs
@@ -34,8 +34,8 @@ pub(crate) struct WrapForValidIterator {
 }
 
 impl IntrinsicObject for WrapForValidIterator {
-    fn init(realm: &Realm) {
-        BuiltInBuilder::with_intrinsic::<Self>(realm)
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
+        BuiltInBuilder::with_intrinsic::<Self>(realm, mc)
             .prototype(realm.intrinsics().constructors().iterator().prototype())
             .static_method(Self::next, js_string!("next"), 0)
             .static_method(Self::r#return, js_string!("return"), 0)

--- a/core/engine/src/builtins/json/mod.rs
+++ b/core/engine/src/builtins/json/mod.rs
@@ -200,11 +200,11 @@ impl<'ast> boa_ast::visitor::Visitor<'ast> for JsonSourceVisitor<'_> {
 pub(crate) struct Json;
 
 impl IntrinsicObject for Json {
-    fn init(realm: &Realm) {
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
         let to_string_tag = JsSymbol::to_string_tag();
         let attribute = Attribute::READONLY | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE;
 
-        BuiltInBuilder::with_intrinsic::<Self>(realm)
+        BuiltInBuilder::with_intrinsic::<Self>(realm, mc)
             .static_method(Self::parse, js_string!("parse"), 2)
             .static_method(Self::stringify, js_string!("stringify"), 3)
             .static_method(Self::raw_json, js_string!("rawJSON"), 1)
@@ -338,7 +338,7 @@ impl Json {
         // 11. If IsCallable(reviver) is true, then
         if let Some(obj) = args.get_or_undefined(1).as_callable() {
             // a. Let root be ! OrdinaryObjectCreate(%Object.prototype%).
-            let root = JsObject::with_object_proto(context.intrinsics());
+            let root = JsObject::with_object_proto(context.gc_collector(), context.intrinsics());
 
             // b. Let rootName be the empty String.
             // c. Perform ! CreateDataPropertyOrThrow(root, rootName, unfiltered).
@@ -467,7 +467,7 @@ impl Json {
         // For objects/arrays or modified values: context = {} (no source property)
         // Per spec, source is only provided when the value is still the same
         // primitive that was produced by parsing the original JSON text.
-        let ctx_obj = JsObject::with_object_proto(context.intrinsics());
+        let ctx_obj = JsObject::with_object_proto(context.gc_collector(), context.intrinsics());
         if let Some(JsonNode::Primitive(source_text)) = source_node {
             // Check if the current value matches what the source text produces.
             // If the reviver modified the value, it won't match and we skip source.
@@ -571,7 +571,7 @@ impl Json {
 
         // 3. Let internalSlotsList be « [[IsRawJSON]] ».
         // 4. Let obj be OrdinaryObjectCreate(null, internalSlotsList).
-        let obj = JsObject::from_proto_and_data(None::<JsObject>, RawJson);
+        let obj = JsObject::from_proto_and_data(context.gc_collector(), None::<JsObject>, RawJson);
 
         // 5. Perform ! CreateDataPropertyOrThrow(obj, "rawJSON", jsonString).
         obj.create_data_property_or_throw(js_string!("rawJSON"), json_string, context)
@@ -738,7 +738,7 @@ impl Json {
         };
 
         // 9. Let wrapper be ! OrdinaryObjectCreate(%Object.prototype%).
-        let wrapper = JsObject::with_object_proto(context.intrinsics());
+        let wrapper = JsObject::with_object_proto(context.gc_collector(), context.intrinsics());
 
         // 10. Perform ! CreateDataPropertyOrThrow(wrapper, the empty String, value).
         wrapper

--- a/core/engine/src/builtins/json/mod.rs
+++ b/core/engine/src/builtins/json/mod.rs
@@ -303,8 +303,8 @@ impl Json {
                 false,
                 false,
                 context.interner_mut(),
-                &gc,
-                false,
+                gc,
+                in_with,
                 spanned_source_text,
                 SourcePath::Json,
             );

--- a/core/engine/src/builtins/map/map_iterator.rs
+++ b/core/engine/src/builtins/map/map_iterator.rs
@@ -52,8 +52,8 @@ pub(crate) struct MapIterator {
 }
 
 impl IntrinsicObject for MapIterator {
-    fn init(realm: &Realm) {
-        BuiltInBuilder::with_intrinsic::<Self>(realm)
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
+        BuiltInBuilder::with_intrinsic::<Self>(realm, mc)
             .prototype(realm.intrinsics().constructors().iterator().prototype())
             .static_method(Self::next, js_string!("next"), 0)
             .static_property(
@@ -89,6 +89,7 @@ impl MapIterator {
             iteration_kind: kind,
         };
         let map_iterator = JsObject::from_proto_and_data_with_shared_shape(
+            context.gc_collector(),
             context.root_shape(),
             context.intrinsics().objects().iterator_prototypes().map(),
             iter,

--- a/core/engine/src/builtins/map/mod.rs
+++ b/core/engine/src/builtins/map/mod.rs
@@ -41,20 +41,20 @@ mod tests;
 pub(crate) struct Map;
 
 impl IntrinsicObject for Map {
-    fn init(realm: &Realm) {
-        let get_species = BuiltInBuilder::callable(realm, Self::get_species)
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
+        let get_species = BuiltInBuilder::callable(realm, Self::get_species, mc)
             .name(js_string!("get [Symbol.species]"))
             .build();
 
-        let get_size = BuiltInBuilder::callable(realm, Self::get_size)
+        let get_size = BuiltInBuilder::callable(realm, Self::get_size, mc)
             .name(js_string!("get size"))
             .build();
 
-        let entries_function = BuiltInBuilder::callable(realm, Self::entries)
+        let entries_function = BuiltInBuilder::callable(realm, Self::entries, mc)
             .name(js_string!("entries"))
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, mc)
             .static_method(Self::group_by, js_string!("groupBy"), 2)
             .static_accessor(
                 JsSymbol::species(),
@@ -144,6 +144,7 @@ impl BuiltInConstructor for Map {
         let prototype =
             get_prototype_from_constructor(new_target, StandardConstructors::map, context)?;
         let map = JsObject::from_proto_and_data_with_shared_shape(
+            context.gc_collector(),
             context.root_shape(),
             prototype,
             <OrderedMap<JsValue>>::new(),
@@ -797,10 +798,13 @@ impl Map {
         let proto = context.intrinsics().constructors().map().prototype();
 
         // 4. Return map.
-        Ok(
-            JsObject::from_proto_and_data_with_shared_shape(context.root_shape(), proto, map)
-                .into(),
+        Ok(JsObject::from_proto_and_data_with_shared_shape(
+            context.gc_collector(),
+            context.root_shape(),
+            proto,
+            map,
         )
+        .into())
     }
 }
 

--- a/core/engine/src/builtins/math/mod.rs
+++ b/core/engine/src/builtins/math/mod.rs
@@ -27,9 +27,9 @@ mod tests;
 pub(crate) struct Math;
 
 impl IntrinsicObject for Math {
-    fn init(realm: &Realm) {
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
         let attribute = Attribute::READONLY | Attribute::NON_ENUMERABLE | Attribute::PERMANENT;
-        let builder = BuiltInBuilder::with_intrinsic::<Self>(realm)
+        let builder = BuiltInBuilder::with_intrinsic::<Self>(realm, mc)
             .static_property(js_string!("E"), std::f64::consts::E, attribute)
             .static_property(js_string!("LN10"), std::f64::consts::LN_10, attribute)
             .static_property(js_string!("LN2"), std::f64::consts::LN_2, attribute)

--- a/core/engine/src/builtins/mod.rs
+++ b/core/engine/src/builtins/mod.rs
@@ -130,7 +130,7 @@ pub(crate) trait IntrinsicObject {
     ///
     /// This is where the methods, properties, static methods and the constructor of a built-in must
     /// be initialized to be accessible from ECMAScript.
-    fn init(realm: &Realm);
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>);
 
     /// Gets the intrinsic object.
     fn get(intrinsics: &Intrinsics) -> JsObject;
@@ -242,113 +242,113 @@ impl Realm {
     /// Abstract operation [`CreateIntrinsics ( realmRec )`][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-createintrinsics
-    pub(crate) fn initialize(&self) {
-        BuiltInFunctionObject::init(self);
-        OrdinaryObject::init(self);
-        Iterator::init(self);
-        AsyncIterator::init(self);
-        AsyncFromSyncIterator::init(self);
-        IteratorConstructor::init(self);
-        WrapForValidIterator::init(self);
-        IteratorHelper::init(self);
-        Math::init(self);
-        Json::init(self);
-        Array::init(self);
-        ArrayIterator::init(self);
-        Proxy::init(self);
-        ArrayBuffer::init(self);
-        SharedArrayBuffer::init(self);
-        BigInt::init(self);
-        Boolean::init(self);
-        Date::init(self);
-        DataView::init(self);
-        Map::init(self);
-        MapIterator::init(self);
-        IsFinite::init(self);
-        IsNaN::init(self);
-        ParseInt::init(self);
-        ParseFloat::init(self);
-        Number::init(self);
-        Eval::init(self);
-        Set::init(self);
-        SetIterator::init(self);
-        String::init(self);
-        StringIterator::init(self);
-        RegExp::init(self);
-        RegExpStringIterator::init(self);
-        BuiltinTypedArray::init(self);
-        Int8Array::init(self);
-        Uint8Array::init(self);
-        Uint8ClampedArray::init(self);
-        Int16Array::init(self);
-        Uint16Array::init(self);
-        Int32Array::init(self);
-        Uint32Array::init(self);
-        BigInt64Array::init(self);
-        BigUint64Array::init(self);
+    pub(crate) fn initialize(&self, mc: &boa_gc::MutationContext<'static, '_>) {
+        BuiltInFunctionObject::init(self, mc);
+        OrdinaryObject::init(self, mc);
+        Iterator::init(self, mc);
+        AsyncIterator::init(self, mc);
+        AsyncFromSyncIterator::init(self, mc);
+        IteratorConstructor::init(self, mc);
+        WrapForValidIterator::init(self, mc);
+        IteratorHelper::init(self, mc);
+        Math::init(self, mc);
+        Json::init(self, mc);
+        Array::init(self, mc);
+        ArrayIterator::init(self, mc);
+        Proxy::init(self, mc);
+        ArrayBuffer::init(self, mc);
+        SharedArrayBuffer::init(self, mc);
+        BigInt::init(self, mc);
+        Boolean::init(self, mc);
+        Date::init(self, mc);
+        DataView::init(self, mc);
+        Map::init(self, mc);
+        MapIterator::init(self, mc);
+        IsFinite::init(self, mc);
+        IsNaN::init(self, mc);
+        ParseInt::init(self, mc);
+        ParseFloat::init(self, mc);
+        Number::init(self, mc);
+        Eval::init(self, mc);
+        Set::init(self, mc);
+        SetIterator::init(self, mc);
+        String::init(self, mc);
+        StringIterator::init(self, mc);
+        RegExp::init(self, mc);
+        RegExpStringIterator::init(self, mc);
+        BuiltinTypedArray::init(self, mc);
+        Int8Array::init(self, mc);
+        Uint8Array::init(self, mc);
+        Uint8ClampedArray::init(self, mc);
+        Int16Array::init(self, mc);
+        Uint16Array::init(self, mc);
+        Int32Array::init(self, mc);
+        Uint32Array::init(self, mc);
+        BigInt64Array::init(self, mc);
+        BigUint64Array::init(self, mc);
         #[cfg(feature = "float16")]
-        typed_array::Float16Array::init(self);
-        Float32Array::init(self);
-        Float64Array::init(self);
-        Symbol::init(self);
-        Error::init(self);
-        RangeError::init(self);
-        ReferenceError::init(self);
-        TypeError::init(self);
-        ThrowTypeError::init(self);
-        SyntaxError::init(self);
-        EvalError::init(self);
-        UriError::init(self);
-        AggregateError::init(self);
-        Reflect::init(self);
-        Generator::init(self);
-        GeneratorFunction::init(self);
-        Promise::init(self);
-        AsyncFunction::init(self);
-        AsyncGenerator::init(self);
-        AsyncGeneratorFunction::init(self);
-        EncodeUri::init(self);
-        EncodeUriComponent::init(self);
-        DecodeUri::init(self);
-        DecodeUriComponent::init(self);
-        WeakRef::init(self);
-        WeakMap::init(self);
-        WeakSet::init(self);
-        Atomics::init(self);
-        FinalizationRegistry::init(self);
+        typed_array::Float16Array::init(self, mc);
+        Float32Array::init(self, mc);
+        Float64Array::init(self, mc);
+        Symbol::init(self, mc);
+        Error::init(self, mc);
+        RangeError::init(self, mc);
+        ReferenceError::init(self, mc);
+        TypeError::init(self, mc);
+        ThrowTypeError::init(self, mc);
+        SyntaxError::init(self, mc);
+        EvalError::init(self, mc);
+        UriError::init(self, mc);
+        AggregateError::init(self, mc);
+        Reflect::init(self, mc);
+        Generator::init(self, mc);
+        GeneratorFunction::init(self, mc);
+        Promise::init(self, mc);
+        AsyncFunction::init(self, mc);
+        AsyncGenerator::init(self, mc);
+        AsyncGeneratorFunction::init(self, mc);
+        EncodeUri::init(self, mc);
+        EncodeUriComponent::init(self, mc);
+        DecodeUri::init(self, mc);
+        DecodeUriComponent::init(self, mc);
+        WeakRef::init(self, mc);
+        WeakMap::init(self, mc);
+        WeakSet::init(self, mc);
+        Atomics::init(self, mc);
+        FinalizationRegistry::init(self, mc);
 
         #[cfg(feature = "annex-b")]
         {
-            escape::Escape::init(self);
-            escape::Unescape::init(self);
+            escape::Escape::init(self, mc);
+            escape::Unescape::init(self, mc);
         }
 
         #[cfg(feature = "intl")]
         {
-            intl::Intl::init(self);
-            intl::Collator::init(self);
-            intl::ListFormat::init(self);
-            intl::Locale::init(self);
-            intl::DateTimeFormat::init(self);
-            intl::Segmenter::init(self);
-            intl::segmenter::Segments::init(self);
-            intl::segmenter::SegmentIterator::init(self);
-            intl::PluralRules::init(self);
-            intl::NumberFormat::init(self);
+            intl::Intl::init(self, mc);
+            intl::Collator::init(self, mc);
+            intl::ListFormat::init(self, mc);
+            intl::Locale::init(self, mc);
+            intl::DateTimeFormat::init(self, mc);
+            intl::Segmenter::init(self, mc);
+            intl::segmenter::Segments::init(self, mc);
+            intl::segmenter::SegmentIterator::init(self, mc);
+            intl::PluralRules::init(self, mc);
+            intl::NumberFormat::init(self, mc);
         }
 
         #[cfg(feature = "temporal")]
         {
-            temporal::Temporal::init(self);
-            temporal::Now::init(self);
-            temporal::Instant::init(self);
-            temporal::Duration::init(self);
-            temporal::PlainDate::init(self);
-            temporal::PlainTime::init(self);
-            temporal::PlainDateTime::init(self);
-            temporal::PlainMonthDay::init(self);
-            temporal::PlainYearMonth::init(self);
-            temporal::ZonedDateTime::init(self);
+            temporal::Temporal::init(self, mc);
+            temporal::Now::init(self, mc);
+            temporal::Instant::init(self, mc);
+            temporal::Duration::init(self, mc);
+            temporal::PlainDate::init(self, mc);
+            temporal::PlainTime::init(self, mc);
+            temporal::PlainDateTime::init(self, mc);
+            temporal::PlainMonthDay::init(self, mc);
+            temporal::PlainYearMonth::init(self, mc);
+            temporal::ZonedDateTime::init(self, mc);
         }
     }
 }

--- a/core/engine/src/builtins/number/globals.rs
+++ b/core/engine/src/builtins/number/globals.rs
@@ -36,8 +36,8 @@ fn is_finite(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<J
 pub(crate) struct IsFinite;
 
 impl IntrinsicObject for IsFinite {
-    fn init(realm: &Realm) {
-        BuiltInBuilder::callable_with_intrinsic::<Self>(realm, is_finite)
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
+        BuiltInBuilder::callable_with_intrinsic::<Self>(realm, is_finite, mc)
             .name(Self::NAME)
             .length(1)
             .build();
@@ -78,8 +78,8 @@ pub(crate) fn is_nan(_: &JsValue, args: &[JsValue], context: &mut Context) -> Js
 pub(crate) struct IsNaN;
 
 impl IntrinsicObject for IsNaN {
-    fn init(realm: &Realm) {
-        BuiltInBuilder::callable_with_intrinsic::<Self>(realm, is_nan)
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
+        BuiltInBuilder::callable_with_intrinsic::<Self>(realm, is_nan, mc)
             .name(Self::NAME)
             .length(1)
             .build();
@@ -267,8 +267,8 @@ pub(crate) fn parse_int(_: &JsValue, args: &[JsValue], context: &mut Context) ->
 pub(crate) struct ParseInt;
 
 impl IntrinsicObject for ParseInt {
-    fn init(realm: &Realm) {
-        BuiltInBuilder::callable_with_intrinsic::<Self>(realm, parse_int)
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
+        BuiltInBuilder::callable_with_intrinsic::<Self>(realm, parse_int, mc)
             .name(Self::NAME)
             .length(2)
             .build();
@@ -383,8 +383,8 @@ pub(crate) fn parse_float(
 pub(crate) struct ParseFloat;
 
 impl IntrinsicObject for ParseFloat {
-    fn init(realm: &Realm) {
-        BuiltInBuilder::callable_with_intrinsic::<Self>(realm, parse_float)
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
+        BuiltInBuilder::callable_with_intrinsic::<Self>(realm, parse_float, mc)
             .name(Self::NAME)
             .length(1)
             .build();

--- a/core/engine/src/builtins/number/mod.rs
+++ b/core/engine/src/builtins/number/mod.rs
@@ -47,10 +47,10 @@ const BUF_SIZE: usize = 2200;
 pub(crate) struct Number;
 
 impl IntrinsicObject for Number {
-    fn init(realm: &Realm) {
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
         let attribute = Attribute::READONLY | Attribute::NON_ENUMERABLE | Attribute::PERMANENT;
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, mc)
             .static_property(js_string!("EPSILON"), f64::EPSILON, attribute)
             .static_property(
                 js_string!("MAX_SAFE_INTEGER"),
@@ -126,8 +126,12 @@ impl BuiltInConstructor for Number {
         }
         let prototype =
             get_prototype_from_constructor(new_target, StandardConstructors::number, context)?;
-        let this =
-            JsObject::from_proto_and_data_with_shared_shape(context.root_shape(), prototype, data);
+        let this = JsObject::from_proto_and_data_with_shared_shape(
+            context.gc_collector(),
+            context.root_shape(),
+            prototype,
+            data,
+        );
         Ok(this.into())
     }
 }

--- a/core/engine/src/builtins/object/for_in_iterator.rs
+++ b/core/engine/src/builtins/object/for_in_iterator.rs
@@ -58,17 +58,21 @@ impl ForInIterator {
         context: &Context,
     ) -> (JsObject, JsValue) {
         let iterator = JsObject::from_proto_and_data_with_shared_shape(
+            context.gc_collector(),
             context.root_shape(),
             context.intrinsics().constructors().iterator().prototype(),
             Self::new(object),
         )
         .upcast();
 
-        let next_method =
-            FunctionObjectBuilder::new(context.realm(), NativeFunction::from_fn_ptr(Self::next))
-                .name(js_string!("next"))
-                .length(0)
-                .build();
+        let next_method = FunctionObjectBuilder::new(
+            context.realm(),
+            context.gc_collector(),
+            NativeFunction::from_fn_ptr(Self::next),
+        )
+        .name(js_string!("next"))
+        .length(0)
+        .build();
 
         (iterator, next_method.into())
     }

--- a/core/engine/src/builtins/object/mod.rs
+++ b/core/engine/src/builtins/object/mod.rs
@@ -48,17 +48,17 @@ mod tests;
 pub struct OrdinaryObject;
 
 impl IntrinsicObject for OrdinaryObject {
-    fn init(realm: &Realm) {
-        let legacy_proto_getter = BuiltInBuilder::callable(realm, Self::legacy_proto_getter)
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
+        let legacy_proto_getter = BuiltInBuilder::callable(realm, Self::legacy_proto_getter, mc)
             .name(js_string!("get __proto__"))
             .build();
 
-        let legacy_setter_proto = BuiltInBuilder::callable(realm, Self::legacy_proto_setter)
+        let legacy_setter_proto = BuiltInBuilder::callable(realm, Self::legacy_proto_setter, mc)
             .name(js_string!("set __proto__"))
             .length(1)
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, mc)
             .inherits(None)
             .accessor(
                 js_string!("__proto__"),
@@ -172,6 +172,7 @@ impl BuiltInConstructor for OrdinaryObject {
             let prototype =
                 get_prototype_from_constructor(new_target, StandardConstructors::object, context)?;
             let object = JsObject::from_proto_and_data_with_shared_shape(
+                context.gc_collector(),
                 context.root_shape(),
                 prototype,
                 OrdinaryObject,
@@ -183,7 +184,7 @@ impl BuiltInConstructor for OrdinaryObject {
 
         // 2. If value is undefined or null, return OrdinaryObjectCreate(%Object.prototype%).
         if value.is_null_or_undefined() {
-            Ok(JsObject::with_object_proto(context.intrinsics()).into())
+            Ok(JsObject::with_object_proto(context.gc_collector(), context.intrinsics()).into())
         } else {
             // 3. Return ! ToObject(value).
             value.to_object(context).map(JsValue::from)
@@ -440,7 +441,7 @@ impl OrdinaryObject {
         }
     }
 
-    /// `Object.create( proto, [propertiesObject] )`
+    /// `Object.create( context.gc_collector(), proto, [propertiesObject] )`
     ///
     /// Creates a new object from the provided prototype.
     ///
@@ -457,6 +458,7 @@ impl OrdinaryObject {
         let obj = match prototype.variant() {
             JsVariant::Object(_) | JsVariant::Null => {
                 JsObject::from_proto_and_data_with_shared_shape(
+                    context.gc_collector(),
                     context.root_shape(),
                     prototype.as_object(),
                     OrdinaryObject,
@@ -532,7 +534,7 @@ impl OrdinaryObject {
             obj.__own_property_keys__(&mut InternalMethodPropertyContext::new(context))?;
 
         // 3. Let descriptors be OrdinaryObjectCreate(%Object.prototype%).
-        let descriptors = JsObject::with_object_proto(context.intrinsics());
+        let descriptors = JsObject::with_object_proto(context.gc_collector(), context.intrinsics());
 
         // 4. For each element key of ownKeys, do
         for key in own_keys {
@@ -573,7 +575,7 @@ impl OrdinaryObject {
 
         // 2. Let obj be ! OrdinaryObjectCreate(%Object.prototype%).
         // 3. Assert: obj is an extensible ordinary object with no own properties.
-        let obj = JsObject::with_object_proto(context.intrinsics());
+        let obj = JsObject::with_object_proto(context.gc_collector(), context.intrinsics());
 
         // 4. If Desc has a [[Value]] field, then
         if let Some(value) = desc.value() {
@@ -1299,12 +1301,13 @@ impl OrdinaryObject {
 
         // 2. Let obj be ! OrdinaryObjectCreate(%Object.prototype%).
         // 3. Assert: obj is an extensible ordinary object with no own properties.
-        let obj = JsObject::with_object_proto(context.intrinsics());
+        let obj = JsObject::with_object_proto(context.gc_collector(), context.intrinsics());
 
         // 4. Let closure be a new Abstract Closure with parameters (key, value) that captures
         // obj and performs the following steps when called:
         let closure = FunctionObjectBuilder::new(
             context.realm(),
+            context.gc_collector(),
             NativeFunction::from_copy_closure_with_captures(
                 |_, args, obj, context| {
                     let key = args.get_or_undefined(0);
@@ -1413,7 +1416,7 @@ impl OrdinaryObject {
         }
 
         // 2. Let obj be OrdinaryObjectCreate(null).
-        let obj = JsObject::with_null_proto();
+        let obj = JsObject::with_null_proto(context.gc_collector());
 
         // 3. For each Record { [[Key]], [[Elements]] } g of groups, do
         for (key, elements) in groups {

--- a/core/engine/src/builtins/options.rs
+++ b/core/engine/src/builtins/options.rs
@@ -74,12 +74,15 @@ pub(crate) fn get_option<T: OptionType>(
 /// default empty `JsObject`. It throws a `TypeError` if `options` is not undefined and not a `JsObject`.
 ///
 /// [spec]: https://tc39.es/ecma402/#sec-getoptionsobject
-pub(crate) fn get_options_object(options: &JsValue) -> JsResult<JsObject> {
+pub(crate) fn get_options_object(
+    options: &JsValue,
+    mc: &boa_gc::MutationContext<'static, '_>,
+) -> JsResult<JsObject> {
     match options.variant() {
         // If options is undefined, then
         JsVariant::Undefined => {
             // a. Return OrdinaryObjectCreate(null).
-            Ok(JsObject::with_null_proto())
+            Ok(JsObject::with_null_proto(mc))
         }
         // 2. If Type(options) is Object, then
         JsVariant::Object(obj) => {

--- a/core/engine/src/builtins/promise/mod.rs
+++ b/core/engine/src/builtins/promise/mod.rs
@@ -252,6 +252,7 @@ impl PromiseCapability {
         // 5. Let executor be CreateBuiltinFunction(executorClosure, 2, "", « »).
         let executor = FunctionObjectBuilder::new(
             context.realm(),
+            context.gc_collector(),
             NativeFunction::from_copy_closure_with_captures(
                 |_this, args: &[JsValue], captures, _| {
                     let mut promise_capability = captures.borrow_mut();
@@ -338,12 +339,12 @@ impl PromiseCapability {
 }
 
 impl IntrinsicObject for Promise {
-    fn init(realm: &Realm) {
-        let get_species = BuiltInBuilder::callable(realm, Self::get_species)
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
+        let get_species = BuiltInBuilder::callable(realm, Self::get_species, mc)
             .name(js_string!("get [Symbol.species]"))
             .build();
 
-        let builder = BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        let builder = BuiltInBuilder::from_standard_constructor::<Self>(realm, mc)
             .static_method(Self::all, js_string!("all"), 1)
             .static_method(Self::all_settled, js_string!("allSettled"), 1)
             .static_method(Self::any, js_string!("any"), 1)
@@ -422,6 +423,7 @@ impl BuiltInConstructor for Promise {
             get_prototype_from_constructor(new_target, StandardConstructors::promise, context)?;
 
         let promise = JsObject::from_proto_and_data_with_shared_shape(
+            context.gc_collector(),
             context.root_shape(),
             promise,
             // 4. Set promise.[[PromiseState]] to pending.
@@ -556,6 +558,7 @@ impl Promise {
         // 5. Perform ! CreateDataPropertyOrThrow(obj, "resolve", promiseCapability.[[Resolve]]).
         // 6. Perform ! CreateDataPropertyOrThrow(obj, "reject", promiseCapability.[[Reject]]).
         let obj = context.intrinsics().templates().with_resolvers().create(
+            context.gc_collector(),
             OrdinaryObject,
             vec![promise.into(), resolve.into(), reject.into()],
         );
@@ -680,6 +683,7 @@ impl Promise {
             // l. Set onFulfilled.[[RemainingElements]] to remainingElementsCount.
             let on_fulfilled = FunctionObjectBuilder::new(
                 context.realm(),
+                context.gc_collector(),
                 NativeFunction::from_copy_closure_with_captures(
                     |_, args, captures, context| {
                         // https://tc39.es/ecma262/#sec-promise.all-resolve-element-functions
@@ -898,6 +902,7 @@ impl Promise {
             // m. Set onFulfilled.[[RemainingElements]] to remainingElementsCount.
             let on_fulfilled = FunctionObjectBuilder::new(
                 context.realm(),
+                context.gc_collector(),
                 NativeFunction::from_copy_closure_with_captures(
                     |_, args, captures, context| {
                         // https://tc39.es/ecma262/#sec-promise.allsettled-resolve-element-functions
@@ -919,7 +924,10 @@ impl Promise {
                         // 8. Let remainingElementsCount be F.[[RemainingElements]].
 
                         // 9. Let obj be OrdinaryObjectCreate(%Object.prototype%).
-                        let obj = JsObject::with_object_proto(context.intrinsics());
+                        let obj = JsObject::with_object_proto(
+                            context.gc_collector(),
+                            context.intrinsics(),
+                        );
 
                         // 10. Perform ! CreateDataPropertyOrThrow(obj, "status", "fulfilled").
                         obj.create_data_property_or_throw(
@@ -988,6 +996,7 @@ impl Promise {
             // u. Set onRejected.[[RemainingElements]] to remainingElementsCount.
             let on_rejected = FunctionObjectBuilder::new(
                 context.realm(),
+                context.gc_collector(),
                 NativeFunction::from_copy_closure_with_captures(
                     |_, args, captures, context| {
                         // https://tc39.es/ecma262/#sec-promise.allsettled-reject-element-functions
@@ -1009,7 +1018,10 @@ impl Promise {
                         // 8. Let remainingElementsCount be F.[[RemainingElements]].
 
                         // 9. Let obj be OrdinaryObjectCreate(%Object.prototype%).
-                        let obj = JsObject::with_object_proto(context.intrinsics());
+                        let obj = JsObject::with_object_proto(
+                            context.gc_collector(),
+                            context.intrinsics(),
+                        );
 
                         // 10. Perform ! CreateDataPropertyOrThrow(obj, "status", "rejected").
                         obj.create_data_property_or_throw(
@@ -1272,6 +1284,7 @@ impl Promise {
                 // vi. Let onFulfilled be a new Abstract Closure...
                 let on_fulfilled = FunctionObjectBuilder::new(
                     context.realm(),
+                    context.gc_collector(),
                     NativeFunction::from_copy_closure_with_captures(
                         |_, args, captures, context| {
                             // 1. If alreadyCalled.[[Value]] is true, return undefined.
@@ -1291,7 +1304,10 @@ impl Promise {
                             } else {
                                 // 4. Else (variant is all-settled)
                                 // a. Let obj be OrdinaryObjectCreate(%Object.prototype%).
-                                let obj = JsObject::with_object_proto(context.intrinsics());
+                                let obj = JsObject::with_object_proto(
+                                    context.gc_collector(),
+                                    context.intrinsics(),
+                                );
                                 // b. Perform ! CreateDataPropertyOrThrow(obj, "status", "fulfilled").
                                 obj.create_data_property_or_throw(
                                     js_string!("status"),
@@ -1354,6 +1370,7 @@ impl Promise {
                     // Else (variant is all-settled), let onRejected be a new Abstract Closure...
                     let on_rejected_fn = FunctionObjectBuilder::new(
                         context.realm(),
+                        context.gc_collector(),
                         NativeFunction::from_copy_closure_with_captures(
                             |_, args, captures, context| {
                                 // 1. If alreadyCalled.[[Value]] is true, return undefined.
@@ -1367,7 +1384,10 @@ impl Promise {
                                 let x = args.get_or_undefined(0).clone();
 
                                 // 3. Let obj be OrdinaryObjectCreate(%Object.prototype%).
-                                let obj = JsObject::with_object_proto(context.intrinsics());
+                                let obj = JsObject::with_object_proto(
+                                    context.gc_collector(),
+                                    context.intrinsics(),
+                                );
                                 // 4. Perform ! CreateDataPropertyOrThrow(obj, "status", "rejected").
                                 obj.create_data_property_or_throw(
                                     js_string!("status"),
@@ -1573,6 +1593,7 @@ impl Promise {
             // l. Set onRejected.[[RemainingElements]] to remainingElementsCount.
             let on_rejected = FunctionObjectBuilder::new(
                 context.realm(),
+                context.gc_collector(),
                 NativeFunction::from_copy_closure_with_captures(
                     |_, args, captures, context| {
                         // https://tc39.es/ecma262/#sec-promise.any-reject-element-functions
@@ -2006,6 +2027,7 @@ impl Promise {
         // a. Let thenFinallyClosure be a new Abstract Closure with parameters (value) that captures onFinally and C and performs the following steps when called:
         let then_finally_closure = FunctionObjectBuilder::new(
             context.realm(),
+            context.gc_collector(),
             NativeFunction::from_copy_closure_with_captures(
                 |_this, args, captures, context| {
                     /// Capture object for the abstract `returnValue` closure.
@@ -2027,6 +2049,7 @@ impl Promise {
                     // iii. Let returnValue be a new Abstract Closure with no parameters that captures value and performs the following steps when called:
                     let return_value = FunctionObjectBuilder::new(
                         context.realm(),
+                        context.gc_collector(),
                         NativeFunction::from_copy_closure_with_captures(
                             |_this, _args, captures, _context| {
                                 // 1. Return value.
@@ -2057,6 +2080,7 @@ impl Promise {
         // c. Let catchFinallyClosure be a new Abstract Closure with parameters (reason) that captures onFinally and C and performs the following steps when called:
         let catch_finally_closure = FunctionObjectBuilder::new(
             context.realm(),
+            context.gc_collector(),
             NativeFunction::from_copy_closure_with_captures(
                 |_this, args, captures, context| {
                     /// Capture object for the abstract `throwReason` closure.
@@ -2078,6 +2102,7 @@ impl Promise {
                     // iii. Let throwReason be a new Abstract Closure with no parameters that captures reason and performs the following steps when called:
                     let throw_reason = FunctionObjectBuilder::new(
                         context.realm(),
+                        context.gc_collector(),
                         NativeFunction::from_copy_closure_with_captures(
                             |_this, _args, captures, _context| {
                                 // 1. Return ThrowCompletion(reason).
@@ -2452,6 +2477,7 @@ impl Promise {
         // 4. Let resolve be CreateBuiltinFunction(stepsResolve, lengthResolve, "", « [[Promise]], [[AlreadyResolved]] »).
         let resolve = FunctionObjectBuilder::new(
             context.realm(),
+            context.gc_collector(),
             NativeFunction::from_copy_closure_with_captures(
                 |_this, args, captures, context| {
                     // https://tc39.es/ecma262/#sec-promise-resolve-functions
@@ -2549,6 +2575,7 @@ impl Promise {
         // 9. Let reject be CreateBuiltinFunction(stepsReject, lengthReject, "", « [[Promise]], [[AlreadyResolved]] »).
         let reject = FunctionObjectBuilder::new(
             context.realm(),
+            context.gc_collector(),
             NativeFunction::from_copy_closure_with_captures(
                 |_this, args, captures, context| {
                     // https://tc39.es/ecma262/#sec-promise-reject-functions
@@ -2761,7 +2788,7 @@ fn create_keyed_result_object(
     debug_assert_eq!(keys.len(), values.len());
 
     // 2. Let obj be OrdinaryObjectCreate(null).
-    let obj = JsObject::with_null_proto();
+    let obj = JsObject::with_null_proto(context.gc_collector());
 
     // 3. For each integer i such that 0 ≤ i < the number of elements in keys, in ascending order, do
     for (key, value) in keys.iter().zip(values.iter()) {

--- a/core/engine/src/builtins/proxy/mod.rs
+++ b/core/engine/src/builtins/proxy/mod.rs
@@ -87,8 +87,8 @@ impl JsData for Proxy {
 }
 
 impl IntrinsicObject for Proxy {
-    fn init(realm: &Realm) {
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, mc)
             .static_method(Self::revocable, js_string!("revocable"), 2)
             .build_without_prototype();
     }
@@ -181,6 +181,7 @@ impl Proxy {
         // 6. Set P.[[ProxyTarget]] to target.
         // 7. Set P.[[ProxyHandler]] to handler.
         let p = JsObject::from_proto_and_data_with_shared_shape(
+            context.gc_collector(),
             context.root_shape(),
             context.intrinsics().constructors().object().prototype(),
             Self::new(target.clone(), handler.clone()),
@@ -215,7 +216,7 @@ impl Proxy {
             },
             GcRefCell::new(Some(proxy)),
         )
-        .to_js_function(context.realm())
+        .to_js_function(context.realm(), context.gc_collector())
     }
 
     /// `28.2.2.1 Proxy.revocable ( target, handler )`
@@ -232,7 +233,7 @@ impl Proxy {
         let revoker = Self::revoker(p.clone(), context);
 
         // 5. Let result be ! OrdinaryObjectCreate(%Object.prototype%).
-        let result = JsObject::with_object_proto(context.intrinsics());
+        let result = JsObject::with_object_proto(context.gc_collector(), context.intrinsics());
 
         // 6. Perform ! CreateDataPropertyOrThrow(result, "proxy", p).
         result

--- a/core/engine/src/builtins/reflect/mod.rs
+++ b/core/engine/src/builtins/reflect/mod.rs
@@ -33,10 +33,10 @@ mod tests;
 pub(crate) struct Reflect;
 
 impl IntrinsicObject for Reflect {
-    fn init(realm: &Realm) {
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
         let to_string_tag = JsSymbol::to_string_tag();
 
-        BuiltInBuilder::with_intrinsic::<Self>(realm)
+        BuiltInBuilder::with_intrinsic::<Self>(realm, mc)
             .static_method(Self::apply, js_string!("apply"), 3)
             .static_method(Self::construct, js_string!("construct"), 2)
             .static_method(Self::define_property, js_string!("defineProperty"), 3)

--- a/core/engine/src/builtins/regexp/mod.rs
+++ b/core/engine/src/builtins/regexp/mod.rs
@@ -60,44 +60,44 @@ impl RegExp {
 }
 
 impl IntrinsicObject for RegExp {
-    fn init(realm: &Realm) {
-        let get_species = BuiltInBuilder::callable(realm, Self::get_species)
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
+        let get_species = BuiltInBuilder::callable(realm, Self::get_species, mc)
             .name(js_string!("get [Symbol.species]"))
             .build();
 
         let flag_attributes = Attribute::CONFIGURABLE | Attribute::NON_ENUMERABLE;
 
-        let get_has_indices = BuiltInBuilder::callable(realm, Self::get_has_indices)
+        let get_has_indices = BuiltInBuilder::callable(realm, Self::get_has_indices, mc)
             .name(js_string!("get hasIndices"))
             .build();
-        let get_global = BuiltInBuilder::callable(realm, Self::get_global)
+        let get_global = BuiltInBuilder::callable(realm, Self::get_global, mc)
             .name(js_string!("get global"))
             .build();
-        let get_ignore_case = BuiltInBuilder::callable(realm, Self::get_ignore_case)
+        let get_ignore_case = BuiltInBuilder::callable(realm, Self::get_ignore_case, mc)
             .name(js_string!("get ignoreCase"))
             .build();
-        let get_multiline = BuiltInBuilder::callable(realm, Self::get_multiline)
+        let get_multiline = BuiltInBuilder::callable(realm, Self::get_multiline, mc)
             .name(js_string!("get multiline"))
             .build();
-        let get_dot_all = BuiltInBuilder::callable(realm, Self::get_dot_all)
+        let get_dot_all = BuiltInBuilder::callable(realm, Self::get_dot_all, mc)
             .name(js_string!("get dotAll"))
             .build();
-        let get_unicode = BuiltInBuilder::callable(realm, Self::get_unicode)
+        let get_unicode = BuiltInBuilder::callable(realm, Self::get_unicode, mc)
             .name(js_string!("get unicode"))
             .build();
-        let get_unicode_sets = BuiltInBuilder::callable(realm, Self::get_unicode_sets)
+        let get_unicode_sets = BuiltInBuilder::callable(realm, Self::get_unicode_sets, mc)
             .name(js_string!("get unicodeSets"))
             .build();
-        let get_sticky = BuiltInBuilder::callable(realm, Self::get_sticky)
+        let get_sticky = BuiltInBuilder::callable(realm, Self::get_sticky, mc)
             .name(js_string!("get sticky"))
             .build();
-        let get_flags = BuiltInBuilder::callable(realm, Self::get_flags)
+        let get_flags = BuiltInBuilder::callable(realm, Self::get_flags, mc)
             .name(js_string!("get flags"))
             .build();
-        let get_source = BuiltInBuilder::callable(realm, Self::get_source)
+        let get_source = BuiltInBuilder::callable(realm, Self::get_source, mc)
             .name(js_string!("get source"))
             .build();
-        let regexp = BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        let regexp = BuiltInBuilder::from_standard_constructor::<Self>(realm, mc)
             .static_method(Self::escape, js_string!("escape"), 1)
             .static_accessor(
                 JsSymbol::species(),
@@ -425,14 +425,14 @@ impl RegExp {
                 .templates()
                 .regexp_without_proto()
                 .clone();
-            template.set_prototype(prototype);
-            template.create(regexp, vec![0.into()])
+            template.set_prototype(context.gc_collector(), prototype);
+            template.create(context.gc_collector(), regexp, vec![0.into()])
         } else {
-            context
-                .intrinsics()
-                .templates()
-                .regexp()
-                .create(regexp, vec![0.into()])
+            context.intrinsics().templates().regexp().create(
+                context.gc_collector(),
+                regexp,
+                vec![0.into()],
+            )
         };
 
         // 23. Return obj.
@@ -1270,8 +1270,8 @@ impl RegExp {
         #[allow(clippy::if_not_else)]
         let (groups, group_names) = if !named_groups.clone().is_empty() {
             // a. Let groups be OrdinaryObjectCreate(null).
-            let groups = JsObject::with_null_proto();
-            let group_names = JsObject::with_null_proto();
+            let groups = JsObject::with_null_proto(context.gc_collector());
+            let group_names = JsObject::with_null_proto(context.gc_collector());
 
             // e. If the ith capture of R was defined with a GroupName, then
             // i. Let s be the CapturingGroupName of that GroupName.

--- a/core/engine/src/builtins/regexp/regexp_string_iterator.rs
+++ b/core/engine/src/builtins/regexp/regexp_string_iterator.rs
@@ -40,8 +40,8 @@ pub(crate) struct RegExpStringIterator {
 }
 
 impl IntrinsicObject for RegExpStringIterator {
-    fn init(realm: &Realm) {
-        BuiltInBuilder::with_intrinsic::<Self>(realm)
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
+        BuiltInBuilder::with_intrinsic::<Self>(realm, mc)
             .prototype(realm.intrinsics().constructors().iterator().prototype())
             .static_method(Self::next, js_string!("next"), 0)
             .static_property(
@@ -95,6 +95,7 @@ impl RegExpStringIterator {
         // 5. Return ! CreateIteratorFromClosure(closure, "%RegExpStringIteratorPrototype%", %RegExpStringIteratorPrototype%).
 
         let regexp_string_iterator = JsObject::from_proto_and_data_with_shared_shape(
+            context.gc_collector(),
             context.root_shape(),
             context
                 .intrinsics()

--- a/core/engine/src/builtins/set/mod.rs
+++ b/core/engine/src/builtins/set/mod.rs
@@ -123,20 +123,20 @@ impl IntrinsicObject for Set {
     fn get(intrinsics: &Intrinsics) -> JsObject {
         Self::STANDARD_CONSTRUCTOR(intrinsics.constructors()).constructor()
     }
-    fn init(realm: &Realm) {
-        let get_species = BuiltInBuilder::callable(realm, Self::get_species)
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
+        let get_species = BuiltInBuilder::callable(realm, Self::get_species, mc)
             .name(js_string!("get [Symbol.species]"))
             .build();
 
-        let size_getter = BuiltInBuilder::callable(realm, Self::size_getter)
+        let size_getter = BuiltInBuilder::callable(realm, Self::size_getter, mc)
             .name(js_string!("get size"))
             .build();
 
-        let values_function = BuiltInBuilder::callable(realm, Self::values)
+        let values_function = BuiltInBuilder::callable(realm, Self::values, mc)
             .name(js_string!("values"))
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, mc)
             .static_accessor(
                 JsSymbol::species(),
                 Some(get_species),
@@ -221,6 +221,7 @@ impl BuiltInConstructor for Set {
         let prototype =
             get_prototype_from_constructor(new_target, StandardConstructors::set, context)?;
         let set = JsObject::from_proto_and_data_with_shared_shape(
+            context.gc_collector(),
             context.root_shape(),
             prototype,
             OrderedSet::default(),
@@ -841,6 +842,7 @@ impl Set {
         //     9. Set result.[[SetData]] to resultSetData.
         //     10. Return result.
         Ok(JsObject::from_proto_and_data_with_shared_shape(
+            context.gc_collector(),
             context.root_shape(),
             context.intrinsics().constructors().set().prototype(),
             result_set,
@@ -897,6 +899,7 @@ impl Set {
         // 9. Set result.[[SetData]] to resultSetData.
         // 10. Return result.
         Ok(JsObject::from_proto_and_data_with_shared_shape(
+            context.gc_collector(),
             context.root_shape(),
             context.intrinsics().constructors().set().prototype(),
             result_set,
@@ -996,6 +999,7 @@ impl Set {
         // 8. Set result.[[SetData]] to resultSetData.
         // 9. Return result.
         Ok(JsObject::from_proto_and_data_with_shared_shape(
+            context.gc_collector(),
             context.root_shape(),
             context.intrinsics().constructors().set().prototype(),
             result_set,
@@ -1093,6 +1097,7 @@ impl Set {
         // 8. Set result.[[SetData]] to resultSetData.
         // 9. Return result.
         Ok(JsObject::from_proto_and_data_with_shared_shape(
+            context.gc_collector(),
             context.root_shape(),
             context.intrinsics().constructors().set().prototype(),
             result_set,

--- a/core/engine/src/builtins/set/set_iterator.rs
+++ b/core/engine/src/builtins/set/set_iterator.rs
@@ -52,8 +52,8 @@ pub(crate) struct SetIterator {
 }
 
 impl IntrinsicObject for SetIterator {
-    fn init(realm: &Realm) {
-        BuiltInBuilder::with_intrinsic::<Self>(realm)
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
+        BuiltInBuilder::with_intrinsic::<Self>(realm, mc)
             .prototype(realm.intrinsics().constructors().iterator().prototype())
             .static_method(Self::next, js_string!("next"), 0)
             .static_property(
@@ -84,6 +84,7 @@ impl SetIterator {
         context: &Context,
     ) -> JsValue {
         let set_iterator = JsObject::from_proto_and_data_with_shared_shape(
+            context.gc_collector(),
             context.root_shape(),
             context.intrinsics().objects().iterator_prototypes().set(),
             Self {

--- a/core/engine/src/builtins/string/mod.rs
+++ b/core/engine/src/builtins/string/mod.rs
@@ -62,13 +62,13 @@ pub(crate) enum Placement {
 pub(crate) struct String;
 
 impl IntrinsicObject for String {
-    fn init(realm: &Realm) {
-        let trim_start = BuiltInBuilder::callable(realm, Self::trim_start)
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
+        let trim_start = BuiltInBuilder::callable(realm, Self::trim_start, mc)
             .length(0)
             .name(js_string!("trimStart"))
             .build();
 
-        let trim_end = BuiltInBuilder::callable(realm, Self::trim_end)
+        let trim_end = BuiltInBuilder::callable(realm, Self::trim_end, mc)
             .length(0)
             .name(js_string!("trimEnd"))
             .build();
@@ -80,7 +80,7 @@ impl IntrinsicObject for String {
         let trim_right = trim_end.clone();
 
         let attribute = Attribute::READONLY | Attribute::NON_ENUMERABLE | Attribute::PERMANENT;
-        let builder = BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        let builder = BuiltInBuilder::from_standard_constructor::<Self>(realm, mc)
             .property(js_string!("length"), 0, attribute)
             .property(
                 js_string!("trimStart"),
@@ -250,9 +250,13 @@ impl String {
         // 4. Set S.[[GetOwnProperty]] as specified in 10.4.3.1.
         // 5. Set S.[[DefineOwnProperty]] as specified in 10.4.3.2.
         // 6. Set S.[[OwnPropertyKeys]] as specified in 10.4.3.3.
-        let s =
-            JsObject::from_proto_and_data_with_shared_shape(context.root_shape(), prototype, value)
-                .upcast();
+        let s = JsObject::from_proto_and_data_with_shared_shape(
+            context.gc_collector(),
+            context.root_shape(),
+            prototype,
+            value,
+        )
+        .upcast();
 
         // 8. Perform ! DefinePropertyOrThrow(S, "length", PropertyDescriptor { [[Value]]: 𝔽(length),
         // [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: false }).

--- a/core/engine/src/builtins/string/string_iterator.rs
+++ b/core/engine/src/builtins/string/string_iterator.rs
@@ -31,8 +31,8 @@ pub(crate) struct StringIterator {
 }
 
 impl IntrinsicObject for StringIterator {
-    fn init(realm: &Realm) {
-        BuiltInBuilder::with_intrinsic::<Self>(realm)
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
+        BuiltInBuilder::with_intrinsic::<Self>(realm, mc)
             .prototype(realm.intrinsics().constructors().iterator().prototype())
             .static_method(Self::next, js_string!("next"), 0)
             .static_property(
@@ -52,6 +52,7 @@ impl StringIterator {
     /// Create a new `StringIterator`.
     pub(crate) fn create_string_iterator(string: JsString, context: &mut Context) -> JsObject {
         JsObject::from_proto_and_data_with_shared_shape(
+            context.gc_collector(),
             context.root_shape(),
             context
                 .intrinsics()

--- a/core/engine/src/builtins/symbol/mod.rs
+++ b/core/engine/src/builtins/symbol/mod.rs
@@ -93,7 +93,7 @@ impl GlobalSymbolRegistry {
 pub struct Symbol;
 
 impl IntrinsicObject for Symbol {
-    fn init(realm: &Realm) {
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
         let symbol_async_iterator = JsSymbol::async_iterator();
         let symbol_has_instance = JsSymbol::has_instance();
         let symbol_is_concat_spreadable = JsSymbol::is_concat_spreadable();
@@ -112,16 +112,16 @@ impl IntrinsicObject for Symbol {
 
         let attribute = Attribute::READONLY | Attribute::NON_ENUMERABLE | Attribute::PERMANENT;
 
-        let to_primitive = BuiltInBuilder::callable(realm, Self::to_primitive)
+        let to_primitive = BuiltInBuilder::callable(realm, Self::to_primitive, mc)
             .name(js_string!("[Symbol.toPrimitive]"))
             .length(1)
             .build();
 
-        let get_description = BuiltInBuilder::callable(realm, Self::get_description)
+        let get_description = BuiltInBuilder::callable(realm, Self::get_description, mc)
             .name(js_string!("get description"))
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, mc)
             .static_method(Self::for_, js_string!("for"), 1)
             .static_method(Self::key_for, js_string!("keyFor"), 1)
             .static_property(

--- a/core/engine/src/builtins/temporal/duration/mod.rs
+++ b/core/engine/src/builtins/temporal/duration/mod.rs
@@ -59,56 +59,56 @@ impl BuiltInObject for Duration {
 }
 
 impl IntrinsicObject for Duration {
-    fn init(realm: &Realm) {
-        let get_years = BuiltInBuilder::callable(realm, Self::get_years)
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
+        let get_years = BuiltInBuilder::callable(realm, Self::get_years, mc)
             .name(js_string!("get Years"))
             .build();
 
-        let get_months = BuiltInBuilder::callable(realm, Self::get_months)
+        let get_months = BuiltInBuilder::callable(realm, Self::get_months, mc)
             .name(js_string!("get Months"))
             .build();
 
-        let get_weeks = BuiltInBuilder::callable(realm, Self::get_weeks)
+        let get_weeks = BuiltInBuilder::callable(realm, Self::get_weeks, mc)
             .name(js_string!("get Weeks"))
             .build();
 
-        let get_days = BuiltInBuilder::callable(realm, Self::get_days)
+        let get_days = BuiltInBuilder::callable(realm, Self::get_days, mc)
             .name(js_string!("get Days"))
             .build();
 
-        let get_hours = BuiltInBuilder::callable(realm, Self::get_hours)
+        let get_hours = BuiltInBuilder::callable(realm, Self::get_hours, mc)
             .name(js_string!("get Hours"))
             .build();
 
-        let get_minutes = BuiltInBuilder::callable(realm, Self::get_minutes)
+        let get_minutes = BuiltInBuilder::callable(realm, Self::get_minutes, mc)
             .name(js_string!("get Minutes"))
             .build();
 
-        let get_seconds = BuiltInBuilder::callable(realm, Self::get_seconds)
+        let get_seconds = BuiltInBuilder::callable(realm, Self::get_seconds, mc)
             .name(js_string!("get Seconds"))
             .build();
 
-        let get_milliseconds = BuiltInBuilder::callable(realm, Self::get_milliseconds)
+        let get_milliseconds = BuiltInBuilder::callable(realm, Self::get_milliseconds, mc)
             .name(js_string!("get Milliseconds"))
             .build();
 
-        let get_microseconds = BuiltInBuilder::callable(realm, Self::get_microseconds)
+        let get_microseconds = BuiltInBuilder::callable(realm, Self::get_microseconds, mc)
             .name(js_string!("get Microseconds"))
             .build();
 
-        let get_nanoseconds = BuiltInBuilder::callable(realm, Self::get_nanoseconds)
+        let get_nanoseconds = BuiltInBuilder::callable(realm, Self::get_nanoseconds, mc)
             .name(js_string!("get Nanoseconds"))
             .build();
 
-        let get_sign = BuiltInBuilder::callable(realm, Self::get_sign)
+        let get_sign = BuiltInBuilder::callable(realm, Self::get_sign, mc)
             .name(js_string!("get Sign"))
             .build();
 
-        let is_blank = BuiltInBuilder::callable(realm, Self::get_blank)
+        let is_blank = BuiltInBuilder::callable(realm, Self::get_blank, mc)
             .name(js_string!("get blank"))
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, mc)
             .property(
                 JsSymbol::to_string_tag(),
                 StaticJsStrings::DURATION_TAG,
@@ -612,7 +612,7 @@ impl Duration {
         // 2. Set two to ? ToTemporalDuration(two).
         let two = to_temporal_duration(args.get_or_undefined(1), context)?;
         // 3. Let resolvedOptions be ? GetOptionsObject(options).
-        let options = get_options_object(args.get_or_undefined(2))?;
+        let options = get_options_object(args.get_or_undefined(2), context.gc_collector())?;
         // 4. Let relativeToRecord be ? GetTemporalRelativeToOption(resolvedOptions).
         let relative_to = get_relative_to_option(&options, context)?;
 
@@ -908,7 +908,7 @@ impl Duration {
             // a. Let paramString be roundTo.
             let param_string = param_string.clone();
             // b. Set roundTo to OrdinaryObjectCreate(null).
-            let new_round_to = JsObject::with_null_proto();
+            let new_round_to = JsObject::with_null_proto(context.gc_collector());
             // c. Perform ! CreateDataPropertyOrThrow(roundTo, "smallestUnit", paramString).
             new_round_to.create_data_property_or_throw(
                 js_string!("smallestUnit"),
@@ -919,7 +919,7 @@ impl Duration {
         } else {
             // 5. Else,
             // a. Set roundTo to ? GetOptionsObject(roundTo).
-            get_options_object(round_to_arg)?
+            get_options_object(round_to_arg, context.gc_collector())?
         };
 
         // NOTE: 6 & 7 unused in favor of `is_none()`.
@@ -1009,7 +1009,7 @@ impl Duration {
             JsVariant::String(param_string) => {
                 // a. Let paramString be totalOf.
                 // b. Set totalOf to OrdinaryObjectCreate(null).
-                let total_of = JsObject::with_null_proto();
+                let total_of = JsObject::with_null_proto(context.gc_collector());
                 // c. Perform ! CreateDataPropertyOrThrow(totalOf, "unit", paramString).
                 total_of.create_data_property_or_throw(
                     js_string!("unit"),
@@ -1021,7 +1021,7 @@ impl Duration {
             // 5. Else,
             _ => {
                 // a. Set totalOf to ? GetOptionsObject(totalOf).
-                get_options_object(total_of)?
+                get_options_object(total_of, context.gc_collector())?
             }
         };
 
@@ -1072,7 +1072,7 @@ impl Duration {
                 JsNativeError::typ().with_message("this value must be a Duration object.")
             })?;
 
-        let options = get_options_object(args.get_or_undefined(0))?;
+        let options = get_options_object(args.get_or_undefined(0), context.gc_collector())?;
         let precision = get_digits_option(&options, context)?;
         let rounding_mode =
             get_option::<RoundingMode>(&options, js_string!("roundingMode"), context)?;
@@ -1262,7 +1262,8 @@ pub(crate) fn create_temporal_duration(
     // 12. Set object.[[Microseconds]] to ℝ(𝔽(microseconds)).
     // 13. Set object.[[Nanoseconds]] to ℝ(𝔽(nanoseconds)).
 
-    let obj = JsObject::from_proto_and_data(prototype, Duration::new(inner));
+    let obj =
+        JsObject::from_proto_and_data(context.gc_collector(), prototype, Duration::new(inner));
     // 14. Return object.
     Ok(obj)
 }

--- a/core/engine/src/builtins/temporal/instant/mod.rs
+++ b/core/engine/src/builtins/temporal/instant/mod.rs
@@ -61,16 +61,16 @@ impl BuiltInObject for Instant {
 }
 
 impl IntrinsicObject for Instant {
-    fn init(realm: &Realm) {
-        let get_millis = BuiltInBuilder::callable(realm, Self::get_epoch_milliseconds)
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
+        let get_millis = BuiltInBuilder::callable(realm, Self::get_epoch_milliseconds, mc)
             .name(js_string!("get epochMilliseconds"))
             .build();
 
-        let get_nanos = BuiltInBuilder::callable(realm, Self::get_epoch_nanoseconds)
+        let get_nanos = BuiltInBuilder::callable(realm, Self::get_epoch_nanoseconds, mc)
             .name(js_string!("get epochNanoseconds"))
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, mc)
             .property(
                 JsSymbol::to_string_tag(),
                 StaticJsStrings::INSTANT_TAG,
@@ -428,8 +428,10 @@ impl Instant {
         let other = to_temporal_instant(args.get_or_undefined(0), context)?;
 
         // Fetch the necessary options.
-        let settings =
-            get_difference_settings(&get_options_object(args.get_or_undefined(1))?, context)?;
+        let settings = get_difference_settings(
+            &get_options_object(args.get_or_undefined(1), context.gc_collector())?,
+            context,
+        )?;
         let result = instant.inner.until(&other, settings)?;
         create_temporal_duration(result, None, context).map(Into::into)
     }
@@ -462,8 +464,10 @@ impl Instant {
 
         // 3. Return ? DifferenceTemporalInstant(since, instant, other, options).
         let other = to_temporal_instant(args.get_or_undefined(0), context)?;
-        let settings =
-            get_difference_settings(&get_options_object(args.get_or_undefined(1))?, context)?;
+        let settings = get_difference_settings(
+            &get_options_object(args.get_or_undefined(1), context.gc_collector())?,
+            context,
+        )?;
         let result = instant.inner.since(&other, settings)?;
         create_temporal_duration(result, None, context).map(Into::into)
     }
@@ -506,7 +510,7 @@ impl Instant {
             // a. Let paramString be roundTo.
             let param_string = param_string.clone();
             // b. Set roundTo to OrdinaryObjectCreate(null).
-            let new_round_to = JsObject::with_null_proto();
+            let new_round_to = JsObject::with_null_proto(context.gc_collector());
             // c. Perform ! CreateDataPropertyOrThrow(roundTo, "smallestUnit", paramString).
             new_round_to.create_data_property_or_throw(
                 js_string!("smallestUnit"),
@@ -517,7 +521,7 @@ impl Instant {
         } else {
             // 5. Else,
             // a. Set roundTo to ? GetOptionsObject(roundTo).
-            get_options_object(round_to_arg)?
+            get_options_object(round_to_arg, context.gc_collector())?
         };
 
         // 6. NOTE: The following steps read options and perform independent validation in
@@ -624,7 +628,7 @@ impl Instant {
                     .with_message("the this object must be a Temporal.Instant object.")
             })?;
 
-        let options = get_options_object(args.get_or_undefined(0))?;
+        let options = get_options_object(args.get_or_undefined(0), context.gc_collector())?;
 
         let precision = get_digits_option(&options, context)?;
         let rounding_mode =
@@ -784,7 +788,7 @@ pub(crate) fn create_temporal_instant(
         get_prototype_from_constructor(&new_target, StandardConstructors::instant, context)?;
 
     // 4. Set object.[[Nanoseconds]] to epochNanoseconds.
-    let obj = JsObject::from_proto_and_data(proto, Instant::new(instant));
+    let obj = JsObject::from_proto_and_data(context.gc_collector(), proto, Instant::new(instant));
 
     // 5. Return object.
     Ok(obj.into())

--- a/core/engine/src/builtins/temporal/mod.rs
+++ b/core/engine/src/builtins/temporal/mod.rs
@@ -82,8 +82,8 @@ impl BuiltInObject for Temporal {
 }
 
 impl IntrinsicObject for Temporal {
-    fn init(realm: &Realm) {
-        BuiltInBuilder::with_intrinsic::<Self>(realm)
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
+        BuiltInBuilder::with_intrinsic::<Self>(realm, mc)
             .static_property(
                 JsSymbol::to_string_tag(),
                 Self::NAME,

--- a/core/engine/src/builtins/temporal/now.rs
+++ b/core/engine/src/builtins/temporal/now.rs
@@ -39,13 +39,13 @@ pub struct Now;
 
 impl IntrinsicObject for Now {
     /// Initializes the `Temporal.Now` object.
-    fn init(realm: &Realm) {
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
         // is an ordinary object.
         // has a [[Prototype]] internal slot whose value is %Object.prototype%.
         // is not a function object.
         // does not have a [[Construct]] internal method; it cannot be used as a constructor with the new operator.
         // does not have a [[Call]] internal method; it cannot be invoked as a function.
-        BuiltInBuilder::with_intrinsic::<Self>(realm)
+        BuiltInBuilder::with_intrinsic::<Self>(realm, mc)
             .static_property(
                 JsSymbol::to_string_tag(),
                 StaticJsStrings::NOW_TAG,

--- a/core/engine/src/builtins/temporal/plain_date/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_date/mod.rs
@@ -72,72 +72,72 @@ impl BuiltInObject for PlainDate {
 }
 
 impl IntrinsicObject for PlainDate {
-    fn init(realm: &Realm) {
-        let get_calendar_id = BuiltInBuilder::callable(realm, Self::get_calendar_id)
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
+        let get_calendar_id = BuiltInBuilder::callable(realm, Self::get_calendar_id, mc)
             .name(js_string!("get calendarId"))
             .build();
 
-        let get_era = BuiltInBuilder::callable(realm, Self::get_era)
+        let get_era = BuiltInBuilder::callable(realm, Self::get_era, mc)
             .name(js_string!("get era"))
             .build();
 
-        let get_era_year = BuiltInBuilder::callable(realm, Self::get_era_year)
+        let get_era_year = BuiltInBuilder::callable(realm, Self::get_era_year, mc)
             .name(js_string!("get eraYear"))
             .build();
 
-        let get_year = BuiltInBuilder::callable(realm, Self::get_year)
+        let get_year = BuiltInBuilder::callable(realm, Self::get_year, mc)
             .name(js_string!("get year"))
             .build();
 
-        let get_month = BuiltInBuilder::callable(realm, Self::get_month)
+        let get_month = BuiltInBuilder::callable(realm, Self::get_month, mc)
             .name(js_string!("get month"))
             .build();
 
-        let get_month_code = BuiltInBuilder::callable(realm, Self::get_month_code)
+        let get_month_code = BuiltInBuilder::callable(realm, Self::get_month_code, mc)
             .name(js_string!("get monthCode"))
             .build();
 
-        let get_day = BuiltInBuilder::callable(realm, Self::get_day)
+        let get_day = BuiltInBuilder::callable(realm, Self::get_day, mc)
             .name(js_string!("get day"))
             .build();
 
-        let get_day_of_week = BuiltInBuilder::callable(realm, Self::get_day_of_week)
+        let get_day_of_week = BuiltInBuilder::callable(realm, Self::get_day_of_week, mc)
             .name(js_string!("get dayOfWeek"))
             .build();
 
-        let get_day_of_year = BuiltInBuilder::callable(realm, Self::get_day_of_year)
+        let get_day_of_year = BuiltInBuilder::callable(realm, Self::get_day_of_year, mc)
             .name(js_string!("get dayOfYear"))
             .build();
 
-        let get_week_of_year = BuiltInBuilder::callable(realm, Self::get_week_of_year)
+        let get_week_of_year = BuiltInBuilder::callable(realm, Self::get_week_of_year, mc)
             .name(js_string!("get weekOfYear"))
             .build();
 
-        let get_year_of_week = BuiltInBuilder::callable(realm, Self::get_year_of_week)
+        let get_year_of_week = BuiltInBuilder::callable(realm, Self::get_year_of_week, mc)
             .name(js_string!("get yearOfWeek"))
             .build();
 
-        let get_days_in_week = BuiltInBuilder::callable(realm, Self::get_days_in_week)
+        let get_days_in_week = BuiltInBuilder::callable(realm, Self::get_days_in_week, mc)
             .name(js_string!("get daysInWeek"))
             .build();
 
-        let get_days_in_month = BuiltInBuilder::callable(realm, Self::get_days_in_month)
+        let get_days_in_month = BuiltInBuilder::callable(realm, Self::get_days_in_month, mc)
             .name(js_string!("get daysInMonth"))
             .build();
 
-        let get_days_in_year = BuiltInBuilder::callable(realm, Self::get_days_in_year)
+        let get_days_in_year = BuiltInBuilder::callable(realm, Self::get_days_in_year, mc)
             .name(js_string!("get daysInYear"))
             .build();
 
-        let get_months_in_year = BuiltInBuilder::callable(realm, Self::get_months_in_year)
+        let get_months_in_year = BuiltInBuilder::callable(realm, Self::get_months_in_year, mc)
             .name(js_string!("get monthsInYear"))
             .build();
 
-        let get_in_leap_year = BuiltInBuilder::callable(realm, Self::get_in_leap_year)
+        let get_in_leap_year = BuiltInBuilder::callable(realm, Self::get_in_leap_year, mc)
             .name(js_string!("get inLeapYear"))
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, mc)
             .property(
                 JsSymbol::to_string_tag(),
                 StaticJsStrings::PLAIN_DATE_TAG,
@@ -752,7 +752,10 @@ impl PlainDate {
 
         let object = item.as_object();
         if let Some(date) = object.as_ref().and_then(JsObject::downcast_ref::<Self>) {
-            let options = get_options_object(options.unwrap_or(&JsValue::undefined()))?;
+            let options = get_options_object(
+                options.unwrap_or(&JsValue::undefined()),
+                context.gc_collector(),
+            )?;
             let _ = get_option::<Overflow>(&options, js_string!("overflow"), context)?;
             return create_temporal_date(date.inner.clone(), None, context).map(Into::into);
         }
@@ -869,7 +872,7 @@ impl PlainDate {
         let duration = to_temporal_duration_record(args.get_or_undefined(0), context)?;
 
         // 4. Set options to ? GetOptionsObject(options).
-        let options = get_options_object(args.get_or_undefined(1))?;
+        let options = get_options_object(args.get_or_undefined(1), context.gc_collector())?;
 
         let overflow = get_option::<Overflow>(&options, js_string!("overflow"), context)?;
 
@@ -905,7 +908,7 @@ impl PlainDate {
         let duration = to_temporal_duration_record(args.get_or_undefined(0), context)?;
 
         // 4. Set options to ? GetOptionsObject(options).
-        let options = get_options_object(args.get_or_undefined(1))?;
+        let options = get_options_object(args.get_or_undefined(1), context.gc_collector())?;
         let overflow = get_option::<Overflow>(&options, js_string!("overflow"), context)?;
 
         // 5. Let negatedDuration be CreateNegatedTemporalDuration(duration).
@@ -954,7 +957,7 @@ impl PlainDate {
         let fields = to_calendar_fields(&partial_object, date.inner.calendar(), context)?;
 
         // 8. Let resolvedOptions be ? GetOptionsObject(options).
-        let options = get_options_object(args.get_or_undefined(1))?;
+        let options = get_options_object(args.get_or_undefined(1), context.gc_collector())?;
         // 9. Let overflow be ? GetTemporalOverflowOption(resolvedOptions).
         let overflow = get_option::<Overflow>(&options, js_string!("overflow"), context)?;
 
@@ -1018,7 +1021,7 @@ impl PlainDate {
         let other = to_temporal_date(args.get_or_undefined(0), None, context)?;
 
         // 3. Return ? DifferenceTemporalPlainDate(until, temporalDate, other, options).
-        let options = get_options_object(args.get_or_undefined(1))?;
+        let options = get_options_object(args.get_or_undefined(1), context.gc_collector())?;
         let settings = get_difference_settings(&options, context)?;
 
         create_temporal_duration(date.inner.until(&other, settings)?, None, context).map(Into::into)
@@ -1049,7 +1052,7 @@ impl PlainDate {
         // 3. Return ? DifferenceTemporalPlainDate(since, temporalDate, other, options).
         let other = to_temporal_date(args.get_or_undefined(0), None, context)?;
 
-        let options = get_options_object(args.get_or_undefined(1))?;
+        let options = get_options_object(args.get_or_undefined(1), context.gc_collector())?;
         let settings = get_difference_settings(&options, context)?;
 
         create_temporal_duration(date.inner.since(&other, settings)?, None, context).map(Into::into)
@@ -1204,7 +1207,7 @@ impl PlainDate {
                 JsNativeError::typ().with_message("the this object must be a PlainDate object.")
             })?;
 
-        let options = get_options_object(args.get_or_undefined(0))?;
+        let options = get_options_object(args.get_or_undefined(0), context.gc_collector())?;
         let display_calendar =
             get_option::<DisplayCalendar>(&options, js_string!("calendarName"), context)?
                 .unwrap_or(DisplayCalendar::Auto);
@@ -1302,7 +1305,8 @@ pub(crate) fn create_temporal_date(
     // 6. Set object.[[ISOMonth]] to isoMonth.
     // 7. Set object.[[ISODay]] to isoDay.
     // 8. Set object.[[Calendar]] to calendar.
-    let obj = JsObject::from_proto_and_data(prototype, PlainDate::new(inner));
+    let obj =
+        JsObject::from_proto_and_data(context.gc_collector(), prototype, PlainDate::new(inner));
 
     // 9. Return object.
     Ok(obj)
@@ -1326,11 +1330,11 @@ pub(crate) fn to_temporal_date(
     if let Some(object) = item.as_object() {
         // a. If item has an [[InitializedTemporalDate]] internal slot, then
         if let Some(date) = object.downcast_ref::<PlainDate>() {
-            let _options_obj = get_options_object(&options)?;
+            let _options_obj = get_options_object(&options, context.gc_collector())?;
             return Ok(date.inner.clone());
         // b. If item has an [[InitializedTemporalZonedDateTime]] internal slot, then
         } else if let Some(zdt) = object.downcast_ref::<ZonedDateTime>() {
-            let options_obj = get_options_object(&options)?;
+            let options_obj = get_options_object(&options, context.gc_collector())?;
             // i. Perform ? ToTemporalOverflow(options).
             let _overflow = get_option(&options_obj, js_string!("overflow"), context)?
                 .unwrap_or(Overflow::Constrain);
@@ -1341,7 +1345,7 @@ pub(crate) fn to_temporal_date(
             return Ok(zdt.inner.to_plain_date());
         // c. If item has an [[InitializedTemporalDateTime]] internal slot, then
         } else if let Some(dt) = object.downcast_ref::<PlainDateTime>() {
-            let options_obj = get_options_object(&options)?;
+            let options_obj = get_options_object(&options, context.gc_collector())?;
             // i. Perform ? ToTemporalOverflow(options).
             let _overflow = get_option(&options_obj, js_string!("overflow"), context)?
                 .unwrap_or(Overflow::Constrain);
@@ -1356,7 +1360,7 @@ pub(crate) fn to_temporal_date(
         // e. Let fields be ? PrepareCalendarFields(calendar, item, « year, month, month-code, day », «», «»).
         let partial = to_partial_date_record(&object, context)?;
         // f. Let resolvedOptions be ? GetOptionsObject(options).
-        let resolved_options = get_options_object(&options)?;
+        let resolved_options = get_options_object(&options, context.gc_collector())?;
         // g. Let overflow be ? GetTemporalOverflowOption(resolvedOptions).
         let overflow = get_option::<Overflow>(&resolved_options, js_string!("overflow"), context)?;
         // h. Let isoDate be ? CalendarDateFromFields(calendar, fields, overflow).
@@ -1381,7 +1385,7 @@ pub(crate) fn to_temporal_date(
     // 6. If calendar is empty, set calendar to "iso8601".
     // 7. Set calendar to ? CanonicalizeCalendar(calendar).
     // 8. Let resolvedOptions be ? GetOptionsObject(options).
-    let resolved_options = get_options_object(&options)?;
+    let resolved_options = get_options_object(&options, context.gc_collector())?;
     // 9. Perform ? GetTemporalOverflowOption(resolvedOptions).
     let _overflow = get_option::<Overflow>(&resolved_options, js_string!("overflow"), context)?
         .unwrap_or(Overflow::Constrain);

--- a/core/engine/src/builtins/temporal/plain_date_time/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_date_time/mod.rs
@@ -75,96 +75,96 @@ impl BuiltInObject for PlainDateTime {
 }
 
 impl IntrinsicObject for PlainDateTime {
-    fn init(realm: &Realm) {
-        let get_calendar_id = BuiltInBuilder::callable(realm, Self::get_calendar_id)
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
+        let get_calendar_id = BuiltInBuilder::callable(realm, Self::get_calendar_id, mc)
             .name(js_string!("get calendarId"))
             .build();
 
-        let get_era = BuiltInBuilder::callable(realm, Self::get_era)
+        let get_era = BuiltInBuilder::callable(realm, Self::get_era, mc)
             .name(js_string!("get era"))
             .build();
 
-        let get_era_year = BuiltInBuilder::callable(realm, Self::get_era_year)
+        let get_era_year = BuiltInBuilder::callable(realm, Self::get_era_year, mc)
             .name(js_string!("get eraYear"))
             .build();
 
-        let get_year = BuiltInBuilder::callable(realm, Self::get_year)
+        let get_year = BuiltInBuilder::callable(realm, Self::get_year, mc)
             .name(js_string!("get year"))
             .build();
 
-        let get_month = BuiltInBuilder::callable(realm, Self::get_month)
+        let get_month = BuiltInBuilder::callable(realm, Self::get_month, mc)
             .name(js_string!("get month"))
             .build();
 
-        let get_month_code = BuiltInBuilder::callable(realm, Self::get_month_code)
+        let get_month_code = BuiltInBuilder::callable(realm, Self::get_month_code, mc)
             .name(js_string!("get monthCode"))
             .build();
 
-        let get_day = BuiltInBuilder::callable(realm, Self::get_day)
+        let get_day = BuiltInBuilder::callable(realm, Self::get_day, mc)
             .name(js_string!("get day"))
             .build();
 
-        let get_hour = BuiltInBuilder::callable(realm, Self::get_hour)
+        let get_hour = BuiltInBuilder::callable(realm, Self::get_hour, mc)
             .name(js_string!("get hour"))
             .build();
 
-        let get_minute = BuiltInBuilder::callable(realm, Self::get_minute)
+        let get_minute = BuiltInBuilder::callable(realm, Self::get_minute, mc)
             .name(js_string!("get minute"))
             .build();
 
-        let get_second = BuiltInBuilder::callable(realm, Self::get_second)
+        let get_second = BuiltInBuilder::callable(realm, Self::get_second, mc)
             .name(js_string!("get second"))
             .build();
 
-        let get_millisecond = BuiltInBuilder::callable(realm, Self::get_millisecond)
+        let get_millisecond = BuiltInBuilder::callable(realm, Self::get_millisecond, mc)
             .name(js_string!("get millisecond"))
             .build();
 
-        let get_microsecond = BuiltInBuilder::callable(realm, Self::get_microsecond)
+        let get_microsecond = BuiltInBuilder::callable(realm, Self::get_microsecond, mc)
             .name(js_string!("get microsecond"))
             .build();
 
-        let get_nanosecond = BuiltInBuilder::callable(realm, Self::get_nanosecond)
+        let get_nanosecond = BuiltInBuilder::callable(realm, Self::get_nanosecond, mc)
             .name(js_string!("get nanosecond"))
             .build();
 
-        let get_day_of_week = BuiltInBuilder::callable(realm, Self::get_day_of_week)
+        let get_day_of_week = BuiltInBuilder::callable(realm, Self::get_day_of_week, mc)
             .name(js_string!("get dayOfWeek"))
             .build();
 
-        let get_day_of_year = BuiltInBuilder::callable(realm, Self::get_day_of_year)
+        let get_day_of_year = BuiltInBuilder::callable(realm, Self::get_day_of_year, mc)
             .name(js_string!("get dayOfYear"))
             .build();
 
-        let get_week_of_year = BuiltInBuilder::callable(realm, Self::get_week_of_year)
+        let get_week_of_year = BuiltInBuilder::callable(realm, Self::get_week_of_year, mc)
             .name(js_string!("get weekOfYear"))
             .build();
 
-        let get_year_of_week = BuiltInBuilder::callable(realm, Self::get_year_of_week)
+        let get_year_of_week = BuiltInBuilder::callable(realm, Self::get_year_of_week, mc)
             .name(js_string!("get yearOfWeek"))
             .build();
 
-        let get_days_in_week = BuiltInBuilder::callable(realm, Self::get_days_in_week)
+        let get_days_in_week = BuiltInBuilder::callable(realm, Self::get_days_in_week, mc)
             .name(js_string!("get daysInWeek"))
             .build();
 
-        let get_days_in_month = BuiltInBuilder::callable(realm, Self::get_days_in_month)
+        let get_days_in_month = BuiltInBuilder::callable(realm, Self::get_days_in_month, mc)
             .name(js_string!("get daysInMonth"))
             .build();
 
-        let get_days_in_year = BuiltInBuilder::callable(realm, Self::get_days_in_year)
+        let get_days_in_year = BuiltInBuilder::callable(realm, Self::get_days_in_year, mc)
             .name(js_string!("get daysInYear"))
             .build();
 
-        let get_months_in_year = BuiltInBuilder::callable(realm, Self::get_months_in_year)
+        let get_months_in_year = BuiltInBuilder::callable(realm, Self::get_months_in_year, mc)
             .name(js_string!("get monthsInYear"))
             .build();
 
-        let get_in_leap_year = BuiltInBuilder::callable(realm, Self::get_in_leap_year)
+        let get_in_leap_year = BuiltInBuilder::callable(realm, Self::get_in_leap_year, mc)
             .name(js_string!("get inLeapYear"))
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, mc)
             .property(
                 JsSymbol::to_string_tag(),
                 StaticJsStrings::PLAIN_DATETIME_TAG,
@@ -1024,7 +1024,7 @@ impl PlainDateTime {
         let object = item.as_object();
         let dt = if let Some(pdt) = object.as_ref().and_then(JsObject::downcast_ref::<Self>) {
             // a. Perform ? GetTemporalOverflowOption(options).
-            let options = get_options_object(args.get_or_undefined(1))?;
+            let options = get_options_object(args.get_or_undefined(1), context.gc_collector())?;
             let _ = get_option::<Overflow>(&options, js_string!("overflow"), context)?;
             // b. Return ! CreateTemporalDateTime(item.[[ISOYear]], item.[[ISOMonth]],
             // item.[[ISODay]], item.[[ISOHour]], item.[[ISOMinute]], item.[[ISOSecond]],
@@ -1110,7 +1110,7 @@ impl PlainDateTime {
         // 13. Set fields to CalendarMergeFields(calendar, fields, partialDateTime).
         let fields = to_date_time_fields(&partial_object, dt.inner.calendar(), context)?;
         // 14. Let resolvedOptions be ? GetOptionsObject(options).
-        let options = get_options_object(args.get_or_undefined(1))?;
+        let options = get_options_object(args.get_or_undefined(1), context.gc_collector())?;
         // 15. Let overflow be ? GetTemporalOverflowOption(resolvedOptions).
         let overflow = get_option::<Overflow>(&options, js_string!("overflow"), context)?;
 
@@ -1202,7 +1202,7 @@ impl PlainDateTime {
         let duration = to_temporal_duration_record(args.get_or_undefined(0), context)?;
 
         // 4. Set options to ? GetOptionsObject(options).
-        let options = get_options_object(args.get_or_undefined(1))?;
+        let options = get_options_object(args.get_or_undefined(1), context.gc_collector())?;
         let overflow = get_option::<Overflow>(&options, js_string!("overflow"), context)?;
 
         // 5. Let calendarRec be ? CreateCalendarMethodsRecord(temporalDate.[[Calendar]], « date-add »).
@@ -1236,7 +1236,7 @@ impl PlainDateTime {
         let duration = to_temporal_duration_record(args.get_or_undefined(0), context)?;
 
         // 4. Set options to ? GetOptionsObject(options).
-        let options = get_options_object(args.get_or_undefined(1))?;
+        let options = get_options_object(args.get_or_undefined(1), context.gc_collector())?;
         let overflow = get_option::<Overflow>(&options, js_string!("overflow"), context)?;
 
         // 5. Let negatedDuration be CreateNegatedTemporalDuration(duration).
@@ -1268,7 +1268,7 @@ impl PlainDateTime {
 
         let other = to_temporal_datetime(args.get_or_undefined(0), None, context)?;
 
-        let options = get_options_object(args.get_or_undefined(1))?;
+        let options = get_options_object(args.get_or_undefined(1), context.gc_collector())?;
         let settings = get_difference_settings(&options, context)?;
 
         create_temporal_duration(dt.inner.until(&other, settings)?, None, context).map(Into::into)
@@ -1296,7 +1296,7 @@ impl PlainDateTime {
 
         let other = to_temporal_datetime(args.get_or_undefined(0), None, context)?;
 
-        let options = get_options_object(args.get_or_undefined(1))?;
+        let options = get_options_object(args.get_or_undefined(1), context.gc_collector())?;
         let settings = get_difference_settings(&options, context)?;
 
         create_temporal_duration(dt.inner.since(&other, settings)?, None, context).map(Into::into)
@@ -1334,7 +1334,7 @@ impl PlainDateTime {
             // a. Let paramString be roundTo.
             let param_string = param_string.clone();
             // b. Set roundTo to OrdinaryObjectCreate(null).
-            let new_round_to = JsObject::with_null_proto();
+            let new_round_to = JsObject::with_null_proto(context.gc_collector());
             // c. Perform ! CreateDataPropertyOrThrow(roundTo, "smallestUnit", paramString).
             new_round_to.create_data_property_or_throw(
                 js_string!("smallestUnit"),
@@ -1345,7 +1345,7 @@ impl PlainDateTime {
         } else {
             // 5. Else,
             // a. Set roundTo to ? GetOptionsObject(roundTo).
-            get_options_object(round_to_arg)?
+            get_options_object(round_to_arg, context.gc_collector())?
         };
 
         let mut options = RoundingOptions::default();
@@ -1425,7 +1425,7 @@ impl PlainDateTime {
                 JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
             })?;
 
-        let options = get_options_object(args.get_or_undefined(0))?;
+        let options = get_options_object(args.get_or_undefined(0), context.gc_collector())?;
 
         let show_calendar =
             get_option::<DisplayCalendar>(&options, js_string!("calendarName"), context)?
@@ -1538,7 +1538,7 @@ impl PlainDateTime {
         // 3. Let timeZone be ? ToTemporalTimeZoneIdentifier(temporalTimeZoneLike).
         let timezone = to_temporal_timezone_identifier(args.get_or_undefined(0), context)?;
         // 4. Let resolvedOptions be ? GetOptionsObject(options).
-        let options = get_options_object(args.get_or_undefined(1))?;
+        let options = get_options_object(args.get_or_undefined(1), context.gc_collector())?;
         // 5. Let disambiguation be ? GetTemporalDisambiguationOption(resolvedOptions).
         let disambiguation =
             get_option::<Disambiguation>(&options, js_string!("disambiguation"), context)?
@@ -1647,7 +1647,8 @@ pub(crate) fn create_temporal_datetime(
     // 13. Set object.[[ISOMicrosecond]] to microsecond.
     // 14. Set object.[[ISONanosecond]] to nanosecond.
     // 15. Set object.[[Calendar]] to calendar.
-    let obj = JsObject::from_proto_and_data(prototype, PlainDateTime::new(inner));
+    let obj =
+        JsObject::from_proto_and_data(context.gc_collector(), prototype, PlainDateTime::new(inner));
 
     // 16. Return object.
     Ok(obj)
@@ -1669,7 +1670,7 @@ pub(crate) fn to_temporal_datetime(
         // b. If item has an [[InitializedTemporalZonedDateTime]] internal slot, then
         } else if let Some(zdt) = object.downcast_ref::<ZonedDateTime>() {
             // i. Perform ? GetTemporalOverflowOption(resolvedOptions).
-            let options = get_options_object(&options.unwrap_or_default())?;
+            let options = get_options_object(&options.unwrap_or_default(), context.gc_collector())?;
             let _ = get_option::<Overflow>(&options, js_string!("overflow"), context)?;
             // ii. Let instant be ! CreateTemporalInstant(item.[[Nanoseconds]]).
             // iii. Let timeZoneRec be ? CreateTimeZoneMethodsRecord(item.[[TimeZone]], « get-offset-nanoseconds-for »).
@@ -1678,7 +1679,7 @@ pub(crate) fn to_temporal_datetime(
         // c. If item has an [[InitializedTemporalDate]] internal slot, then
         } else if let Some(date) = object.downcast_ref::<PlainDate>() {
             // i. Perform ? GetTemporalOverflowOption(resolvedOptions).
-            let options = get_options_object(&options.unwrap_or_default())?;
+            let options = get_options_object(&options.unwrap_or_default(), context.gc_collector())?;
             let _ = get_option::<Overflow>(&options, js_string!("overflow"), context)?;
             // ii. Return ? CreateTemporalDateTime(item.[[ISOYear]], item.[[ISOMonth]], item.[[ISODay]], 0, 0, 0, 0, 0, 0, item.[[Calendar]]).
             return Ok(date.inner.to_plain_date_time(None)?);
@@ -1691,7 +1692,8 @@ pub(crate) fn to_temporal_datetime(
         // "nanosecond", "second" », «»)
         // TODO: Move validation to `temporal_rs`.
         let partial_dt = to_partial_datetime(&object, context)?;
-        let resolved_options = get_options_object(&options.unwrap_or_default())?;
+        let resolved_options =
+            get_options_object(&options.unwrap_or_default(), context.gc_collector())?;
         // g. Let result be ? InterpretTemporalDateTimeFields(calendarRec, fields, resolvedOptions).
         let overflow = get_option::<Overflow>(&resolved_options, js_string!("overflow"), context)?;
         return InnerDateTime::from_partial(partial_dt, overflow).map_err(Into::into);
@@ -1713,7 +1715,8 @@ pub(crate) fn to_temporal_datetime(
     // h. Set calendar to CanonicalizeUValue("ca", calendar).
     let date = string.to_std_string_escaped().parse::<InnerDateTime>()?;
     // i. Perform ? GetTemporalOverflowOption(resolvedOptions).
-    let resolved_options = get_options_object(&options.unwrap_or_default())?;
+    let resolved_options =
+        get_options_object(&options.unwrap_or_default(), context.gc_collector())?;
     let _ = get_option::<Overflow>(&resolved_options, js_string!("overflow"), context)?;
     // 5. Return ? CreateTemporalDateTime(result.[[Year]], result.[[Month]], result.[[Day]],
     // result.[[Hour]], result.[[Minute]], result.[[Second]], result.[[Millisecond]],

--- a/core/engine/src/builtins/temporal/plain_month_day/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_month_day/mod.rs
@@ -56,20 +56,20 @@ impl BuiltInObject for PlainMonthDay {
 }
 
 impl IntrinsicObject for PlainMonthDay {
-    fn init(realm: &Realm) {
-        let get_day = BuiltInBuilder::callable(realm, Self::get_day)
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
+        let get_day = BuiltInBuilder::callable(realm, Self::get_day, mc)
             .name(js_string!("get day"))
             .build();
 
-        let get_month_code = BuiltInBuilder::callable(realm, Self::get_month_code)
+        let get_month_code = BuiltInBuilder::callable(realm, Self::get_month_code, mc)
             .name(js_string!("get monthCode"))
             .build();
 
-        let get_calendar_id = BuiltInBuilder::callable(realm, Self::get_calendar_id)
+        let get_calendar_id = BuiltInBuilder::callable(realm, Self::get_calendar_id, mc)
             .name(js_string!("get calendarId"))
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, mc)
             .property(
                 JsSymbol::to_string_tag(),
                 StaticJsStrings::PLAIN_MD_TAG,
@@ -297,7 +297,8 @@ impl PlainMonthDay {
         let fields = to_calendar_fields(&object, month_day.inner.calendar(), context)?;
         // 7. Set fields to CalendarMergeFields(calendar, fields, partialMonthDay).
         // 8. Let resolvedOptions be ? GetOptionsObject(options).
-        let resolved_options = get_options_object(args.get_or_undefined(1))?;
+        let resolved_options =
+            get_options_object(args.get_or_undefined(1), context.gc_collector())?;
         // 9. Let overflow be ? GetTemporalOverflowOption(resolvedOptions).
         let overflow = get_option::<Overflow>(&resolved_options, js_string!("overflow"), context)?;
         // 10. Let isoDate be ? CalendarMonthDayFromFields(calendar, fields, overflow).
@@ -354,7 +355,7 @@ impl PlainMonthDay {
             })?;
 
         // 3. Set options to ? NormalizeOptionsObject(options).
-        let options = get_options_object(args.get_or_undefined(0))?;
+        let options = get_options_object(args.get_or_undefined(0), context.gc_collector())?;
         // 4. Let showCalendar be ? ToShowCalendarOption(options).
         // Get calendarName from the options object
         let show_calendar =
@@ -513,7 +514,8 @@ pub(crate) fn create_temporal_month_day(
     // 6. Set object.[[ISODay]] to isoDay.
     // 7. Set object.[[Calendar]] to calendar.
     // 8. Set object.[[ISOYear]] to referenceISOYear.
-    let obj = JsObject::from_proto_and_data(proto, PlainMonthDay::new(inner));
+    let obj =
+        JsObject::from_proto_and_data(context.gc_collector(), proto, PlainMonthDay::new(inner));
 
     // 9. Return object.
     Ok(obj.into())
@@ -531,7 +533,7 @@ fn to_temporal_month_day(
         // a. If item has an [[InitializedTemporalMonthDay]] internal slot, then
         if let Some(md) = obj.downcast_ref::<PlainMonthDay>() {
             // i. Let resolvedOptions be ? GetOptionsObject(options).
-            let options = get_options_object(options)?;
+            let options = get_options_object(options, context.gc_collector())?;
             // ii. Perform ? GetTemporalOverflowOption(resolvedOptions).
             let _ = get_option::<Overflow>(&options, js_string!("overflow"), context)?;
             // iii. Return ! CreateTemporalMonthDay(item.[[ISODate]], item.[[Calendar]]).
@@ -591,7 +593,7 @@ fn to_temporal_month_day(
             .with_calendar(calendar);
 
         // d. Let resolvedOptions be ? GetOptionsObject(options).
-        let options = get_options_object(options)?;
+        let options = get_options_object(options, context.gc_collector())?;
         // e. Let overflow be ? GetTemporalOverflowOption(resolvedOptions).
         let overflow = get_option::<Overflow>(&options, js_string!("overflow"), context)?;
         // f. Let isoDate be ? CalendarMonthDayFromFields(calendar, fields, overflow).
@@ -612,7 +614,7 @@ fn to_temporal_month_day(
     let parse_record =
         ParsedDate::month_day_from_utf8(md_string.to_std_string_escaped().as_bytes())?;
     // 8. Let resolvedOptions be ? GetOptionsObject(options).
-    let options = get_options_object(options)?;
+    let options = get_options_object(options, context.gc_collector())?;
     // 9. Perform ? GetTemporalOverflowOption(resolvedOptions).
     let _ = get_option::<Overflow>(&options, js_string!("overflow"), context)?;
     // 10. If calendar is "iso8601", then

--- a/core/engine/src/builtins/temporal/plain_time/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_time/mod.rs
@@ -56,32 +56,32 @@ impl BuiltInObject for PlainTime {
 }
 
 impl IntrinsicObject for PlainTime {
-    fn init(realm: &Realm) {
-        let get_hour = BuiltInBuilder::callable(realm, Self::get_hour)
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
+        let get_hour = BuiltInBuilder::callable(realm, Self::get_hour, mc)
             .name(js_string!("get hour"))
             .build();
 
-        let get_minute = BuiltInBuilder::callable(realm, Self::get_minute)
+        let get_minute = BuiltInBuilder::callable(realm, Self::get_minute, mc)
             .name(js_string!("get minute"))
             .build();
 
-        let get_second = BuiltInBuilder::callable(realm, Self::get_second)
+        let get_second = BuiltInBuilder::callable(realm, Self::get_second, mc)
             .name(js_string!("get second"))
             .build();
 
-        let get_millisecond = BuiltInBuilder::callable(realm, Self::get_millisecond)
+        let get_millisecond = BuiltInBuilder::callable(realm, Self::get_millisecond, mc)
             .name(js_string!("get millisecond"))
             .build();
 
-        let get_microsecond = BuiltInBuilder::callable(realm, Self::get_microsecond)
+        let get_microsecond = BuiltInBuilder::callable(realm, Self::get_microsecond, mc)
             .name(js_string!("get microsecond"))
             .build();
 
-        let get_nanosecond = BuiltInBuilder::callable(realm, Self::get_nanosecond)
+        let get_nanosecond = BuiltInBuilder::callable(realm, Self::get_nanosecond, mc)
             .name(js_string!("get nanosecond"))
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, mc)
             .property(
                 JsSymbol::to_string_tag(),
                 StaticJsStrings::PLAIN_TIME_TAG,
@@ -548,7 +548,7 @@ impl PlainTime {
         let partial = to_js_partial_time_record(&partial_object, context)?;
         // 17. Let resolvedOptions be ? GetOptionsObject(options).
         // 18. Let overflow be ? GetTemporalOverflowOption(resolvedOptions).
-        let options = get_options_object(args.get_or_undefined(1))?;
+        let options = get_options_object(args.get_or_undefined(1), context.gc_collector())?;
         let overflow = get_option::<Overflow>(&options, js_string!("overflow"), context)?;
 
         create_temporal_time(
@@ -582,8 +582,10 @@ impl PlainTime {
 
         let other = to_temporal_time(args.get_or_undefined(0), None, context)?;
 
-        let settings =
-            get_difference_settings(&get_options_object(args.get_or_undefined(1))?, context)?;
+        let settings = get_difference_settings(
+            &get_options_object(args.get_or_undefined(1), context.gc_collector())?,
+            context,
+        )?;
 
         let result = time.inner.until(&other, settings)?;
 
@@ -612,8 +614,10 @@ impl PlainTime {
 
         let other = to_temporal_time(args.get_or_undefined(0), None, context)?;
 
-        let settings =
-            get_difference_settings(&get_options_object(args.get_or_undefined(1))?, context)?;
+        let settings = get_difference_settings(
+            &get_options_object(args.get_or_undefined(1), context.gc_collector())?,
+            context,
+        )?;
 
         let result = time.inner.since(&other, settings)?;
 
@@ -654,7 +658,7 @@ impl PlainTime {
             // a. Let paramString be roundTo.
             let param_string = param_string.clone();
             // b. Set roundTo to OrdinaryObjectCreate(null).
-            let new_round_to = JsObject::with_null_proto();
+            let new_round_to = JsObject::with_null_proto(context.gc_collector());
             // c. Perform ! CreateDataPropertyOrThrow(roundTo, "smallestUnit", paramString).
             new_round_to.create_data_property_or_throw(
                 js_string!("smallestUnit"),
@@ -665,7 +669,7 @@ impl PlainTime {
         } else {
             // 5. Else,
             // a. Set roundTo to ? GetOptionsObject(roundTo).
-            get_options_object(round_to_arg)?
+            get_options_object(round_to_arg, context.gc_collector())?
         };
 
         let mut options = RoundingOptions::default();
@@ -751,7 +755,7 @@ impl PlainTime {
                 JsNativeError::typ().with_message("the this object must be a PlainTime object.")
             })?;
 
-        let options = get_options_object(args.get_or_undefined(0))?;
+        let options = get_options_object(args.get_or_undefined(0), context.gc_collector())?;
 
         let precision = get_digits_option(&options, context)?;
         let rounding_mode =
@@ -868,7 +872,7 @@ pub(crate) fn create_temporal_time(
     // 7. Set object.[[ISOMillisecond]] to millisecond.
     // 8. Set object.[[ISOMicrosecond]] to microsecond.
     // 9. Set object.[[ISONanosecond]] to nanosecond.
-    let obj = JsObject::from_proto_and_data(prototype, PlainTime { inner });
+    let obj = JsObject::from_proto_and_data(context.gc_collector(), prototype, PlainTime { inner });
 
     // 10. Return object.
     Ok(obj)
@@ -889,7 +893,7 @@ pub(crate) fn to_temporal_time(
             // a. If item has an [[InitializedTemporalTime]] internal slot, then
             if let Some(time) = object.downcast_ref::<PlainTime>() {
                 // i. Return item.
-                let options = get_options_object(options)?;
+                let options = get_options_object(options, context.gc_collector())?;
                 let _overflow = get_option::<Overflow>(&options, js_string!("overflow"), context)?;
                 return Ok(time.inner);
             // b. If item has an [[InitializedTemporalZonedDateTime]] internal slot, then
@@ -900,7 +904,7 @@ pub(crate) fn to_temporal_time(
                 // iv. Return ! CreateTemporalTime(plainDateTime.[[ISOHour]], plainDateTime.[[ISOMinute]],
                 // plainDateTime.[[ISOSecond]], plainDateTime.[[ISOMillisecond]], plainDateTime.[[ISOMicrosecond]],
                 // plainDateTime.[[ISONanosecond]]).
-                let options = get_options_object(options)?;
+                let options = get_options_object(options, context.gc_collector())?;
                 let _overflow = get_option::<Overflow>(&options, js_string!("overflow"), context)?;
                 return Ok(zdt.inner.to_plain_time());
             // c. If item has an [[InitializedTemporalDateTime]] internal slot, then
@@ -908,7 +912,7 @@ pub(crate) fn to_temporal_time(
                 // i. Return ! CreateTemporalTime(item.[[ISOHour]], item.[[ISOMinute]],
                 // item.[[ISOSecond]], item.[[ISOMillisecond]], item.[[ISOMicrosecond]],
                 // item.[[ISONanosecond]]).
-                let options = get_options_object(options)?;
+                let options = get_options_object(options, context.gc_collector())?;
                 let _overflow = get_option::<Overflow>(&options, js_string!("overflow"), context)?;
                 return Ok(PlainTimeInner::from(dt.inner.clone()));
             }
@@ -918,7 +922,7 @@ pub(crate) fn to_temporal_time(
             // result.[[Nanosecond]], overflow).
             let partial = to_js_partial_time_record(&object, context)?;
 
-            let options = get_options_object(options)?;
+            let options = get_options_object(options, context.gc_collector())?;
             let overflow = get_option::<Overflow>(&options, js_string!("overflow"), context)?;
 
             PlainTimeInner::from_partial(partial.as_temporal_partial_time(overflow)?, overflow)
@@ -930,7 +934,7 @@ pub(crate) fn to_temporal_time(
             // c. Assert: IsValidTime(result.[[Hour]], result.[[Minute]], result.[[Second]], result.[[Millisecond]], result.[[Microsecond]], result.[[Nanosecond]]) is true.
             let result = str.to_std_string_escaped().parse::<PlainTimeInner>()?;
 
-            let options = get_options_object(options)?;
+            let options = get_options_object(options, context.gc_collector())?;
             let _overflow = get_option::<Overflow>(&options, js_string!("overflow"), context)?;
 
             Ok(result)

--- a/core/engine/src/builtins/temporal/plain_year_month/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_year_month/mod.rs
@@ -61,48 +61,48 @@ impl BuiltInObject for PlainYearMonth {
 }
 
 impl IntrinsicObject for PlainYearMonth {
-    fn init(realm: &Realm) {
-        let get_calendar_id = BuiltInBuilder::callable(realm, Self::get_calendar_id)
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
+        let get_calendar_id = BuiltInBuilder::callable(realm, Self::get_calendar_id, mc)
             .name(js_string!("get calendarId"))
             .build();
 
-        let get_era_year = BuiltInBuilder::callable(realm, Self::get_era_year)
+        let get_era_year = BuiltInBuilder::callable(realm, Self::get_era_year, mc)
             .name(js_string!("get eraYear"))
             .build();
 
-        let get_era = BuiltInBuilder::callable(realm, Self::get_era)
+        let get_era = BuiltInBuilder::callable(realm, Self::get_era, mc)
             .name(js_string!("get era"))
             .build();
 
-        let get_year = BuiltInBuilder::callable(realm, Self::get_year)
+        let get_year = BuiltInBuilder::callable(realm, Self::get_year, mc)
             .name(js_string!("get year"))
             .build();
 
-        let get_month = BuiltInBuilder::callable(realm, Self::get_month)
+        let get_month = BuiltInBuilder::callable(realm, Self::get_month, mc)
             .name(js_string!("get month"))
             .build();
 
-        let get_month_code = BuiltInBuilder::callable(realm, Self::get_month_code)
+        let get_month_code = BuiltInBuilder::callable(realm, Self::get_month_code, mc)
             .name(js_string!("get monthCode"))
             .build();
 
-        let get_days_in_month = BuiltInBuilder::callable(realm, Self::get_days_in_month)
+        let get_days_in_month = BuiltInBuilder::callable(realm, Self::get_days_in_month, mc)
             .name(js_string!("get daysInMonth"))
             .build();
 
-        let get_days_in_year = BuiltInBuilder::callable(realm, Self::get_days_in_year)
+        let get_days_in_year = BuiltInBuilder::callable(realm, Self::get_days_in_year, mc)
             .name(js_string!("get daysInYear"))
             .build();
 
-        let get_months_in_year = BuiltInBuilder::callable(realm, Self::get_months_in_year)
+        let get_months_in_year = BuiltInBuilder::callable(realm, Self::get_months_in_year, mc)
             .name(js_string!("get monthsInYear"))
             .build();
 
-        let get_in_leap_year = BuiltInBuilder::callable(realm, Self::get_in_leap_year)
+        let get_in_leap_year = BuiltInBuilder::callable(realm, Self::get_in_leap_year, mc)
             .name(js_string!("get inLeapYear"))
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, mc)
             .property(
                 JsSymbol::to_string_tag(),
                 StaticJsStrings::PLAIN_YM_TAG,
@@ -571,7 +571,8 @@ impl PlainYearMonth {
                 .into());
         }
         // 8. Let resolvedOptions be ? GetOptionsObject(options).
-        let resolved_options = get_options_object(args.get_or_undefined(1))?;
+        let resolved_options =
+            get_options_object(args.get_or_undefined(1), context.gc_collector())?;
         // 9. Let overflow be ? GetTemporalOverflowOption(resolvedOptions).
         let overflow = get_option::<Overflow>(&resolved_options, js_string!("overflow"), context)?
             .unwrap_or_default();
@@ -594,7 +595,7 @@ impl PlainYearMonth {
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainYearMonth.html#method.add
     fn add(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         let duration_like = args.get_or_undefined(0);
-        let options = get_options_object(args.get_or_undefined(1))?;
+        let options = get_options_object(args.get_or_undefined(1), context.gc_collector())?;
 
         add_or_subtract_duration(true, this, duration_like, &options, context)
     }
@@ -612,7 +613,7 @@ impl PlainYearMonth {
     /// [temporal_rs-docs]: https://docs.rs/temporal_rs/latest/temporal_rs/struct.PlainYearMonth.html#method.subtract
     fn subtract(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         let duration_like = args.get_or_undefined(0);
-        let options = get_options_object(args.get_or_undefined(1))?;
+        let options = get_options_object(args.get_or_undefined(1), context.gc_collector())?;
 
         add_or_subtract_duration(false, this, duration_like, &options, context)
     }
@@ -645,7 +646,8 @@ impl PlainYearMonth {
                 .into());
         }
 
-        let resolved_options = get_options_object(args.get_or_undefined(1))?;
+        let resolved_options =
+            get_options_object(args.get_or_undefined(1), context.gc_collector())?;
         // TODO: Disallowed units must be rejected in `temporal_rs`.
         let settings = get_difference_settings(&resolved_options, context)?;
         let result = year_month.inner.until(&other, settings)?;
@@ -680,7 +682,8 @@ impl PlainYearMonth {
                 .into());
         }
 
-        let resolved_options = get_options_object(args.get_or_undefined(1))?;
+        let resolved_options =
+            get_options_object(args.get_or_undefined(1), context.gc_collector())?;
         // TODO: Disallowed units must be rejected in `temporal_rs`.
         let settings = get_difference_settings(&resolved_options, context)?;
         let result = year_month.inner.since(&other, settings)?;
@@ -735,7 +738,7 @@ impl PlainYearMonth {
             })?;
 
         // 3. Set options to ? NormalizeOptionsObject(options).
-        let options = get_options_object(args.get_or_undefined(0))?;
+        let options = get_options_object(args.get_or_undefined(0), context.gc_collector())?;
         // 4. Let showCalendar be ? ToShowCalendarOption(options).
         // Get calendarName from the options object
         let show_calendar =
@@ -875,7 +878,7 @@ fn to_temporal_year_month(
         // a. If item has an [[InitializedTemporalYearMonth]] internal slot, then
         if let Some(ym) = obj.downcast_ref::<PlainYearMonth>() {
             // i. Let resolvedOptions be ? GetOptionsObject(options).
-            let resolved_options = get_options_object(&options)?;
+            let resolved_options = get_options_object(&options, context.gc_collector())?;
             // ii. Perform ? GetTemporalOverflowOption(resolvedOptions).
             let _overflow =
                 get_option::<Overflow>(&resolved_options, js_string!("overflow"), context)?
@@ -887,7 +890,7 @@ fn to_temporal_year_month(
         // c. Let fields be ? PrepareCalendarFields(calendar, item, « year, month, month-code », «», «»).
         let partial = to_partial_year_month(&obj, context)?;
         // d. Let resolvedOptions be ? GetOptionsObject(options).
-        let resolved_options = get_options_object(&options)?;
+        let resolved_options = get_options_object(&options, context.gc_collector())?;
         // e. Let overflow be ? GetTemporalOverflowOption(resolvedOptions).
         let overflow = get_option::<Overflow>(&resolved_options, js_string!("overflow"), context)?;
         // f. Let isoDate be ? CalendarYearMonthFromFields(calendar, fields, overflow).
@@ -908,7 +911,7 @@ fn to_temporal_year_month(
     // 6. If calendar is empty, set calendar to "iso8601".
     // 7. Set calendar to ? CanonicalizeCalendar(calendar).
     // 8. Let resolvedOptions be ? GetOptionsObject(options).
-    let resolved_options = get_options_object(&options)?;
+    let resolved_options = get_options_object(&options, context.gc_collector())?;
     // 9. Perform ? GetTemporalOverflowOption(resolvedOptions).
     let _overflow = get_option::<Overflow>(&resolved_options, js_string!("overflow"), context)?
         .unwrap_or(Overflow::Constrain);
@@ -956,7 +959,7 @@ pub(crate) fn create_temporal_year_month(
     // 7. Set object.[[Calendar]] to calendar.
     // 8. Set object.[[ISODay]] to referenceISODay.
 
-    let obj = JsObject::from_proto_and_data(proto, PlainYearMonth::new(ym));
+    let obj = JsObject::from_proto_and_data(context.gc_collector(), proto, PlainYearMonth::new(ym));
 
     // 9. Return object.
     Ok(obj.into())

--- a/core/engine/src/builtins/temporal/zoneddatetime/mod.rs
+++ b/core/engine/src/builtins/temporal/zoneddatetime/mod.rs
@@ -71,120 +71,122 @@ impl BuiltInObject for ZonedDateTime {
 }
 
 impl IntrinsicObject for ZonedDateTime {
-    fn init(realm: &Realm) {
-        let get_calendar_id = BuiltInBuilder::callable(realm, Self::get_calendar_id)
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
+        let get_calendar_id = BuiltInBuilder::callable(realm, Self::get_calendar_id, mc)
             .name(js_string!("get calendarId"))
             .build();
 
-        let get_timezone_id = BuiltInBuilder::callable(realm, Self::get_timezone_id)
+        let get_timezone_id = BuiltInBuilder::callable(realm, Self::get_timezone_id, mc)
             .name(js_string!("get timeZoneId"))
             .build();
 
-        let get_era = BuiltInBuilder::callable(realm, Self::get_era)
+        let get_era = BuiltInBuilder::callable(realm, Self::get_era, mc)
             .name(js_string!("get era"))
             .build();
 
-        let get_era_year = BuiltInBuilder::callable(realm, Self::get_era_year)
+        let get_era_year = BuiltInBuilder::callable(realm, Self::get_era_year, mc)
             .name(js_string!("get eraYear"))
             .build();
 
-        let get_year = BuiltInBuilder::callable(realm, Self::get_year)
+        let get_year = BuiltInBuilder::callable(realm, Self::get_year, mc)
             .name(js_string!("get year"))
             .build();
 
-        let get_month = BuiltInBuilder::callable(realm, Self::get_month)
+        let get_month = BuiltInBuilder::callable(realm, Self::get_month, mc)
             .name(js_string!("get month"))
             .build();
 
-        let get_month_code = BuiltInBuilder::callable(realm, Self::get_month_code)
+        let get_month_code = BuiltInBuilder::callable(realm, Self::get_month_code, mc)
             .name(js_string!("get monthCode"))
             .build();
 
-        let get_day = BuiltInBuilder::callable(realm, Self::get_day)
+        let get_day = BuiltInBuilder::callable(realm, Self::get_day, mc)
             .name(js_string!("get day"))
             .build();
 
-        let get_hour = BuiltInBuilder::callable(realm, Self::get_hour)
+        let get_hour = BuiltInBuilder::callable(realm, Self::get_hour, mc)
             .name(js_string!("get hour"))
             .build();
 
-        let get_minute = BuiltInBuilder::callable(realm, Self::get_minute)
+        let get_minute = BuiltInBuilder::callable(realm, Self::get_minute, mc)
             .name(js_string!("get minute"))
             .build();
 
-        let get_second = BuiltInBuilder::callable(realm, Self::get_second)
+        let get_second = BuiltInBuilder::callable(realm, Self::get_second, mc)
             .name(js_string!("get second"))
             .build();
 
-        let get_millisecond = BuiltInBuilder::callable(realm, Self::get_millisecond)
+        let get_millisecond = BuiltInBuilder::callable(realm, Self::get_millisecond, mc)
             .name(js_string!("get millisecond"))
             .build();
 
-        let get_microsecond = BuiltInBuilder::callable(realm, Self::get_microsecond)
+        let get_microsecond = BuiltInBuilder::callable(realm, Self::get_microsecond, mc)
             .name(js_string!("get microsecond"))
             .build();
 
-        let get_nanosecond = BuiltInBuilder::callable(realm, Self::get_nanosecond)
+        let get_nanosecond = BuiltInBuilder::callable(realm, Self::get_nanosecond, mc)
             .name(js_string!("get nanosecond"))
             .build();
 
-        let get_epoch_milliseconds = BuiltInBuilder::callable(realm, Self::get_epoch_milliseconds)
-            .name(js_string!("get epochMilliseconds"))
-            .build();
+        let get_epoch_milliseconds =
+            BuiltInBuilder::callable(realm, Self::get_epoch_milliseconds, mc)
+                .name(js_string!("get epochMilliseconds"))
+                .build();
 
-        let get_epoch_nanoseconds = BuiltInBuilder::callable(realm, Self::get_epoch_nanoseconds)
-            .name(js_string!("get epochNanoseconds"))
-            .build();
+        let get_epoch_nanoseconds =
+            BuiltInBuilder::callable(realm, Self::get_epoch_nanoseconds, mc)
+                .name(js_string!("get epochNanoseconds"))
+                .build();
 
-        let get_day_of_week = BuiltInBuilder::callable(realm, Self::get_day_of_week)
+        let get_day_of_week = BuiltInBuilder::callable(realm, Self::get_day_of_week, mc)
             .name(js_string!("get dayOfWeek"))
             .build();
 
-        let get_day_of_year = BuiltInBuilder::callable(realm, Self::get_day_of_year)
+        let get_day_of_year = BuiltInBuilder::callable(realm, Self::get_day_of_year, mc)
             .name(js_string!("get dayOfYear"))
             .build();
 
-        let get_week_of_year = BuiltInBuilder::callable(realm, Self::get_week_of_year)
+        let get_week_of_year = BuiltInBuilder::callable(realm, Self::get_week_of_year, mc)
             .name(js_string!("get weekOfYear"))
             .build();
 
-        let get_hours_in_day = BuiltInBuilder::callable(realm, Self::get_hours_in_day)
+        let get_hours_in_day = BuiltInBuilder::callable(realm, Self::get_hours_in_day, mc)
             .name(js_string!("get daysInWeek"))
             .build();
 
-        let get_year_of_week = BuiltInBuilder::callable(realm, Self::get_year_of_week)
+        let get_year_of_week = BuiltInBuilder::callable(realm, Self::get_year_of_week, mc)
             .name(js_string!("get yearOfWeek"))
             .build();
 
-        let get_days_in_week = BuiltInBuilder::callable(realm, Self::get_days_in_week)
+        let get_days_in_week = BuiltInBuilder::callable(realm, Self::get_days_in_week, mc)
             .name(js_string!("get daysInWeek"))
             .build();
 
-        let get_days_in_month = BuiltInBuilder::callable(realm, Self::get_days_in_month)
+        let get_days_in_month = BuiltInBuilder::callable(realm, Self::get_days_in_month, mc)
             .name(js_string!("get daysInMonth"))
             .build();
 
-        let get_days_in_year = BuiltInBuilder::callable(realm, Self::get_days_in_year)
+        let get_days_in_year = BuiltInBuilder::callable(realm, Self::get_days_in_year, mc)
             .name(js_string!("get daysInYear"))
             .build();
 
-        let get_months_in_year = BuiltInBuilder::callable(realm, Self::get_months_in_year)
+        let get_months_in_year = BuiltInBuilder::callable(realm, Self::get_months_in_year, mc)
             .name(js_string!("get monthsInYear"))
             .build();
 
-        let get_in_leap_year = BuiltInBuilder::callable(realm, Self::get_in_leap_year)
+        let get_in_leap_year = BuiltInBuilder::callable(realm, Self::get_in_leap_year, mc)
             .name(js_string!("get inLeapYear"))
             .build();
 
-        let get_offset_nanos = BuiltInBuilder::callable(realm, Self::get_offset_nanoseconds)
+        let get_offset_nanos = BuiltInBuilder::callable(realm, Self::get_offset_nanoseconds, mc)
             .name(js_string!("get offsetNanoseconds"))
             .build();
 
-        let get_offset = BuiltInBuilder::callable(realm, Self::get_offset)
+        let get_offset = BuiltInBuilder::callable(realm, Self::get_offset, mc)
             .name(js_string!("get offset"))
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, mc)
             .property(
                 JsSymbol::to_string_tag(),
                 StaticJsStrings::ZONED_DT_TAG,
@@ -1214,7 +1216,8 @@ impl ZonedDateTime {
         )?;
 
         // 19. Let resolvedOptions be ? GetOptionsObject(options).
-        let resolved_options = get_options_object(args.get_or_undefined(1))?;
+        let resolved_options =
+            get_options_object(args.get_or_undefined(1), context.gc_collector())?;
         // 20. Let disambiguation be ? GetTemporalDisambiguationOption(resolvedOptions).
         let disambiguation =
             get_option::<Disambiguation>(&resolved_options, js_string!("disambiguation"), context)?;
@@ -1345,7 +1348,7 @@ impl ZonedDateTime {
 
         let duration = to_temporal_duration(args.get_or_undefined(0), context)?;
 
-        let options = get_options_object(args.get_or_undefined(1))?;
+        let options = get_options_object(args.get_or_undefined(1), context.gc_collector())?;
         let overflow = get_option::<Overflow>(&options, js_string!("overflow"), context)?;
 
         let result =
@@ -1376,7 +1379,7 @@ impl ZonedDateTime {
 
         let duration = to_temporal_duration(args.get_or_undefined(0), context)?;
 
-        let options = get_options_object(args.get_or_undefined(1))?;
+        let options = get_options_object(args.get_or_undefined(1), context.gc_collector())?;
         let overflow = get_option::<Overflow>(&options, js_string!("overflow"), context)?;
 
         let result =
@@ -1407,7 +1410,7 @@ impl ZonedDateTime {
 
         let other = to_temporal_zoneddatetime(args.get_or_undefined(0), None, context)?;
 
-        let options = get_options_object(args.get_or_undefined(1))?;
+        let options = get_options_object(args.get_or_undefined(1), context.gc_collector())?;
         let settings = get_difference_settings(&options, context)?;
 
         let result =
@@ -1438,7 +1441,7 @@ impl ZonedDateTime {
 
         let other = to_temporal_zoneddatetime(args.get_or_undefined(0), None, context)?;
 
-        let options = get_options_object(args.get_or_undefined(1))?;
+        let options = get_options_object(args.get_or_undefined(1), context.gc_collector())?;
         let settings = get_difference_settings(&options, context)?;
 
         let result =
@@ -1482,7 +1485,7 @@ impl ZonedDateTime {
             // a. Let paramString be roundTo.
             let param_string = param_string.clone();
             // b. Set roundTo to OrdinaryObjectCreate(null).
-            let new_round_to = JsObject::with_null_proto();
+            let new_round_to = JsObject::with_null_proto(context.gc_collector());
             // c. Perform ! CreateDataPropertyOrThrow(roundTo, "smallestUnit", paramString).
             new_round_to.create_data_property_or_throw(
                 js_string!("smallestUnit"),
@@ -1493,7 +1496,7 @@ impl ZonedDateTime {
         } else {
             // 5. Else,
             // a. Set roundTo to ? GetOptionsObject(roundTo).
-            get_options_object(round_to_arg)?
+            get_options_object(round_to_arg, context.gc_collector())?
         };
 
         // 6. NOTE: The following steps read options and perform independent validation
@@ -1571,7 +1574,7 @@ impl ZonedDateTime {
                 JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
             })?;
 
-        let options = get_options_object(args.get_or_undefined(0))?;
+        let options = get_options_object(args.get_or_undefined(0), context.gc_collector())?;
 
         let show_calendar =
             get_option::<DisplayCalendar>(&options, js_string!("calendarName"), context)?
@@ -1741,7 +1744,7 @@ impl ZonedDateTime {
         let options_obj = if let Some(param_str) = direction_param.as_string() {
             // a. Let paramString be directionParam.
             // b. Set directionParam to OrdinaryObjectCreate(null).
-            let obj = JsObject::with_null_proto();
+            let obj = JsObject::with_null_proto(context.gc_collector());
             // c. Perform ! CreateDataPropertyOrThrow(directionParam, "direction", paramString).
             obj.create_data_property_or_throw(
                 js_string!("direction"),
@@ -1752,7 +1755,7 @@ impl ZonedDateTime {
         // 6. Else,
         } else {
             // a. Set directionParam to ? GetOptionsObject(directionParam).
-            get_options_object(direction_param)?
+            get_options_object(direction_param, context.gc_collector())?
         };
 
         // TODO: step 7
@@ -1902,7 +1905,8 @@ pub(crate) fn create_temporal_zoneddatetime(
     // 4. Set object.[[EpochNanoseconds]] to epochNanoseconds.
     // 5. Set object.[[TimeZone]] to timeZone.
     // 6. Set object.[[Calendar]] to calendar.
-    let obj = JsObject::from_proto_and_data(prototype, ZonedDateTime::new(inner));
+    let obj =
+        JsObject::from_proto_and_data(context.gc_collector(), prototype, ZonedDateTime::new(inner));
 
     // 7. Return object.
     Ok(obj)
@@ -1927,7 +1931,10 @@ pub(crate) fn to_temporal_zoneddatetime(
                 // (GetTemporalDisambiguationOption reads "disambiguation", GetTemporalOffsetOption
                 // reads "offset", and GetTemporalOverflowOption reads "overflow").
                 // ii. Let resolvedOptions be ? GetOptionsObject(options).
-                let options = get_options_object(options.unwrap_or(&JsValue::undefined()))?;
+                let options = get_options_object(
+                    options.unwrap_or(&JsValue::undefined()),
+                    context.gc_collector(),
+                )?;
                 // iii. Perform ? GetTemporalDisambiguationOption(resolvedOptions).
                 let _disambiguation =
                     get_option::<Disambiguation>(&options, js_string!("disambiguation"), context)?
@@ -1946,7 +1953,10 @@ pub(crate) fn to_temporal_zoneddatetime(
             // f. If offsetString is unset, the
             // i. Set offsetBehaviour to wall.
             // g. Let resolvedOptions be ? GetOptionsObject(options).
-            let options = get_options_object(options.unwrap_or(&JsValue::undefined()))?;
+            let options = get_options_object(
+                options.unwrap_or(&JsValue::undefined()),
+                context.gc_collector(),
+            )?;
             // h. Let disambiguation be ? GetTemporalDisambiguationOption(resolvedOptions).
             let disambiguation =
                 get_option::<Disambiguation>(&options, js_string!("disambiguation"), context)?;
@@ -1985,7 +1995,10 @@ pub(crate) fn to_temporal_zoneddatetime(
             // k. Set calendar to ? CanonicalizeCalendar(calendar).
             // l. Set matchBehaviour to match-minutes.
             // m. Let resolvedOptions be ? GetOptionsObject(options).
-            let options = get_options_object(options.unwrap_or(&JsValue::undefined()))?;
+            let options = get_options_object(
+                options.unwrap_or(&JsValue::undefined()),
+                context.gc_collector(),
+            )?;
             // n. Let disambiguation be ? GetTemporalDisambiguationOption(resolvedOptions).
             let disambiguation =
                 get_option::<Disambiguation>(&options, js_string!("disambiguation"), context)?

--- a/core/engine/src/builtins/typed_array/builtin.rs
+++ b/core/engine/src/builtins/typed_array/builtin.rs
@@ -35,37 +35,37 @@ use crate::{builtins::array_buffer::utils::memmove_naive, value::JsVariant};
 pub(crate) struct BuiltinTypedArray;
 
 impl IntrinsicObject for BuiltinTypedArray {
-    fn init(realm: &Realm) {
-        let get_species = BuiltInBuilder::callable(realm, Self::get_species)
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
+        let get_species = BuiltInBuilder::callable(realm, Self::get_species, mc)
             .name(js_string!("get [Symbol.species]"))
             .build();
 
-        let get_buffer = BuiltInBuilder::callable(realm, Self::buffer)
+        let get_buffer = BuiltInBuilder::callable(realm, Self::buffer, mc)
             .name(js_string!("get buffer"))
             .build();
 
-        let get_byte_length = BuiltInBuilder::callable(realm, Self::byte_length)
+        let get_byte_length = BuiltInBuilder::callable(realm, Self::byte_length, mc)
             .name(js_string!("get byteLength"))
             .build();
 
-        let get_byte_offset = BuiltInBuilder::callable(realm, Self::byte_offset)
+        let get_byte_offset = BuiltInBuilder::callable(realm, Self::byte_offset, mc)
             .name(js_string!("get byteOffset"))
             .build();
 
-        let get_length = BuiltInBuilder::callable(realm, Self::length)
+        let get_length = BuiltInBuilder::callable(realm, Self::length, mc)
             .name(js_string!("get length"))
             .build();
 
-        let get_to_string_tag = BuiltInBuilder::callable(realm, Self::to_string_tag)
+        let get_to_string_tag = BuiltInBuilder::callable(realm, Self::to_string_tag, mc)
             .name(js_string!("get [Symbol.toStringTag]"))
             .build();
 
-        let values_function = BuiltInBuilder::callable(realm, Self::values)
+        let values_function = BuiltInBuilder::callable(realm, Self::values, mc)
             .name(js_string!("values"))
             .length(0)
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, mc)
             .static_accessor(
                 JsSymbol::species(),
                 Some(get_species),
@@ -2815,8 +2815,13 @@ impl BuiltinTypedArray {
         let len = values.len() as u64;
         // 2. Perform ? AllocateTypedArrayBuffer(O, len).
         let buf = Self::allocate_buffer::<T>(len, context)?;
-        let obj = JsObject::from_proto_and_data_with_shared_shape(context.root_shape(), proto, buf)
-            .upcast();
+        let obj = JsObject::from_proto_and_data_with_shared_shape(
+            context.gc_collector(),
+            context.root_shape(),
+            proto,
+            buf,
+        )
+        .upcast();
 
         // 3. Let k be 0.
         // 4. Repeat, while k < len,
@@ -2865,9 +2870,13 @@ impl BuiltinTypedArray {
         let indexed = Self::allocate_buffer::<T>(length, context)?;
 
         // 2. Let obj be ! IntegerIndexedObjectCreate(proto).
-        let obj =
-            JsObject::from_proto_and_data_with_shared_shape(context.root_shape(), proto, indexed)
-                .upcast();
+        let obj = JsObject::from_proto_and_data_with_shared_shape(
+            context.gc_collector(),
+            context.root_shape(),
+            proto,
+            indexed,
+        )
+        .upcast();
 
         // 9. Return obj.
         Ok(obj)
@@ -3008,6 +3017,7 @@ impl BuiltinTypedArray {
         // 15. Set O.[[ByteOffset]] to 0.
         // 16. Set O.[[ArrayLength]] to elementLength.
         let obj = JsObject::from_proto_and_data_with_shared_shape(
+            context.gc_collector(),
             context.root_shape(),
             proto,
             TypedArray::new(
@@ -3128,6 +3138,7 @@ impl BuiltinTypedArray {
         // 11. Set O.[[ByteOffset]] to offset.
         // 12. Return unused.
         Ok(JsObject::from_proto_and_data_with_shared_shape(
+            context.gc_collector(),
             context.root_shape(),
             proto,
             TypedArray::new(buffer, T::ERASED, offset, byte_length, array_length),
@@ -3151,8 +3162,13 @@ impl BuiltinTypedArray {
 
         // 2. Perform ? AllocateTypedArrayBuffer(O, len).
         let buf = Self::allocate_buffer::<T>(len, context)?;
-        let obj = JsObject::from_proto_and_data_with_shared_shape(context.root_shape(), proto, buf)
-            .upcast();
+        let obj = JsObject::from_proto_and_data_with_shared_shape(
+            context.gc_collector(),
+            context.root_shape(),
+            proto,
+            buf,
+        )
+        .upcast();
 
         // 3. Let k be 0.
         // 4. Repeat, while k < len,

--- a/core/engine/src/builtins/typed_array/mod.rs
+++ b/core/engine/src/builtins/typed_array/mod.rs
@@ -47,12 +47,12 @@ impl<T: TypedArrayMarker> IntrinsicObject for T {
         Self::STANDARD_CONSTRUCTOR(intrinsics.constructors()).constructor()
     }
 
-    fn init(realm: &Realm) {
-        let get_species = BuiltInBuilder::callable(realm, BuiltinTypedArray::get_species)
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
+        let get_species = BuiltInBuilder::callable(realm, BuiltinTypedArray::get_species, mc)
             .name(js_string!("get [Symbol.species]"))
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, mc)
             .prototype(
                 realm
                     .intrinsics()

--- a/core/engine/src/builtins/uri/mod.rs
+++ b/core/engine/src/builtins/uri/mod.rs
@@ -88,8 +88,8 @@ impl UriFunctions {
 pub(crate) struct DecodeUri;
 
 impl IntrinsicObject for DecodeUri {
-    fn init(realm: &Realm) {
-        BuiltInBuilder::callable_with_intrinsic::<Self>(realm, decode_uri)
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
+        BuiltInBuilder::callable_with_intrinsic::<Self>(realm, decode_uri, mc)
             .name(Self::NAME)
             .length(1)
             .build();
@@ -106,8 +106,8 @@ impl BuiltInObject for DecodeUri {
 pub(crate) struct DecodeUriComponent;
 
 impl IntrinsicObject for DecodeUriComponent {
-    fn init(realm: &Realm) {
-        BuiltInBuilder::callable_with_intrinsic::<Self>(realm, decode_uri_component)
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
+        BuiltInBuilder::callable_with_intrinsic::<Self>(realm, decode_uri_component, mc)
             .name(Self::NAME)
             .length(1)
             .build();
@@ -128,8 +128,8 @@ impl BuiltInObject for DecodeUriComponent {
 pub(crate) struct EncodeUri;
 
 impl IntrinsicObject for EncodeUri {
-    fn init(realm: &Realm) {
-        BuiltInBuilder::callable_with_intrinsic::<Self>(realm, encode_uri)
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
+        BuiltInBuilder::callable_with_intrinsic::<Self>(realm, encode_uri, mc)
             .name(Self::NAME)
             .length(1)
             .build();
@@ -145,8 +145,8 @@ impl BuiltInObject for EncodeUri {
 pub(crate) struct EncodeUriComponent;
 
 impl IntrinsicObject for EncodeUriComponent {
-    fn init(realm: &Realm) {
-        BuiltInBuilder::callable_with_intrinsic::<Self>(realm, encode_uri_component)
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
+        BuiltInBuilder::callable_with_intrinsic::<Self>(realm, encode_uri_component, mc)
             .name(Self::NAME)
             .length(1)
             .build();

--- a/core/engine/src/builtins/weak/weak_ref.rs
+++ b/core/engine/src/builtins/weak/weak_ref.rs
@@ -30,8 +30,8 @@ impl IntrinsicObject for WeakRef {
         Self::STANDARD_CONSTRUCTOR(intrinsics.constructors()).constructor()
     }
 
-    fn init(realm: &Realm) {
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, mc)
             .property(
                 JsSymbol::to_string_tag(),
                 js_string!("WeakRef"),
@@ -85,6 +85,7 @@ impl BuiltInConstructor for WeakRef {
         let prototype =
             get_prototype_from_constructor(new_target, StandardConstructors::weak_ref, context)?;
         let weak_ref = JsObject::from_proto_and_data_with_shared_shape(
+            context.gc_collector(),
             context.root_shape(),
             prototype,
             WeakGc::new(context.gc_collector(), target.inner()),

--- a/core/engine/src/builtins/weak_map/mod.rs
+++ b/core/engine/src/builtins/weak_map/mod.rs
@@ -36,8 +36,8 @@ impl IntrinsicObject for WeakMap {
         Self::STANDARD_CONSTRUCTOR(intrinsics.constructors()).constructor()
     }
 
-    fn init(realm: &Realm) {
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, mc)
             .property(
                 JsSymbol::to_string_tag(),
                 Self::NAME,
@@ -95,6 +95,7 @@ impl BuiltInConstructor for WeakMap {
         let prototype =
             get_prototype_from_constructor(new_target, StandardConstructors::weak_map, context)?;
         let map = JsObject::from_proto_and_data_with_shared_shape(
+            context.gc_collector(),
             context.root_shape(),
             prototype,
             NativeWeakMap::new(context.gc_collector()),

--- a/core/engine/src/builtins/weak_set/mod.rs
+++ b/core/engine/src/builtins/weak_set/mod.rs
@@ -32,8 +32,8 @@ impl IntrinsicObject for WeakSet {
         Self::STANDARD_CONSTRUCTOR(intrinsics.constructors()).constructor()
     }
 
-    fn init(realm: &Realm) {
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+    fn init(realm: &Realm, mc: &boa_gc::MutationContext<'static, '_>) {
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, mc)
             .property(
                 JsSymbol::to_string_tag(),
                 Self::NAME,
@@ -84,6 +84,7 @@ impl BuiltInConstructor for WeakSet {
         let prototype =
             get_prototype_from_constructor(new_target, StandardConstructors::weak_set, context)?;
         let weak_set = JsObject::from_proto_and_data_with_shared_shape(
+            context.gc_collector(),
             context.root_shape(),
             prototype,
             NativeWeakSet::new(context.gc_collector()),

--- a/core/engine/src/class.rs
+++ b/core/engine/src/class.rs
@@ -196,8 +196,12 @@ pub trait Class: NativeObject + Sized {
 
         let data = Self::data_constructor(new_target, args, context)?;
 
-        let object =
-            JsObject::from_proto_and_data_with_shared_shape(context.root_shape(), prototype, data);
+        let object = JsObject::from_proto_and_data_with_shared_shape(
+            context.gc_collector(),
+            context.root_shape(),
+            prototype,
+            data,
+        );
 
         Self::object_constructor(&object, args, context)?;
 
@@ -228,8 +232,12 @@ pub trait Class: NativeObject + Sized {
             })?
             .prototype();
 
-        let object =
-            JsObject::from_proto_and_data_with_shared_shape(context.root_shape(), prototype, data);
+        let object = JsObject::from_proto_and_data_with_shared_shape(
+            context.gc_collector(),
+            context.root_shape(),
+            prototype,
+            data,
+        );
 
         Self::object_constructor(&object, &[], context)?;
 

--- a/core/engine/src/context/hooks.rs
+++ b/core/engine/src/context/hooks.rs
@@ -169,8 +169,12 @@ pub trait HostHooks {
     /// Equivalent to the step 7 of [`InitializeHostDefinedRealm ( )`][ihdr].
     ///
     /// [ihdr]: https://tc39.es/ecma262/#sec-initializehostdefinedrealm
-    fn create_global_object(&self, intrinsics: &Intrinsics) -> JsObject {
-        JsObject::with_object_proto(intrinsics)
+    fn create_global_object(
+        &self,
+        mc: &boa_gc::MutationContext<'static, '_>,
+        intrinsics: &Intrinsics,
+    ) -> JsObject {
+        JsObject::with_object_proto(mc, intrinsics)
     }
 
     /// Creates the global `this` of a new [`Context`] from the initial intrinsics.

--- a/core/engine/src/context/intrinsics.rs
+++ b/core/engine/src/context/intrinsics.rs
@@ -79,19 +79,12 @@ pub struct StandardConstructor {
     prototype: JsObject,
 }
 
-impl Default for StandardConstructor {
-    fn default() -> Self {
-        // SAFETY: The global mutation context is used as a fallback during the context threading migration.
-        Self::uninit(&unsafe { boa_gc::MutationContext::global() })
-    }
-}
-
 impl StandardConstructor {
     /// Creates a new uninitialized `StandardConstructor` using the given context.
     pub(crate) fn uninit(mc: &boa_gc::MutationContext<'static, '_>) -> Self {
         Self {
             constructor: JsFunction::empty_intrinsic_function_in(mc, true),
-            prototype: JsObject::with_null_proto_in(mc),
+            prototype: JsObject::with_null_proto(mc),
         }
     }
     /// Creates a new `StandardConstructor` from the constructor and the prototype.
@@ -103,7 +96,7 @@ impl StandardConstructor {
     }
 
     /// Build a constructor with a defined prototype, using the given context.
-    fn with_prototype_in(mc: &boa_gc::MutationContext<'static, '_>, prototype: JsObject) -> Self {
+    fn with_prototype(mc: &boa_gc::MutationContext<'static, '_>, prototype: JsObject) -> Self {
         Self {
             constructor: JsFunction::empty_intrinsic_function_in(mc, true),
             prototype,
@@ -111,10 +104,6 @@ impl StandardConstructor {
     }
 
     /// Build a constructor with a defined prototype.
-    fn with_prototype(prototype: JsObject) -> Self {
-        // SAFETY: The global mutation context is used as a fallback during the context threading migration.
-        Self::with_prototype_in(&unsafe { boa_gc::MutationContext::global() }, prototype)
-    }
 
     /// Return the prototype of the constructor object.
     ///
@@ -223,9 +212,9 @@ pub struct StandardConstructors {
 impl StandardConstructors {
     pub(crate) fn uninit(mc: &boa_gc::MutationContext<'static, '_>) -> Self {
         Self {
-            object: StandardConstructor::with_prototype_in(
+            object: StandardConstructor::with_prototype(
                 mc,
-                JsObject::from_object_and_vtable_in(
+                JsObject::from_object_and_vtable(
                     mc,
                     Object::<OrdinaryObject>::default(),
                     &IMMUTABLE_PROTOTYPE_EXOTIC_INTERNAL_METHODS,
@@ -240,22 +229,22 @@ impl StandardConstructors {
             },
             async_function: StandardConstructor::uninit(mc),
             generator_function: StandardConstructor::uninit(mc),
-            array: StandardConstructor::with_prototype_in(
+            array: StandardConstructor::with_prototype(
                 mc,
-                JsObject::from_proto_and_data_in(mc, None, Array),
+                JsObject::from_proto_and_data(mc, None, Array),
             ),
             bigint: StandardConstructor::uninit(mc),
-            number: StandardConstructor::with_prototype_in(
+            number: StandardConstructor::with_prototype(
                 mc,
-                JsObject::from_proto_and_data_in(mc, None, 0.0),
+                JsObject::from_proto_and_data(mc, None, 0.0),
             ),
-            boolean: StandardConstructor::with_prototype_in(
+            boolean: StandardConstructor::with_prototype(
                 mc,
-                JsObject::from_proto_and_data_in(mc, None, false),
+                JsObject::from_proto_and_data(mc, None, false),
             ),
-            string: StandardConstructor::with_prototype_in(
+            string: StandardConstructor::with_prototype(
                 mc,
-                JsObject::from_proto_and_data_in(mc, None, js_string!()),
+                JsObject::from_proto_and_data(mc, None, js_string!()),
             ),
             regexp: StandardConstructor::uninit(mc),
             symbol: StandardConstructor::uninit(mc),
@@ -1191,16 +1180,16 @@ impl IntrinsicObjects {
     #[allow(clippy::unnecessary_wraps)]
     pub(crate) fn uninit(mc: &boa_gc::MutationContext<'static, '_>) -> Option<Self> {
         Some(Self {
-            reflect: JsObject::with_null_proto_in(mc),
-            math: JsObject::with_null_proto_in(mc),
-            json: JsObject::with_null_proto_in(mc),
+            reflect: JsObject::with_null_proto(mc),
+            math: JsObject::with_null_proto(mc),
+            json: JsObject::with_null_proto(mc),
             throw_type_error: JsFunction::empty_intrinsic_function_in(mc, false),
             array_prototype_values: JsFunction::empty_intrinsic_function_in(mc, false),
             array_prototype_to_string: JsFunction::empty_intrinsic_function_in(mc, false),
             iterator_prototypes: IteratorPrototypes::uninit_in(mc),
-            generator: JsObject::with_null_proto_in(mc),
-            async_generator: JsObject::with_null_proto_in(mc),
-            atomics: JsObject::with_null_proto_in(mc),
+            generator: JsObject::with_null_proto(mc),
+            async_generator: JsObject::with_null_proto(mc),
+            atomics: JsObject::with_null_proto(mc),
             eval: JsFunction::empty_intrinsic_function_in(mc, false),
             uri_functions: UriFunctions::uninit_in(mc),
             is_finite: JsFunction::empty_intrinsic_function_in(mc, false),
@@ -1212,13 +1201,13 @@ impl IntrinsicObjects {
             #[cfg(feature = "annex-b")]
             unescape: JsFunction::empty_intrinsic_function_in(mc, false),
             #[cfg(feature = "intl")]
-            intl: JsObject::new_unique(None, Intl::new()?),
+            intl: JsObject::new_unique(mc, None, Intl::new()?),
             #[cfg(feature = "intl")]
-            segments_prototype: JsObject::with_null_proto(),
+            segments_prototype: JsObject::with_null_proto(mc),
             #[cfg(feature = "temporal")]
-            temporal: JsObject::with_null_proto(),
+            temporal: JsObject::with_null_proto(mc),
             #[cfg(feature = "temporal")]
-            now: JsObject::with_null_proto(),
+            now: JsObject::with_null_proto(mc),
         })
     }
 
@@ -1468,46 +1457,46 @@ impl ObjectTemplates {
 
         // pre-initialize used shapes.
         let ordinary_object =
-            ObjectTemplate::with_prototype_in(mc, root_shape, constructors.object().prototype());
+            ObjectTemplate::with_prototype(mc, root_shape, constructors.object().prototype());
         let mut array = ObjectTemplate::new(root_shape);
         let length_property_key: PropertyKey = js_string!("length").into();
-        array.property_in(
+        array.property(
             mc,
             length_property_key.clone(),
             Attribute::WRITABLE | Attribute::PERMANENT | Attribute::NON_ENUMERABLE,
         );
-        array.set_prototype_in(mc, constructors.array().prototype());
+        array.set_prototype(mc, constructors.array().prototype());
 
         let number =
-            ObjectTemplate::with_prototype_in(mc, root_shape, constructors.number().prototype());
+            ObjectTemplate::with_prototype(mc, root_shape, constructors.number().prototype());
         let symbol =
-            ObjectTemplate::with_prototype_in(mc, root_shape, constructors.symbol().prototype());
+            ObjectTemplate::with_prototype(mc, root_shape, constructors.symbol().prototype());
         let bigint =
-            ObjectTemplate::with_prototype_in(mc, root_shape, constructors.bigint().prototype());
+            ObjectTemplate::with_prototype(mc, root_shape, constructors.bigint().prototype());
         let boolean =
-            ObjectTemplate::with_prototype_in(mc, root_shape, constructors.boolean().prototype());
+            ObjectTemplate::with_prototype(mc, root_shape, constructors.boolean().prototype());
         let mut string = ObjectTemplate::new(root_shape);
-        string.property_in(
+        string.property(
             mc,
             length_property_key.clone(),
             Attribute::READONLY | Attribute::PERMANENT | Attribute::NON_ENUMERABLE,
         );
-        string.set_prototype_in(mc, constructors.string().prototype());
+        string.set_prototype(mc, constructors.string().prototype());
 
         let mut regexp_without_proto = ObjectTemplate::new(root_shape);
-        regexp_without_proto.property_in(mc, js_string!("lastIndex").into(), Attribute::WRITABLE);
+        regexp_without_proto.property(mc, js_string!("lastIndex").into(), Attribute::WRITABLE);
 
         let mut regexp = regexp_without_proto.clone();
-        regexp.set_prototype_in(mc, constructors.regexp().prototype());
+        regexp.set_prototype(mc, constructors.regexp().prototype());
 
         let name_property_key: PropertyKey = js_string!("name").into();
         let mut function = ObjectTemplate::new(root_shape);
-        function.property_in(
+        function.property(
             mc,
             length_property_key.clone(),
             Attribute::READONLY | Attribute::CONFIGURABLE | Attribute::NON_ENUMERABLE,
         );
-        function.property_in(
+        function.property(
             mc,
             name_property_key,
             Attribute::READONLY | Attribute::CONFIGURABLE | Attribute::NON_ENUMERABLE,
@@ -1517,7 +1506,7 @@ impl ObjectTemplates {
         let mut async_function = function.clone();
         let mut function_with_prototype = function.clone();
 
-        function_with_prototype.property_in(
+        function_with_prototype.property(
             mc,
             PROTOTYPE.into(),
             Attribute::WRITABLE | Attribute::PERMANENT | Attribute::NON_ENUMERABLE,
@@ -1527,15 +1516,15 @@ impl ObjectTemplates {
 
         let function_with_prototype_without_proto = function_with_prototype.clone();
 
-        function.set_prototype_in(mc, constructors.function().prototype());
-        function_with_prototype.set_prototype_in(mc, constructors.function().prototype());
-        async_function.set_prototype_in(mc, constructors.async_function().prototype());
-        generator_function.set_prototype_in(mc, constructors.generator_function().prototype());
+        function.set_prototype(mc, constructors.function().prototype());
+        function_with_prototype.set_prototype(mc, constructors.function().prototype());
+        async_function.set_prototype(mc, constructors.async_function().prototype());
+        generator_function.set_prototype(mc, constructors.generator_function().prototype());
         async_generator_function
-            .set_prototype_in(mc, constructors.async_generator_function().prototype());
+            .set_prototype(mc, constructors.async_generator_function().prototype());
 
         let mut function_prototype = ordinary_object.clone();
-        function_prototype.property_in(
+        function_prototype.property(
             mc,
             CONSTRUCTOR.into(),
             Attribute::WRITABLE | Attribute::CONFIGURABLE | Attribute::NON_ENUMERABLE,
@@ -1545,7 +1534,7 @@ impl ObjectTemplates {
 
         // 4. Perform DefinePropertyOrThrow(obj, "length", PropertyDescriptor { [[Value]]: 𝔽(len),
         // [[Writable]]: true, [[Enumerable]]: false, [[Configurable]]: true }).
-        unmapped_arguments.property_in(
+        unmapped_arguments.property(
             mc,
             length_property_key,
             Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE,
@@ -1554,7 +1543,7 @@ impl ObjectTemplates {
         // 7. Perform ! DefinePropertyOrThrow(obj, @@iterator, PropertyDescriptor {
         // [[Value]]: %Array.prototype.values%, [[Writable]]: true, [[Enumerable]]: false,
         // [[Configurable]]: true }).
-        unmapped_arguments.property_in(
+        unmapped_arguments.property(
             mc,
             JsSymbol::iterator().into(),
             Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE,
@@ -1565,7 +1554,7 @@ impl ObjectTemplates {
         // 8. Perform ! DefinePropertyOrThrow(obj, "callee", PropertyDescriptor {
         // [[Get]]: %ThrowTypeError%, [[Set]]: %ThrowTypeError%, [[Enumerable]]: false,
         // [[Configurable]]: false }).
-        unmapped_arguments.accessor_in(
+        unmapped_arguments.accessor(
             mc,
             js_string!("callee").into(),
             true,
@@ -1575,37 +1564,37 @@ impl ObjectTemplates {
 
         // 21. Perform ! DefinePropertyOrThrow(obj, "callee", PropertyDescriptor {
         // [[Value]]: func, [[Writable]]: true, [[Enumerable]]: false, [[Configurable]]: true }).
-        mapped_arguments.property_in(
+        mapped_arguments.property(
             mc,
             js_string!("callee").into(),
             Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE,
         );
 
         let mut iterator_result = ordinary_object.clone();
-        iterator_result.property_in(
+        iterator_result.property(
             mc,
             js_string!("value").into(),
             Attribute::WRITABLE | Attribute::CONFIGURABLE | Attribute::ENUMERABLE,
         );
-        iterator_result.property_in(
+        iterator_result.property(
             mc,
             js_string!("done").into(),
             Attribute::WRITABLE | Attribute::CONFIGURABLE | Attribute::ENUMERABLE,
         );
 
         let mut namespace = ObjectTemplate::new(root_shape);
-        namespace.property_in(mc, JsSymbol::to_string_tag().into(), Attribute::empty());
+        namespace.property(mc, JsSymbol::to_string_tag().into(), Attribute::empty());
 
         let with_resolvers = {
             let mut with_resolvers = ordinary_object.clone();
 
             with_resolvers
                 // 4. Perform ! CreateDataPropertyOrThrow(obj, "promise", promiseCapability.[[Promise]]).
-                .property_in(mc, js_string!("promise").into(), Attribute::all())
+                .property(mc, js_string!("promise").into(), Attribute::all())
                 // 5. Perform ! CreateDataPropertyOrThrow(obj, "resolve", promiseCapability.[[Resolve]]).
-                .property_in(mc, js_string!("resolve").into(), Attribute::all())
+                .property(mc, js_string!("resolve").into(), Attribute::all())
                 // 6. Perform ! CreateDataPropertyOrThrow(obj, "reject", promiseCapability.[[Reject]]).
-                .property_in(mc, js_string!("reject").into(), Attribute::all());
+                .property(mc, js_string!("reject").into(), Attribute::all());
 
             with_resolvers
         };
@@ -1613,8 +1602,8 @@ impl ObjectTemplates {
         let wait_async = {
             let mut obj = ordinary_object.clone();
 
-            obj.property_in(mc, js_string!("async").into(), Attribute::all())
-                .property_in(mc, js_string!("value").into(), Attribute::all());
+            obj.property(mc, js_string!("async").into(), Attribute::all())
+                .property(mc, js_string!("value").into(), Attribute::all());
 
             obj
         };

--- a/core/engine/src/context/mod.rs
+++ b/core/engine/src/context/mod.rs
@@ -548,9 +548,11 @@ impl Context {
 
     /// Create a new Realm with the default global bindings.
     pub fn create_realm(&mut self) -> JsResult<Realm> {
-        let realm = Realm::create(self.host_hooks.as_ref(), &self.root_shape, &unsafe {
-            boa_gc::MutationContext::global()
-        })?;
+        let realm = Realm::create(
+            self.host_hooks.as_ref(),
+            &self.root_shape,
+            self.gc_collector(),
+        )?;
 
         let old_realm = self.enter_realm(realm);
 

--- a/core/engine/src/context/mod.rs
+++ b/core/engine/src/context/mod.rs
@@ -291,7 +291,7 @@ impl Context {
         length: usize,
         body: NativeFunction,
     ) -> JsResult<()> {
-        let function = FunctionObjectBuilder::new(self.realm(), body)
+        let function = FunctionObjectBuilder::new(self.realm(), self.gc_collector(), body)
             .name(name.clone())
             .length(length)
             .constructor(true)
@@ -324,7 +324,7 @@ impl Context {
         length: usize,
         body: NativeFunction,
     ) -> JsResult<()> {
-        let function = FunctionObjectBuilder::new(self.realm(), body)
+        let function = FunctionObjectBuilder::new(self.realm(), self.gc_collector(), body)
             .name(name.clone())
             .length(length)
             .constructor(false)
@@ -1226,7 +1226,7 @@ impl ContextBuilder {
 
         // SAFETY: The global mutation context is used as a fallback during the context threading migration.
         let mc = unsafe { boa_gc::MutationContext::global() };
-        let root_shape = RootShape::new_in(&mc);
+        let root_shape = RootShape::new(&mc);
 
         let host_hooks = self.host_hooks.unwrap_or(Rc::new(DefaultHooks));
         let clock = self.clock.unwrap_or_else(|| Rc::new(StdClock::new()));

--- a/core/engine/src/environments/runtime/mod.rs
+++ b/core/engine/src/environments/runtime/mod.rs
@@ -223,7 +223,7 @@ impl EnvironmentStack {
         let index = self.depth;
 
         self.push_env(Environment::Declarative(Gc::new(
-            &gc,
+            gc,
             DeclarativeEnvironment::new(
                 DeclarativeEnvironmentKind::Lexical(LexicalEnvironment::new(bindings_count)),
                 poisoned,

--- a/core/engine/src/error/mod.rs
+++ b/core/engine/src/error/mod.rs
@@ -1346,6 +1346,7 @@ impl JsNativeError {
         };
 
         let o = JsObject::from_proto_and_data_with_shared_shape(
+            context.gc_collector(),
             context.root_shape(),
             prototype,
             Error::with_stack(tag, stack.0.clone()),

--- a/core/engine/src/module/mod.rs
+++ b/core/engine/src/module/mod.rs
@@ -658,7 +658,7 @@ impl Module {
                         },
                         self.clone(),
                     )
-                    .to_js_function(context.realm()),
+                    .to_js_function(context.realm(), context.gc_collector()),
                 ),
                 None,
                 context,
@@ -670,7 +670,7 @@ impl Module {
                         |_, _, module, context| Ok(module.evaluate(context)?.into()),
                         self.clone(),
                     )
-                    .to_js_function(context.realm()),
+                    .to_js_function(context.realm(), context.gc_collector()),
                 ),
                 None,
                 context,
@@ -784,8 +784,12 @@ impl<T: IntoIterator<Item = (JsString, NativeFunction)> + Clone> IntoJsModule fo
             unsafe {
                 SyntheticModuleInitializer::from_closure(move |module, context| {
                     for (name, f) in names.iter().zip(fns.iter()) {
-                        module
-                            .set_export(name, f.clone().to_js_function(context.realm()).into())?;
+                        module.set_export(
+                            name,
+                            f.clone()
+                                .to_js_function(context.realm(), context.gc_collector())
+                                .into(),
+                        )?;
                     }
                     Ok(())
                 })

--- a/core/engine/src/module/namespace.rs
+++ b/core/engine/src/module/namespace.rs
@@ -100,6 +100,7 @@ impl ModuleNamespace {
 
         // 10. Return M.
         context.intrinsics().templates().namespace().create(
+            context.gc_collector(),
             Self {
                 module,
                 exports,

--- a/core/engine/src/module/source.rs
+++ b/core/engine/src/module/source.rs
@@ -1657,7 +1657,7 @@ impl SourceTextModule {
             self.code.has_tla,
             false,
             context.interner_mut(),
-            &mc,
+            mc,
             false,
             spanned_source_text,
             self.code.path.clone().into(),

--- a/core/engine/src/module/source.rs
+++ b/core/engine/src/module/source.rs
@@ -1477,6 +1477,7 @@ impl SourceTextModule {
         // 5. Let onFulfilled be CreateBuiltinFunction(fulfilledClosure, 0, "", « »).
         let on_fulfilled = FunctionObjectBuilder::new(
             context.realm(),
+            context.gc_collector(),
             NativeFunction::from_copy_closure_with_captures(
                 |_, _, module, context| {
                     //     a. Perform AsyncModuleExecutionFulfilled(module).
@@ -1493,6 +1494,7 @@ impl SourceTextModule {
         // 7. Let onRejected be CreateBuiltinFunction(rejectedClosure, 0, "", « »).
         let on_rejected = FunctionObjectBuilder::new(
             context.realm(),
+            context.gc_collector(),
             NativeFunction::from_copy_closure_with_captures(
                 |_, args, module, context| {
                     let error = JsError::from_opaque(args.get_or_undefined(0).clone());

--- a/core/engine/src/module/synthetic.rs
+++ b/core/engine/src/module/synthetic.rs
@@ -322,7 +322,7 @@ impl SyntheticModule {
             false,
             false,
             context.interner_mut(),
-            &mc,
+            mc,
             false,
             // A synthetic module does not contain `SourceText`
             SpannedSourceText::new_empty(),

--- a/core/engine/src/native_function/mod.rs
+++ b/core/engine/src/native_function/mod.rs
@@ -312,8 +312,12 @@ impl NativeFunction {
     ///
     /// Useful to create functions that will only be used once, such as callbacks.
     #[must_use]
-    pub fn to_js_function(self, realm: &Realm) -> JsFunction {
-        FunctionObjectBuilder::new(realm, self).build()
+    pub fn to_js_function(
+        self,
+        realm: &Realm,
+        mc: &boa_gc::MutationContext<'static, '_>,
+    ) -> JsFunction {
+        FunctionObjectBuilder::new(realm, mc, self).build()
     }
 }
 
@@ -443,6 +447,7 @@ fn native_function_construct(
                         context,
                     )?;
                     Ok(JsObject::from_proto_and_data_with_shared_shape(
+                        context.gc_collector(),
                         context.root_shape(),
                         prototype,
                         OrdinaryObject,

--- a/core/engine/src/object/builtins/jsarraybuffer.rs
+++ b/core/engine/src/object/builtins/jsarraybuffer.rs
@@ -124,6 +124,7 @@ impl JsArrayBuffer {
         // 3. Set obj.[[ArrayBufferData]] to block.
         // 4. Set obj.[[ArrayBufferByteLength]] to byteLength.
         let obj = JsObject::new(
+            context.gc_collector(),
             context.root_shape(),
             prototype,
             ArrayBuffer::from_data(block, JsValue::undefined()),

--- a/core/engine/src/object/builtins/jsdataview.rs
+++ b/core/engine/src/object/builtins/jsdataview.rs
@@ -135,6 +135,7 @@ impl JsDataView {
         }
 
         let obj = JsObject::new(
+            context.gc_collector(),
             context.root_shape(),
             prototype,
             DataView {

--- a/core/engine/src/object/builtins/jsdate.rs
+++ b/core/engine/src/object/builtins/jsdate.rs
@@ -45,9 +45,13 @@ impl JsDate {
     pub fn new(context: &mut Context) -> Self {
         let prototype = context.intrinsics().constructors().date().prototype();
         let now = Date::utc_now(context);
-        let inner =
-            JsObject::from_proto_and_data_with_shared_shape(context.root_shape(), prototype, now)
-                .upcast();
+        let inner = JsObject::from_proto_and_data_with_shared_shape(
+            context.gc_collector(),
+            context.root_shape(),
+            prototype,
+            now,
+        )
+        .upcast();
 
         Self { inner }
     }
@@ -552,6 +556,7 @@ impl JsDate {
 
         Ok(Self {
             inner: JsObject::from_proto_and_data_with_shared_shape(
+                context.gc_collector(),
                 context.root_shape(),
                 prototype,
                 date_time,

--- a/core/engine/src/object/builtins/jsfunction.rs
+++ b/core/engine/src/object/builtins/jsfunction.rs
@@ -128,7 +128,7 @@ impl JsFunction {
         constructor: bool,
     ) -> Self {
         Self {
-            inner: JsObject::from_proto_and_data_in(
+            inner: JsObject::from_proto_and_data(
                 mc,
                 None,
                 NativeFunctionObject {

--- a/core/engine/src/object/builtins/jsmap.rs
+++ b/core/engine/src/object/builtins/jsmap.rs
@@ -155,6 +155,7 @@ impl JsMap {
     /// # let context = &mut Context::default();
     /// // `some_object` can be any JavaScript `Map` object.
     /// let some_object = JsObject::from_proto_and_data(
+    ///     context.gc_collector(),
     ///     context.intrinsics().constructors().map().prototype(),
     ///     OrderedMap::<JsValue>::new(),
     /// );
@@ -198,6 +199,7 @@ impl JsMap {
 
         // Create a default map object with [[MapData]] as a new empty list
         JsObject::from_proto_and_data_with_shared_shape(
+            context.gc_collector(),
             context.root_shape(),
             prototype,
             <OrderedMap<JsValue>>::new(),

--- a/core/engine/src/object/builtins/jspromise.rs
+++ b/core/engine/src/object/builtins/jspromise.rs
@@ -62,7 +62,7 @@ use std::{future::Future, pin::Pin, task};
 ///                 Err(JsError::from_opaque(args.get_or_undefined(0).clone())
 ///                     .into())
 ///             })
-///             .to_js_function(context.realm()),
+///             .to_js_function(context.realm(), context.gc_collector()),
 ///         ),
 ///         None,
 ///         context,
@@ -71,7 +71,7 @@ use std::{future::Future, pin::Pin, task};
 ///         NativeFunction::from_fn_ptr(|_, args, _| {
 ///             Ok(args.get_or_undefined(0).clone())
 ///         })
-///         .to_js_function(context.realm()),
+///         .to_js_function(context.realm(), context.gc_collector()),
 ///         context,
 ///     )?
 ///     .finally(
@@ -84,7 +84,7 @@ use std::{future::Future, pin::Pin, task};
 ///             )?;
 ///             Ok(JsValue::undefined())
 ///         })
-///         .to_js_function(context.realm()),
+///         .to_js_function(context.realm(), context.gc_collector()),
 ///         context,
 ///     )?;
 ///
@@ -168,6 +168,7 @@ impl JsPromise {
         F: FnOnce(&ResolvingFunctions, &mut Context) -> JsResult<JsValue>,
     {
         let promise = JsObject::from_proto_and_data_with_shared_shape(
+            context.gc_collector(),
             context.root_shape(),
             context.intrinsics().constructors().promise().prototype(),
             Promise::new(),
@@ -219,6 +220,7 @@ impl JsPromise {
     #[inline]
     pub fn new_pending(context: &mut Context) -> (Self, ResolvingFunctions) {
         let promise = JsObject::from_proto_and_data_with_shared_shape(
+            context.gc_collector(),
             context.root_shape(),
             context.intrinsics().constructors().promise().prototype(),
             Promise::new(),
@@ -255,7 +257,7 @@ impl JsPromise {
     ///     PromiseState::Fulfilled(JsValue::undefined())
     /// );
     ///
-    /// assert!(JsPromise::from_object(JsObject::with_null_proto()).is_err());
+    /// assert!(JsPromise::from_object(JsObject::with_null_proto(context.gc_collector())).is_err());
     ///
     /// # Ok(())
     /// # }
@@ -541,7 +543,7 @@ impl JsPromise {
     ///                 .to_string(context)
     ///                 .map(JsValue::from)
     ///         })
-    ///         .to_js_function(context.realm()),
+    ///         .to_js_function(context.realm(), context.gc_collector()),
     ///     ),
     ///     None,
     ///     context,
@@ -611,7 +613,7 @@ impl JsPromise {
     ///             .to_string(context)
     ///             .map(JsValue::from)
     ///     })
-    ///     .to_js_function(context.realm()),
+    ///     .to_js_function(context.realm(), context.gc_collector()),
     ///     context,
     /// )?;
     ///
@@ -685,7 +687,7 @@ impl JsPromise {
     ///         )?;
     ///         Ok(JsValue::undefined())
     ///     })
-    ///     .to_js_function(context.realm()),
+    ///     .to_js_function(context.realm(), context.gc_collector()),
     ///     context,
     /// )?;
     ///
@@ -1125,8 +1127,8 @@ impl JsPromise {
         };
 
         drop(self.then(
-            Some(resolve.to_js_function(context.realm())),
-            Some(reject.to_js_function(context.realm())),
+            Some(resolve.to_js_function(context.realm(), context.gc_collector())),
+            Some(reject.to_js_function(context.realm(), context.gc_collector())),
             context,
         )?);
 
@@ -1165,7 +1167,7 @@ impl JsPromise {
     ///             assert_eq!(*args.get_or_undefined(0), JsValue::new(1));
     ///             Ok(JsValue::new(2))
     ///         })
-    ///         .to_js_function(context.realm()),
+    ///         .to_js_function(context.realm(), context.gc_collector()),
     ///     ),
     ///     None,
     ///     context,
@@ -1192,7 +1194,7 @@ impl JsPromise {
     ///         NativeFunction::from_fn_ptr(|_, _, _| {
     ///             panic!("This will not happen.");
     ///         })
-    ///         .to_js_function(context.realm()),
+    ///         .to_js_function(context.realm(), context.gc_collector()),
     ///     ),
     ///     None,
     ///     context,
@@ -1241,6 +1243,7 @@ impl JsPromise {
         // 4. Let onFulfilled be CreateBuiltinFunction(fulfilledClosure, 1, "", « »).
         let on_fulfilled = FunctionObjectBuilder::new(
             context.realm(),
+            context.gc_collector(),
             NativeFunction::from_copy_closure_with_captures(
                 |_this, args, captures, context| {
                     // a. Let prevContext be the running execution context.
@@ -1305,6 +1308,7 @@ impl JsPromise {
         // 6. Let onRejected be CreateBuiltinFunction(rejectedClosure, 1, "", « »).
         let on_rejected = FunctionObjectBuilder::new(
             context.realm(),
+            context.gc_collector(),
             NativeFunction::from_copy_closure_with_captures(
                 |_this, args, captures, context| {
                     // a. Let prevContext be the running execution context.

--- a/core/engine/src/object/builtins/jsproxy.rs
+++ b/core/engine/src/object/builtins/jsproxy.rs
@@ -394,21 +394,28 @@ impl JsProxyBuilder {
     /// [`JsObject`] in case there's a need to manipulate the returned object
     /// inside Rust code.
     pub fn build(self, context: &mut Context) -> JsResult<JsProxy> {
-        let handler = JsObject::with_object_proto(context.intrinsics());
+        let handler = JsObject::with_object_proto(context.gc_collector(), context.intrinsics());
 
         if let Some(apply) = self.apply {
-            let f = FunctionObjectBuilder::new(context.realm(), NativeFunction::from_fn_ptr(apply))
-                .length(3)
-                .build();
+            let f = FunctionObjectBuilder::new(
+                context.realm(),
+                context.gc_collector(),
+                NativeFunction::from_fn_ptr(apply),
+            )
+            .length(3)
+            .build();
             handler
                 .create_data_property_or_throw(js_string!("apply"), f, context)
                 .js_expect("new object should be writable")?;
         }
         if let Some(construct) = self.construct {
-            let f =
-                FunctionObjectBuilder::new(context.realm(), NativeFunction::from_fn_ptr(construct))
-                    .length(3)
-                    .build();
+            let f = FunctionObjectBuilder::new(
+                context.realm(),
+                context.gc_collector(),
+                NativeFunction::from_fn_ptr(construct),
+            )
+            .length(3)
+            .build();
             handler
                 .create_data_property_or_throw(js_string!("construct"), f, context)
                 .js_expect("new object should be writable")?;
@@ -416,6 +423,7 @@ impl JsProxyBuilder {
         if let Some(define_property) = self.define_property {
             let f = FunctionObjectBuilder::new(
                 context.realm(),
+                context.gc_collector(),
                 NativeFunction::from_fn_ptr(define_property),
             )
             .length(3)
@@ -427,6 +435,7 @@ impl JsProxyBuilder {
         if let Some(delete_property) = self.delete_property {
             let f = FunctionObjectBuilder::new(
                 context.realm(),
+                context.gc_collector(),
                 NativeFunction::from_fn_ptr(delete_property),
             )
             .length(2)
@@ -436,9 +445,13 @@ impl JsProxyBuilder {
                 .js_expect("new object should be writable")?;
         }
         if let Some(get) = self.get {
-            let f = FunctionObjectBuilder::new(context.realm(), NativeFunction::from_fn_ptr(get))
-                .length(3)
-                .build();
+            let f = FunctionObjectBuilder::new(
+                context.realm(),
+                context.gc_collector(),
+                NativeFunction::from_fn_ptr(get),
+            )
+            .length(3)
+            .build();
             handler
                 .create_data_property_or_throw(js_string!("get"), f, context)
                 .js_expect("new object should be writable")?;
@@ -446,6 +459,7 @@ impl JsProxyBuilder {
         if let Some(get_own_property_descriptor) = self.get_own_property_descriptor {
             let f = FunctionObjectBuilder::new(
                 context.realm(),
+                context.gc_collector(),
                 NativeFunction::from_fn_ptr(get_own_property_descriptor),
             )
             .length(2)
@@ -457,6 +471,7 @@ impl JsProxyBuilder {
         if let Some(get_prototype_of) = self.get_prototype_of {
             let f = FunctionObjectBuilder::new(
                 context.realm(),
+                context.gc_collector(),
                 NativeFunction::from_fn_ptr(get_prototype_of),
             )
             .length(1)
@@ -466,9 +481,13 @@ impl JsProxyBuilder {
                 .js_expect("new object should be writable")?;
         }
         if let Some(has) = self.has {
-            let f = FunctionObjectBuilder::new(context.realm(), NativeFunction::from_fn_ptr(has))
-                .length(2)
-                .build();
+            let f = FunctionObjectBuilder::new(
+                context.realm(),
+                context.gc_collector(),
+                NativeFunction::from_fn_ptr(has),
+            )
+            .length(2)
+            .build();
             handler
                 .create_data_property_or_throw(js_string!("has"), f, context)
                 .js_expect("new object should be writable")?;
@@ -476,6 +495,7 @@ impl JsProxyBuilder {
         if let Some(is_extensible) = self.is_extensible {
             let f = FunctionObjectBuilder::new(
                 context.realm(),
+                context.gc_collector(),
                 NativeFunction::from_fn_ptr(is_extensible),
             )
             .length(1)
@@ -485,10 +505,13 @@ impl JsProxyBuilder {
                 .js_expect("new object should be writable")?;
         }
         if let Some(own_keys) = self.own_keys {
-            let f =
-                FunctionObjectBuilder::new(context.realm(), NativeFunction::from_fn_ptr(own_keys))
-                    .length(1)
-                    .build();
+            let f = FunctionObjectBuilder::new(
+                context.realm(),
+                context.gc_collector(),
+                NativeFunction::from_fn_ptr(own_keys),
+            )
+            .length(1)
+            .build();
             handler
                 .create_data_property_or_throw(js_string!("ownKeys"), f, context)
                 .js_expect("new object should be writable")?;
@@ -496,6 +519,7 @@ impl JsProxyBuilder {
         if let Some(prevent_extensions) = self.prevent_extensions {
             let f = FunctionObjectBuilder::new(
                 context.realm(),
+                context.gc_collector(),
                 NativeFunction::from_fn_ptr(prevent_extensions),
             )
             .length(1)
@@ -505,9 +529,13 @@ impl JsProxyBuilder {
                 .js_expect("new object should be writable")?;
         }
         if let Some(set) = self.set {
-            let f = FunctionObjectBuilder::new(context.realm(), NativeFunction::from_fn_ptr(set))
-                .length(4)
-                .build();
+            let f = FunctionObjectBuilder::new(
+                context.realm(),
+                context.gc_collector(),
+                NativeFunction::from_fn_ptr(set),
+            )
+            .length(4)
+            .build();
             handler
                 .create_data_property_or_throw(js_string!("set"), f, context)
                 .js_expect("new object should be writable")?;
@@ -515,6 +543,7 @@ impl JsProxyBuilder {
         if let Some(set_prototype_of) = self.set_prototype_of {
             let f = FunctionObjectBuilder::new(
                 context.realm(),
+                context.gc_collector(),
                 NativeFunction::from_fn_ptr(set_prototype_of),
             )
             .length(2)
@@ -525,6 +554,7 @@ impl JsProxyBuilder {
         }
 
         let proxy = JsObject::from_proto_and_data_with_shared_shape(
+            context.gc_collector(),
             context.root_shape(),
             context.intrinsics().constructors().object().prototype(),
             Proxy::new(self.target, handler),

--- a/core/engine/src/object/builtins/jsset.rs
+++ b/core/engine/src/object/builtins/jsset.rs
@@ -29,6 +29,7 @@ impl JsSet {
     pub fn new(context: &mut Context) -> Self {
         Self {
             inner: JsObject::from_proto_and_data_with_shared_shape(
+                context.gc_collector(),
                 context.root_shape(),
                 context.intrinsics().constructors().set().prototype(),
                 OrderedSet::new(),
@@ -179,6 +180,7 @@ impl JsSet {
 
         Self {
             inner: JsObject::from_proto_and_data_with_shared_shape(
+                context.gc_collector(),
                 context.root_shape(),
                 context.intrinsics().constructors().set().prototype(),
                 set,

--- a/core/engine/src/object/builtins/jssharedarraybuffer.rs
+++ b/core/engine/src/object/builtins/jssharedarraybuffer.rs
@@ -58,7 +58,7 @@ impl JsSharedArrayBuffer {
             .shared_array_buffer()
             .prototype();
 
-        let inner = JsObject::new(context.root_shape(), proto, buffer);
+        let inner = JsObject::new(context.gc_collector(), context.root_shape(), proto, buffer);
 
         Self { inner }
     }

--- a/core/engine/src/object/builtins/jstypedarray.rs
+++ b/core/engine/src/object/builtins/jstypedarray.rs
@@ -516,7 +516,9 @@ impl JsTypedArray {
     /// let array = JsUint8Array::from_iter(data, context)?;
     ///
     /// let greater_than_10_predicate = FunctionObjectBuilder::new(
-    ///     context.realm(), ///     NativeFunction::from_fn_ptr(|_this, args, _context| {
+    ///     context.realm(),
+    ///     context.gc_collector(),
+    ///     NativeFunction::from_fn_ptr(|_this, args, _context| {
     ///         let element = args
     ///             .first()
     ///             .cloned()
@@ -573,7 +575,9 @@ impl JsTypedArray {
     /// let array = JsUint8Array::from_iter(data, context)?;
     ///
     /// let lower_than_200_predicate = FunctionObjectBuilder::new(
-    ///     context.realm(), ///     NativeFunction::from_fn_ptr(|_this, args, _context| {
+    ///     context.realm(),
+    ///     context.gc_collector(),
+    ///     NativeFunction::from_fn_ptr(|_this, args, _context| {
     ///         let element = args
     ///             .first()
     ///             .cloned()
@@ -622,7 +626,9 @@ impl JsTypedArray {
     /// let array = JsUint8Array::from_iter(data, context)?;
     ///
     /// let lower_than_200_predicate = FunctionObjectBuilder::new(
-    ///     context.realm(), ///     NativeFunction::from_fn_ptr(|_this, args, _context| {
+    ///     context.realm(),
+    ///     context.gc_collector(),
+    ///     NativeFunction::from_fn_ptr(|_this, args, _context| {
     ///         let element = args
     ///             .first()
     ///             .cloned()
@@ -678,7 +684,9 @@ impl JsTypedArray {
     /// let num_to_modify = context.alloc(GcRefCell::new(0u8));
     ///
     /// let js_function = FunctionObjectBuilder::new(
-    ///     context.realm(), ///     NativeFunction::from_copy_closure_with_captures(
+    ///     context.realm(),
+    ///     context.gc_collector(),
+    ///     NativeFunction::from_copy_closure_with_captures(
     ///         |_, args, captures, inner_context| {
     ///             let element = args
     ///                 .first()

--- a/core/engine/src/object/builtins/jstypedarray.rs
+++ b/core/engine/src/object/builtins/jstypedarray.rs
@@ -516,8 +516,7 @@ impl JsTypedArray {
     /// let array = JsUint8Array::from_iter(data, context)?;
     ///
     /// let greater_than_10_predicate = FunctionObjectBuilder::new(
-    ///     context.realm(),
-    ///     NativeFunction::from_fn_ptr(|_this, args, _context| {
+    ///     context.realm(), ///     NativeFunction::from_fn_ptr(|_this, args, _context| {
     ///         let element = args
     ///             .first()
     ///             .cloned()
@@ -574,8 +573,7 @@ impl JsTypedArray {
     /// let array = JsUint8Array::from_iter(data, context)?;
     ///
     /// let lower_than_200_predicate = FunctionObjectBuilder::new(
-    ///     context.realm(),
-    ///     NativeFunction::from_fn_ptr(|_this, args, _context| {
+    ///     context.realm(), ///     NativeFunction::from_fn_ptr(|_this, args, _context| {
     ///         let element = args
     ///             .first()
     ///             .cloned()
@@ -624,8 +622,7 @@ impl JsTypedArray {
     /// let array = JsUint8Array::from_iter(data, context)?;
     ///
     /// let lower_than_200_predicate = FunctionObjectBuilder::new(
-    ///     context.realm(),
-    ///     NativeFunction::from_fn_ptr(|_this, args, _context| {
+    ///     context.realm(), ///     NativeFunction::from_fn_ptr(|_this, args, _context| {
     ///         let element = args
     ///             .first()
     ///             .cloned()
@@ -681,8 +678,7 @@ impl JsTypedArray {
     /// let num_to_modify = context.alloc(GcRefCell::new(0u8));
     ///
     /// let js_function = FunctionObjectBuilder::new(
-    ///     context.realm(),
-    ///     NativeFunction::from_copy_closure_with_captures(
+    ///     context.realm(), ///     NativeFunction::from_copy_closure_with_captures(
     ///         |_, args, captures, inner_context| {
     ///             let element = args
     ///                 .first()

--- a/core/engine/src/object/builtins/jsweakmap.rs
+++ b/core/engine/src/object/builtins/jsweakmap.rs
@@ -28,6 +28,7 @@ impl JsWeakMap {
     pub fn new(context: &mut Context) -> Self {
         Self {
             inner: JsObject::from_proto_and_data_with_shared_shape(
+                context.gc_collector(),
                 context.root_shape(),
                 context.intrinsics().constructors().weak_map().prototype(),
                 NativeWeakMap::new(context.gc_collector()),

--- a/core/engine/src/object/builtins/jsweakset.rs
+++ b/core/engine/src/object/builtins/jsweakset.rs
@@ -28,6 +28,7 @@ impl JsWeakSet {
     pub fn new(context: &mut Context) -> Self {
         Self {
             inner: JsObject::from_proto_and_data_with_shared_shape(
+                context.gc_collector(),
                 context.root_shape(),
                 context.intrinsics().constructors().weak_set().prototype(),
                 NativeWeakSet::new(context.gc_collector()),

--- a/core/engine/src/object/datatypes.rs
+++ b/core/engine/src/object/datatypes.rs
@@ -34,7 +34,7 @@ use super::internal_methods::{InternalObjectMethods, ORDINARY_INTERNAL_METHODS};
 /// }
 ///
 /// let object =
-///     JsObject::from_proto_and_data(None, CustomStruct { counter: 5 });
+///     JsObject::from_proto_and_data(context.gc_collector(), None, CustomStruct { counter: 5 });
 ///
 /// assert_eq!(object.downcast_ref::<CustomStruct>().unwrap().counter, 5);
 /// ```

--- a/core/engine/src/object/datatypes.rs
+++ b/core/engine/src/object/datatypes.rs
@@ -33,6 +33,7 @@ use super::internal_methods::{InternalObjectMethods, ORDINARY_INTERNAL_METHODS};
 ///     counter: usize,
 /// }
 ///
+/// # let context = &mut boa_engine::Context::default();
 /// let object =
 ///     JsObject::from_proto_and_data(context.gc_collector(), None, CustomStruct { counter: 5 });
 ///

--- a/core/engine/src/object/internal_methods/mod.rs
+++ b/core/engine/src/object/internal_methods/mod.rs
@@ -44,6 +44,11 @@ impl<'ctx> InternalMethodPropertyContext<'ctx> {
     pub(crate) fn slot(&mut self) -> &mut Slot {
         &mut self.slot
     }
+
+    #[inline]
+    pub(crate) fn slot_and_mc(&mut self) -> (&mut Slot, &boa_gc::MutationContext<'static, '_>) {
+        (&mut self.slot, self.context.gc_collector())
+    }
 }
 
 impl Deref for InternalMethodPropertyContext<'_> {
@@ -532,8 +537,9 @@ pub(crate) fn ordinary_get_prototype_of(
 pub(crate) fn ordinary_set_prototype_of(
     obj: &JsObject,
     val: JsPrototype,
-    _: &mut Context,
+    context: &mut Context,
 ) -> JsResult<bool> {
+    let mc = context.gc_collector();
     // 1. Assert: Either Type(V) is Object or Type(V) is Null.
     // 2. Let current be O.[[Prototype]].
     let current = obj.prototype();
@@ -573,7 +579,7 @@ pub(crate) fn ordinary_set_prototype_of(
     }
 
     // 9. Set O.[[Prototype]] to V.
-    obj.set_prototype(val);
+    obj.set_prototype(mc, val);
 
     // 10. Return true.
     Ok(true)
@@ -657,12 +663,14 @@ pub(crate) fn ordinary_define_own_property(
     let extensible = obj.__is_extensible__(context)?;
 
     // 3. Return ValidateAndApplyPropertyDescriptor(O, P, extensible, Desc, current).
+    let (slot, mc) = context.slot_and_mc();
     Ok(validate_and_apply_property_descriptor(
         Some((obj, key)),
         extensible,
         desc,
         current,
-        context.slot(),
+        slot,
+        mc,
     ))
 }
 
@@ -945,7 +953,7 @@ pub(crate) fn ordinary_delete(
             // 4. If desc.[[Configurable]] is true, then
             Some(desc) if desc.expect_configurable() => {
                 // a. Remove the own property with name P from O.
-                obj.borrow_mut().remove(key);
+                obj.borrow_mut().remove(context.gc_collector(), key);
                 // b. Return true.
                 true
             }
@@ -1004,7 +1012,16 @@ pub(crate) fn is_compatible_property_descriptor(
     current: Option<PropertyDescriptor>,
 ) -> bool {
     // 1. Return ValidateAndApplyPropertyDescriptor(undefined, undefined, Extensible, Desc, Current).
-    validate_and_apply_property_descriptor(None, extensible, desc, current, &mut Slot::new())
+    let mut dummy_slot = Slot::new();
+    let dummy_mc = unsafe { boa_gc::MutationContext::global() };
+    validate_and_apply_property_descriptor(
+        None,
+        extensible,
+        desc,
+        current,
+        &mut dummy_slot,
+        &dummy_mc,
+    )
 }
 
 /// Abstract operation `ValidateAndApplyPropertyDescriptor`
@@ -1019,6 +1036,7 @@ pub(crate) fn validate_and_apply_property_descriptor(
     desc: PropertyDescriptor,
     current: Option<PropertyDescriptor>,
     slot: &mut Slot,
+    mc: &boa_gc::MutationContext<'static, '_>,
 ) -> bool {
     // 1. Assert: If O is not undefined, then IsPropertyKey(P) is true.
 
@@ -1033,6 +1051,7 @@ pub(crate) fn validate_and_apply_property_descriptor(
 
         if let Some((obj, key)) = obj_and_key {
             obj.borrow_mut().properties.insert_with_slot(
+                mc,
                 key,
                 // c. If IsGenericDescriptor(Desc) is true or IsDataDescriptor(Desc) is true, then
                 if desc.is_generic_descriptor() || desc.is_data_descriptor() {
@@ -1153,7 +1172,7 @@ pub(crate) fn validate_and_apply_property_descriptor(
         current.fill_with(desc);
         obj.borrow_mut()
             .properties
-            .insert_with_slot(key, current, slot);
+            .insert_with_slot(mc, key, current, slot);
         slot.attributes |= SlotAttributes::FOUND;
     }
 

--- a/core/engine/src/object/jsobject.rs
+++ b/core/engine/src/object/jsobject.rs
@@ -106,7 +106,7 @@ impl JsObject {
     /// ```
     /// # use boa_engine::{Context, JsObject};
     /// let context = &mut Context::default();
-    /// let obj = JsObject::default(context.intrinsics());
+    /// let obj = JsObject::default(context.gc_collector(), context.intrinsics());
     ///
     /// assert!(obj.is_ordinary());
     /// ```
@@ -235,6 +235,7 @@ impl JsObject {
     /// #[derive(Debug, Trace, Finalize, JsData)]
     /// struct CustomStruct;
     ///
+    /// # let context = &mut boa_engine::Context::default();
     /// let obj = JsObject::from_proto_and_data(context.gc_collector(), None, OrdinaryObject);
     ///
     /// // Downcast consumes the object on success.
@@ -242,6 +243,7 @@ impl JsObject {
     /// assert!(typed.is_ok());
     ///
     /// // Downcast fails for a wrong type, returning the original object.
+    /// # let context = &mut boa_engine::Context::default();
     /// let obj = JsObject::from_proto_and_data(context.gc_collector(), None, OrdinaryObject);
     /// let result = obj.downcast::<CustomStruct>();
     /// assert!(result.is_err());
@@ -288,6 +290,7 @@ impl JsObject {
     /// #[derive(Debug, Trace, Finalize, JsData)]
     /// struct CustomStruct;
     ///
+    /// # let context = &mut boa_engine::Context::default();
     /// let obj = JsObject::from_proto_and_data(context.gc_collector(), None, OrdinaryObject);
     ///
     /// // Downcast ref succeeds for the correct type.
@@ -325,6 +328,7 @@ impl JsObject {
     /// #[derive(Debug, Trace, Finalize, JsData)]
     /// struct CustomStruct;
     ///
+    /// # let context = &mut boa_engine::Context::default();
     /// let obj = JsObject::from_proto_and_data(context.gc_collector(), None, OrdinaryObject);
     ///
     /// // Downcast mut succeeds for the correct type.
@@ -361,6 +365,7 @@ impl JsObject {
     /// #[derive(Debug, Trace, Finalize, JsData)]
     /// struct CustomStruct;
     ///
+    /// # let context = &mut boa_engine::Context::default();
     /// let obj = JsObject::from_proto_and_data(context.gc_collector(), None, OrdinaryObject);
     ///
     /// assert!(obj.is::<OrdinaryObject>());
@@ -773,6 +778,7 @@ impl<T: NativeObject> JsObject<T> {
     /// ```
     /// # use boa_engine::JsObject;
     /// # use boa_engine::builtins::object::OrdinaryObject;
+    /// # let context = &mut boa_engine::Context::default();
     /// let obj = JsObject::from_proto_and_data(context.gc_collector(), None, OrdinaryObject);
     ///
     /// // Multiple immutable borrows are allowed.
@@ -799,8 +805,9 @@ impl<T: NativeObject> JsObject<T> {
     /// ```
     /// # use boa_engine::{Context, JsObject};
     /// # use boa_engine::builtins::object::OrdinaryObject;
-    /// let context = &mut Context::default();
+    /// # let context = &mut Context::default();
     /// let obj = JsObject::from_proto_and_data(
+    ///     context.gc_collector(),
     ///     context.intrinsics().constructors().object().prototype(),
     ///     OrdinaryObject,
     /// );
@@ -828,6 +835,7 @@ impl<T: NativeObject> JsObject<T> {
     /// ```
     /// # use boa_engine::JsObject;
     /// # use boa_engine::builtins::object::OrdinaryObject;
+    /// # let context = &mut boa_engine::Context::default();
     /// let obj = JsObject::from_proto_and_data(context.gc_collector(), None, OrdinaryObject);
     ///
     /// // Non-panicking immutable borrow.
@@ -851,6 +859,7 @@ impl<T: NativeObject> JsObject<T> {
     /// ```
     /// # use boa_engine::JsObject;
     /// # use boa_engine::builtins::object::OrdinaryObject;
+    /// # let context = &mut boa_engine::Context::default();
     /// let obj = JsObject::from_proto_and_data(context.gc_collector(), None, OrdinaryObject);
     ///
     /// // Non-panicking mutable borrow.
@@ -872,6 +881,7 @@ impl<T: NativeObject> JsObject<T> {
     /// ```
     /// # use boa_engine::JsObject;
     /// # use boa_engine::builtins::object::OrdinaryObject;
+    /// # let context = &mut boa_engine::Context::default();
     /// let obj = JsObject::from_proto_and_data(context.gc_collector(), None, OrdinaryObject);
     /// let clone = obj.clone();
     ///
@@ -879,6 +889,7 @@ impl<T: NativeObject> JsObject<T> {
     /// assert!(JsObject::equals(&obj, &clone));
     ///
     /// // A separate object is different, even with identical data.
+    /// # let context = &mut boa_engine::Context::default();
     /// let other = JsObject::from_proto_and_data(context.gc_collector(), None, OrdinaryObject);
     /// assert!(!JsObject::equals(&obj, &other));
     /// ```
@@ -1075,6 +1086,7 @@ impl<T: NativeObject> JsObject<T> {
     /// let context = &mut Context::default();
     ///
     /// let typed_obj = JsObject::new(
+    ///     context.gc_collector(),
     ///     context.root_shape(),
     ///     context.intrinsics().constructors().object().prototype(),
     ///     OrdinaryObject,
@@ -1117,6 +1129,7 @@ impl<T: NativeObject> JsObject<T> {
     /// ```
     /// # use boa_engine::JsObject;
     /// # use boa_engine::builtins::object::OrdinaryObject;
+    /// # let context = &mut boa_engine::Context::default();
     /// let typed_obj = JsObject::new_unique(context.gc_collector(), None, OrdinaryObject);
     ///
     /// // Upcast to an erased JsObject.
@@ -1133,6 +1146,7 @@ impl<T: NativeObject> JsObject<T> {
     /// # use boa_engine::JsObject;
     /// # use boa_engine::builtins::object::OrdinaryObject;
     /// // Create a typed JsObject<OrdinaryObject>.
+    /// # let context = &mut boa_engine::Context::default();
     /// let typed_obj = JsObject::new_unique(context.gc_collector(), None, OrdinaryObject);
     ///
     /// // Upcast erases the type, producing an untyped JsObject.

--- a/core/engine/src/object/jsobject.rs
+++ b/core/engine/src/object/jsobject.rs
@@ -112,12 +112,12 @@ impl JsObject {
     /// ```
     #[inline]
     #[must_use]
-    pub fn default(intrinsics: &Intrinsics) -> Self {
-        Self::with_object_proto(intrinsics)
+    pub fn default(mc: &boa_gc::MutationContext<'static, '_>, intrinsics: &Intrinsics) -> Self {
+        Self::with_object_proto(mc, intrinsics)
     }
 
     /// Creates a new `JsObject` from its inner object and its vtable using the given context.
-    pub(crate) fn from_object_and_vtable_in<T: NativeObject>(
+    pub(crate) fn from_object_and_vtable<T: NativeObject>(
         mc: &boa_gc::MutationContext<'static, '_>,
         object: Object<T>,
         vtable: &'static InternalObjectMethods,
@@ -133,19 +133,6 @@ impl JsObject {
         JsObject { inner }.upcast()
     }
 
-    /// Creates a new `JsObject` from its inner object and its vtable.
-    pub(crate) fn from_object_and_vtable<T: NativeObject>(
-        object: Object<T>,
-        vtable: &'static InternalObjectMethods,
-    ) -> Self {
-        Self::from_object_and_vtable_in(
-            // SAFETY: The global mutation context is used as a fallback during the context threading migration.
-            &unsafe { boa_gc::MutationContext::global() },
-            object,
-            vtable,
-        )
-    }
-
     /// Creates a new ordinary object with its prototype set to the `Object` prototype.
     ///
     /// This is equivalent to calling the specification's abstract operation
@@ -158,15 +145,19 @@ impl JsObject {
     /// ```
     /// # use boa_engine::{Context, JsObject};
     /// let context = &mut Context::default();
-    /// let obj = JsObject::with_object_proto(context.intrinsics());
+    /// let obj = JsObject::with_object_proto(context.gc_collector(), context.intrinsics());
     ///
     /// assert!(obj.is_ordinary());
     /// assert!(obj.prototype().is_some());
     /// ```
     #[inline]
     #[must_use]
-    pub fn with_object_proto(intrinsics: &Intrinsics) -> Self {
+    pub fn with_object_proto(
+        mc: &boa_gc::MutationContext<'static, '_>,
+        intrinsics: &Intrinsics,
+    ) -> Self {
         Self::from_proto_and_data(
+            mc,
             intrinsics.constructors().object().prototype(),
             OrdinaryObject,
         )
@@ -175,34 +166,12 @@ impl JsObject {
     /// Creates a new ordinary object, with its prototype set to null using the given context.
     #[inline]
     #[must_use]
-    pub fn with_null_proto_in(mc: &boa_gc::MutationContext<'static, '_>) -> Self {
-        Self::from_proto_and_data_in(mc, None, OrdinaryObject)
-    }
-
-    /// Creates a new ordinary object, with its prototype set to null.
-    ///
-    /// This is equivalent to calling the specification's abstract operation
-    /// [`OrdinaryObjectCreate(null)`][call].
-    ///
-    /// [call]: https://tc39.es/ecma262/#sec-ordinaryobjectcreate
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use boa_engine::JsObject;
-    /// let obj = JsObject::with_null_proto();
-    /// assert!(obj.prototype().is_none());
-    /// assert!(obj.is_ordinary());
-    /// ```
-    #[inline]
-    #[must_use]
-    pub fn with_null_proto() -> Self {
-        // SAFETY: The global mutation context is used as a fallback during the context threading migration.
-        Self::with_null_proto_in(&unsafe { boa_gc::MutationContext::global() })
+    pub fn with_null_proto(mc: &boa_gc::MutationContext<'static, '_>) -> Self {
+        Self::from_proto_and_data(mc, None, OrdinaryObject)
     }
 
     /// Creates a new object with the provided prototype and object data, using the given context.
-    pub fn from_proto_and_data_in<O: Into<Option<Self>>, T: NativeObject>(
+    pub fn from_proto_and_data<O: Into<Option<Self>>, T: NativeObject>(
         mc: &boa_gc::MutationContext<'static, '_>,
         prototype: O,
         data: T,
@@ -213,7 +182,7 @@ impl JsObject {
             VTableObject {
                 object: GcRefCell::new(Object {
                     data: ObjectData::new(data),
-                    properties: PropertyMap::from_prototype_unique_shape(prototype.into()),
+                    properties: PropertyMap::from_prototype_unique_shape(mc, prototype.into()),
                     extensible: true,
                     private_elements: ThinVec::new(),
                 }),
@@ -224,49 +193,8 @@ impl JsObject {
         JsObject { inner }.upcast()
     }
 
-    /// Creates a new object with the provided prototype and object data.
-    ///
-    /// This is equivalent to calling the specification's abstract operation [`OrdinaryObjectCreate`],
-    /// with the difference that the `additionalInternalSlotsList` parameter is determined by
-    /// the provided `data`.
-    ///
-    /// [`OrdinaryObjectCreate`]: https://tc39.es/ecma262/#sec-ordinaryobjectcreate
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use boa_engine::{Context, JsObject};
-    /// # use boa_engine::builtins::object::OrdinaryObject;
-    /// let context = &mut Context::default();
-    /// let obj = JsObject::from_proto_and_data(
-    ///     context.intrinsics().constructors().object().prototype(),
-    ///     OrdinaryObject,
-    /// );
-    ///
-    /// assert!(obj.is_ordinary());
-    /// assert!(obj.prototype().is_some());
-    ///
-    /// // Create an object with no prototype.
-    /// let null_obj = JsObject::from_proto_and_data(None, OrdinaryObject);
-    /// assert!(null_obj.prototype().is_none());
-    /// ```
-    pub fn from_proto_and_data<O: Into<Option<Self>>, T: NativeObject>(
-        prototype: O,
-        data: T,
-    ) -> Self {
-        Self::from_proto_and_data_in(
-            // SAFETY: The global mutation context is used as a fallback during the context threading migration.
-            &unsafe { boa_gc::MutationContext::global() },
-            prototype,
-            data,
-        )
-    }
-
     /// Creates a new object with the provided prototype and object data using the given context.
-    pub(crate) fn from_proto_and_data_with_shared_shape_in<
-        O: Into<Option<Self>>,
-        T: NativeObject,
-    >(
+    pub(crate) fn from_proto_and_data_with_shared_shape<O: Into<Option<Self>>, T: NativeObject>(
         mc: &boa_gc::MutationContext<'static, '_>,
         root_shape: &RootShape,
         prototype: O,
@@ -279,6 +207,7 @@ impl JsObject {
                 object: GcRefCell::new(Object {
                     data: ObjectData::new(data),
                     properties: PropertyMap::from_prototype_with_shared_shape(
+                        mc,
                         root_shape,
                         prototype.into(),
                     ),
@@ -290,27 +219,6 @@ impl JsObject {
         );
 
         JsObject { inner }
-    }
-
-    /// Creates a new object with the provided prototype and object data.
-    ///
-    /// This is equivalent to calling the specification's abstract operation [`OrdinaryObjectCreate`],
-    /// with the difference that the `additionalInternalSlotsList` parameter is determined by
-    /// the provided `data`.
-    ///
-    /// [`OrdinaryObjectCreate`]: https://tc39.es/ecma262/#sec-ordinaryobjectcreate
-    pub(crate) fn from_proto_and_data_with_shared_shape<O: Into<Option<Self>>, T: NativeObject>(
-        root_shape: &RootShape,
-        prototype: O,
-        data: T,
-    ) -> JsObject<T> {
-        Self::from_proto_and_data_with_shared_shape_in(
-            // SAFETY: The global mutation context is used as a fallback during the context threading migration.
-            &unsafe { boa_gc::MutationContext::global() },
-            root_shape,
-            prototype,
-            data,
-        )
     }
 
     /// Downcasts the object's inner data if the object is of type `T`.
@@ -327,14 +235,14 @@ impl JsObject {
     /// #[derive(Debug, Trace, Finalize, JsData)]
     /// struct CustomStruct;
     ///
-    /// let obj = JsObject::from_proto_and_data(None, OrdinaryObject);
+    /// let obj = JsObject::from_proto_and_data(context.gc_collector(), None, OrdinaryObject);
     ///
     /// // Downcast consumes the object on success.
     /// let typed = obj.downcast::<OrdinaryObject>();
     /// assert!(typed.is_ok());
     ///
     /// // Downcast fails for a wrong type, returning the original object.
-    /// let obj = JsObject::from_proto_and_data(None, OrdinaryObject);
+    /// let obj = JsObject::from_proto_and_data(context.gc_collector(), None, OrdinaryObject);
     /// let result = obj.downcast::<CustomStruct>();
     /// assert!(result.is_err());
     /// ```
@@ -380,7 +288,7 @@ impl JsObject {
     /// #[derive(Debug, Trace, Finalize, JsData)]
     /// struct CustomStruct;
     ///
-    /// let obj = JsObject::from_proto_and_data(None, OrdinaryObject);
+    /// let obj = JsObject::from_proto_and_data(context.gc_collector(), None, OrdinaryObject);
     ///
     /// // Downcast ref succeeds for the correct type.
     /// assert!(obj.downcast_ref::<OrdinaryObject>().is_some());
@@ -417,7 +325,7 @@ impl JsObject {
     /// #[derive(Debug, Trace, Finalize, JsData)]
     /// struct CustomStruct;
     ///
-    /// let obj = JsObject::from_proto_and_data(None, OrdinaryObject);
+    /// let obj = JsObject::from_proto_and_data(context.gc_collector(), None, OrdinaryObject);
     ///
     /// // Downcast mut succeeds for the correct type.
     /// assert!(obj.downcast_mut::<OrdinaryObject>().is_some());
@@ -453,7 +361,7 @@ impl JsObject {
     /// #[derive(Debug, Trace, Finalize, JsData)]
     /// struct CustomStruct;
     ///
-    /// let obj = JsObject::from_proto_and_data(None, OrdinaryObject);
+    /// let obj = JsObject::from_proto_and_data(context.gc_collector(), None, OrdinaryObject);
     ///
     /// assert!(obj.is::<OrdinaryObject>());
     /// assert!(!obj.is::<CustomStruct>());
@@ -476,7 +384,7 @@ impl JsObject {
     /// ```
     /// # use boa_engine::{Context, JsObject};
     /// let context = &mut Context::default();
-    /// let obj = JsObject::with_object_proto(context.intrinsics());
+    /// let obj = JsObject::with_object_proto(context.gc_collector(), context.intrinsics());
     ///
     /// assert!(obj.is_ordinary());
     /// ```
@@ -502,7 +410,7 @@ impl JsObject {
     /// assert!(JsObject::from(array).is_array());
     ///
     /// // An ordinary object is not an array.
-    /// let obj = JsObject::with_object_proto(context.intrinsics());
+    /// let obj = JsObject::with_object_proto(context.gc_collector(), context.intrinsics());
     /// assert!(!obj.is_array());
     /// # Ok(())
     /// # }
@@ -593,10 +501,10 @@ impl JsObject {
     /// # fn main() -> JsResult<()> {
     /// let context = &mut Context::default();
     ///
-    /// let obj1 = JsObject::with_object_proto(context.intrinsics());
+    /// let obj1 = JsObject::with_object_proto(context.gc_collector(), context.intrinsics());
     /// obj1.set(js_string!("key"), 42, false, context)?;
     ///
-    /// let obj2 = JsObject::with_object_proto(context.intrinsics());
+    /// let obj2 = JsObject::with_object_proto(context.gc_collector(), context.intrinsics());
     /// obj2.set(js_string!("key"), 42, false, context)?;
     ///
     /// assert!(JsObject::deep_strict_equals(&obj1, &obj2, context)?);
@@ -865,7 +773,7 @@ impl<T: NativeObject> JsObject<T> {
     /// ```
     /// # use boa_engine::JsObject;
     /// # use boa_engine::builtins::object::OrdinaryObject;
-    /// let obj = JsObject::from_proto_and_data(None, OrdinaryObject);
+    /// let obj = JsObject::from_proto_and_data(context.gc_collector(), None, OrdinaryObject);
     ///
     /// // Multiple immutable borrows are allowed.
     /// let borrowed = obj.borrow();
@@ -898,7 +806,7 @@ impl<T: NativeObject> JsObject<T> {
     /// );
     ///
     /// // Set the prototype to `None` via a mutable borrow.
-    /// obj.borrow_mut().set_prototype(None);
+    /// obj.borrow_mut().set_prototype(context.gc_collector(), None);
     /// assert!(obj.prototype().is_none());
     /// ```
     #[inline]
@@ -920,7 +828,7 @@ impl<T: NativeObject> JsObject<T> {
     /// ```
     /// # use boa_engine::JsObject;
     /// # use boa_engine::builtins::object::OrdinaryObject;
-    /// let obj = JsObject::from_proto_and_data(None, OrdinaryObject);
+    /// let obj = JsObject::from_proto_and_data(context.gc_collector(), None, OrdinaryObject);
     ///
     /// // Non-panicking immutable borrow.
     /// let result = obj.try_borrow();
@@ -943,7 +851,7 @@ impl<T: NativeObject> JsObject<T> {
     /// ```
     /// # use boa_engine::JsObject;
     /// # use boa_engine::builtins::object::OrdinaryObject;
-    /// let obj = JsObject::from_proto_and_data(None, OrdinaryObject);
+    /// let obj = JsObject::from_proto_and_data(context.gc_collector(), None, OrdinaryObject);
     ///
     /// // Non-panicking mutable borrow.
     /// let result = obj.try_borrow_mut();
@@ -964,14 +872,14 @@ impl<T: NativeObject> JsObject<T> {
     /// ```
     /// # use boa_engine::JsObject;
     /// # use boa_engine::builtins::object::OrdinaryObject;
-    /// let obj = JsObject::from_proto_and_data(None, OrdinaryObject);
+    /// let obj = JsObject::from_proto_and_data(context.gc_collector(), None, OrdinaryObject);
     /// let clone = obj.clone();
     ///
     /// // A clone points to the same GC allocation.
     /// assert!(JsObject::equals(&obj, &clone));
     ///
     /// // A separate object is different, even with identical data.
-    /// let other = JsObject::from_proto_and_data(None, OrdinaryObject);
+    /// let other = JsObject::from_proto_and_data(context.gc_collector(), None, OrdinaryObject);
     /// assert!(!JsObject::equals(&obj, &other));
     /// ```
     #[must_use]
@@ -992,10 +900,10 @@ impl<T: NativeObject> JsObject<T> {
     /// # use boa_engine::{Context, JsObject};
     /// let context = &mut Context::default();
     ///
-    /// let obj = JsObject::with_object_proto(context.intrinsics());
+    /// let obj = JsObject::with_object_proto(context.gc_collector(), context.intrinsics());
     /// assert!(obj.prototype().is_some());
     ///
-    /// let null_obj = JsObject::with_null_proto();
+    /// let null_obj = JsObject::with_null_proto(context.gc_collector());
     /// assert!(null_obj.prototype().is_none());
     /// ```
     #[inline]
@@ -1025,41 +933,55 @@ impl<T: NativeObject> JsObject<T> {
     /// ```
     /// # use boa_engine::{Context, JsObject};
     /// let context = &mut Context::default();
-    /// let obj = JsObject::with_object_proto(context.intrinsics());
+    /// let obj = JsObject::with_object_proto(context.gc_collector(), context.intrinsics());
     ///
     /// assert!(obj.prototype().is_some());
     ///
     /// // Set the prototype to `None`.
-    /// obj.set_prototype(None);
+    /// obj.set_prototype(context.gc_collector(), None);
     /// assert!(obj.prototype().is_none());
     /// ```
     #[inline]
     #[track_caller]
     #[allow(clippy::must_use_candidate)]
-    pub fn set_prototype(&self, prototype: JsPrototype) -> bool {
-        self.borrow_mut().set_prototype(prototype)
+    pub fn set_prototype(
+        &self,
+        mc: &boa_gc::MutationContext<'static, '_>,
+        prototype: JsPrototype,
+    ) -> bool {
+        self.borrow_mut().set_prototype(mc, prototype)
     }
 
     /// Helper function for property insertion.
     #[track_caller]
-    pub(crate) fn insert<K, P>(&self, key: K, property: P) -> bool
+    pub(crate) fn insert<K, P>(
+        &self,
+        mc: &boa_gc::MutationContext<'static, '_>,
+        key: K,
+        property: P,
+    ) -> bool
     where
         K: Into<PropertyKey>,
         P: Into<PropertyDescriptor>,
     {
-        self.borrow_mut().insert(key, property)
+        self.borrow_mut().insert(mc, key, property)
     }
 
     /// Inserts a field in the object `properties` without checking if it's writable.
     ///
     /// If a field was already in the object with the same name, than `true` is returned
     /// with that field, otherwise `false` is returned.
-    pub fn insert_property<K, P>(&self, key: K, property: P) -> bool
+    pub fn insert_property<K, P>(
+        &self,
+        mc: &boa_gc::MutationContext<'static, '_>,
+        key: K,
+        property: P,
+    ) -> bool
     where
         K: Into<PropertyKey>,
         P: Into<PropertyDescriptor>,
     {
-        self.insert(key.into(), property)
+        self.insert(mc, key.into(), property)
     }
 
     /// It determines if Object is a callable function with a `[[Call]]` internal method.
@@ -1113,7 +1035,7 @@ impl<T: NativeObject> JsObject<T> {
 
 impl<T: NativeObject> JsObject<T> {
     /// Creates a new `JsObject` from a `RootShape`, prototype, and data using the given context.
-    pub fn new_in<O: Into<Option<JsObject>>>(
+    pub fn new<O: Into<Option<JsObject>>>(
         mc: &boa_gc::MutationContext<'static, '_>,
         root_shape: &RootShape,
         prototype: O,
@@ -1126,6 +1048,7 @@ impl<T: NativeObject> JsObject<T> {
                 object: GcRefCell::new(Object {
                     data: ObjectData::new(data),
                     properties: PropertyMap::from_prototype_with_shared_shape(
+                        mc,
                         root_shape,
                         prototype.into(),
                     ),
@@ -1161,18 +1084,8 @@ impl<T: NativeObject> JsObject<T> {
     /// let obj = typed_obj.upcast();
     /// assert!(obj.is_ordinary());
     /// ```
-    pub fn new<O: Into<Option<JsObject>>>(root_shape: &RootShape, prototype: O, data: T) -> Self {
-        Self::new_in(
-            // SAFETY: The global mutation context is used as a fallback during the context threading migration.
-            &unsafe { boa_gc::MutationContext::global() },
-            root_shape,
-            prototype,
-            data,
-        )
-    }
-
     /// Creates a new `JsObject` from prototype, and data using the given context.
-    pub fn new_unique_in<O: Into<Option<JsObject>>>(
+    pub fn new_unique<O: Into<Option<JsObject>>>(
         mc: &boa_gc::MutationContext<'static, '_>,
         prototype: O,
         data: T,
@@ -1183,7 +1096,7 @@ impl<T: NativeObject> JsObject<T> {
             VTableObject {
                 object: GcRefCell::new(Object {
                     data: ObjectData::new(data),
-                    properties: PropertyMap::from_prototype_unique_shape(prototype.into()),
+                    properties: PropertyMap::from_prototype_unique_shape(mc, prototype.into()),
                     extensible: true,
                     private_elements: ThinVec::new(),
                 }),
@@ -1204,22 +1117,13 @@ impl<T: NativeObject> JsObject<T> {
     /// ```
     /// # use boa_engine::JsObject;
     /// # use boa_engine::builtins::object::OrdinaryObject;
-    /// let typed_obj = JsObject::new_unique(None, OrdinaryObject);
+    /// let typed_obj = JsObject::new_unique(context.gc_collector(), None, OrdinaryObject);
     ///
     /// // Upcast to an erased JsObject.
     /// let obj = typed_obj.upcast();
     /// assert!(obj.is_ordinary());
     /// assert!(obj.prototype().is_none());
     /// ```
-    pub fn new_unique<O: Into<Option<JsObject>>>(prototype: O, data: T) -> Self {
-        Self::new_unique_in(
-            // SAFETY: The global mutation context is used as a fallback during the context threading migration.
-            &unsafe { boa_gc::MutationContext::global() },
-            prototype,
-            data,
-        )
-    }
-
     /// Upcasts this object's inner data from a specific type `T` to an erased type
     /// `dyn NativeObject`.
     ///
@@ -1229,7 +1133,7 @@ impl<T: NativeObject> JsObject<T> {
     /// # use boa_engine::JsObject;
     /// # use boa_engine::builtins::object::OrdinaryObject;
     /// // Create a typed JsObject<OrdinaryObject>.
-    /// let typed_obj = JsObject::new_unique(None, OrdinaryObject);
+    /// let typed_obj = JsObject::new_unique(context.gc_collector(), None, OrdinaryObject);
     ///
     /// // Upcast erases the type, producing an untyped JsObject.
     /// let obj: JsObject = typed_obj.upcast();

--- a/core/engine/src/object/mod.rs
+++ b/core/engine/src/object/mod.rs
@@ -272,10 +272,17 @@ impl<T: ?Sized> Object<T> {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-invariants-of-the-essential-internal-methods
     #[track_caller]
-    pub fn set_prototype<O: Into<JsPrototype>>(&mut self, prototype: O) -> bool {
+    pub fn set_prototype<O: Into<JsPrototype>>(
+        &mut self,
+        mc: &boa_gc::MutationContext<'static, '_>,
+        prototype: O,
+    ) -> bool {
         let prototype = prototype.into();
         if self.extensible {
-            self.properties.shape = self.properties.shape.change_prototype_transition(prototype);
+            self.properties.shape = self
+                .properties
+                .shape
+                .change_prototype_transition(mc, prototype);
             true
         } else {
             // If target is non-extensible, [[SetPrototypeOf]] must return false
@@ -300,20 +307,29 @@ impl<T: ?Sized> Object<T> {
     ///
     /// If a field was already in the object with the same name, then `true` is returned
     /// otherwise, `false` is returned.
-    pub(crate) fn insert<K, P>(&mut self, key: K, property: P) -> bool
+    pub(crate) fn insert<K, P>(
+        &mut self,
+        mc: &boa_gc::MutationContext<'static, '_>,
+        key: K,
+        property: P,
+    ) -> bool
     where
         K: Into<PropertyKey>,
         P: Into<PropertyDescriptor>,
     {
-        self.properties.insert(&key.into(), property.into())
+        self.properties.insert(mc, &key.into(), property.into())
     }
 
     /// Helper function for property removal without checking if it's configurable.
     ///
     /// Returns `true` if the property was removed, `false` otherwise.
     #[inline]
-    pub(crate) fn remove(&mut self, key: &PropertyKey) -> bool {
-        self.properties.remove(key)
+    pub(crate) fn remove(
+        &mut self,
+        mc: &boa_gc::MutationContext<'static, '_>,
+        key: &PropertyKey,
+    ) -> bool {
+        self.properties.remove(mc, key)
     }
 
     /// Append a private element to an object.
@@ -394,9 +410,9 @@ where
 }
 
 /// Builder for creating native function objects
-#[derive(Debug)]
 pub struct FunctionObjectBuilder<'realm> {
     realm: &'realm Realm,
+    mc: &'realm boa_gc::MutationContext<'static, 'realm>,
     function: NativeFunction,
     constructor: Option<ConstructorKind>,
     name: JsString,
@@ -407,9 +423,14 @@ impl<'realm> FunctionObjectBuilder<'realm> {
     /// Create a new `FunctionBuilder` for creating a native function.
     #[inline]
     #[must_use]
-    pub fn new(realm: &'realm Realm, function: NativeFunction) -> Self {
+    pub fn new(
+        realm: &'realm Realm,
+        mc: &'realm boa_gc::MutationContext<'static, 'realm>,
+        function: NativeFunction,
+    ) -> Self {
         Self {
             realm,
+            mc,
             function,
             constructor: None,
             name: js_string!(),
@@ -454,6 +475,7 @@ impl<'realm> FunctionObjectBuilder<'realm> {
     #[must_use]
     pub fn build(self) -> JsFunction {
         let object = self.realm.intrinsics().templates().function().create(
+            self.mc,
             NativeFunctionObject {
                 f: self.function,
                 name: self.name.clone(),
@@ -510,13 +532,14 @@ impl<'ctx> ObjectInitializer<'ctx> {
     /// Create a new `ObjectBuilder`.
     #[inline]
     pub fn new(context: &'ctx mut Context) -> Self {
-        let object = JsObject::with_object_proto(context.intrinsics());
+        let object = JsObject::with_object_proto(context.gc_collector(), context.intrinsics());
         Self { context, object }
     }
 
     /// Create a new `ObjectBuilder` with custom [`NativeObject`] data.
     pub fn with_native_data<T: NativeObject>(data: T, context: &'ctx mut Context) -> Self {
         let object = JsObject::from_proto_and_data_with_shared_shape(
+            context.gc_collector(),
             context.root_shape(),
             context.intrinsics().constructors().object().prototype(),
             data,
@@ -531,9 +554,13 @@ impl<'ctx> ObjectInitializer<'ctx> {
         proto: JsObject,
         context: &'ctx mut Context,
     ) -> Self {
-        let object =
-            JsObject::from_proto_and_data_with_shared_shape(context.root_shape(), proto, data)
-                .upcast();
+        let object = JsObject::from_proto_and_data_with_shared_shape(
+            context.gc_collector(),
+            context.root_shape(),
+            proto,
+            data,
+        )
+        .upcast();
         Self { context, object }
     }
 
@@ -543,19 +570,22 @@ impl<'ctx> ObjectInitializer<'ctx> {
         B: Into<FunctionBinding>,
     {
         let binding = binding.into();
-        let function = FunctionObjectBuilder::new(self.context.realm(), function)
-            .name(binding.name)
-            .length(length)
-            .constructor(false)
-            .build();
+        let function =
+            FunctionObjectBuilder::new(self.context.realm(), self.context.gc_collector(), function)
+                .name(binding.name)
+                .length(length)
+                .constructor(false)
+                .build();
 
         self.object.borrow_mut().insert(
+            self.context.gc_collector(),
             binding.binding,
             PropertyDescriptor::builder()
                 .value(function)
                 .writable(true)
                 .enumerable(false)
-                .configurable(true),
+                .configurable(true)
+                .build(),
         );
         self
     }
@@ -570,8 +600,11 @@ impl<'ctx> ObjectInitializer<'ctx> {
             .value(value)
             .writable(attribute.writable())
             .enumerable(attribute.enumerable())
-            .configurable(attribute.configurable());
-        self.object.borrow_mut().insert(key, property);
+            .configurable(attribute.configurable())
+            .build();
+        self.object
+            .borrow_mut()
+            .insert(self.context.gc_collector(), key, property);
         self
     }
 
@@ -597,8 +630,11 @@ impl<'ctx> ObjectInitializer<'ctx> {
             .maybe_get(get)
             .maybe_set(set)
             .enumerable(attribute.enumerable())
-            .configurable(attribute.configurable());
-        self.object.borrow_mut().insert(key, property);
+            .configurable(attribute.configurable())
+            .build();
+        self.object
+            .borrow_mut()
+            .insert(self.context.gc_collector(), key, property);
         self
     }
 
@@ -666,19 +702,22 @@ impl<'ctx> ConstructorBuilder<'ctx> {
         B: Into<FunctionBinding>,
     {
         let binding = binding.into();
-        let function = FunctionObjectBuilder::new(self.context.realm(), function)
-            .name(binding.name)
-            .length(length)
-            .constructor(false)
-            .build();
+        let function =
+            FunctionObjectBuilder::new(self.context.realm(), self.context.gc_collector(), function)
+                .name(binding.name)
+                .length(length)
+                .constructor(false)
+                .build();
 
         self.prototype.insert(
+            self.context.gc_collector(),
             binding.binding,
             PropertyDescriptor::builder()
                 .value(function)
                 .writable(true)
                 .enumerable(false)
-                .configurable(true),
+                .configurable(true)
+                .build(),
         );
         self
     }
@@ -694,19 +733,22 @@ impl<'ctx> ConstructorBuilder<'ctx> {
         B: Into<FunctionBinding>,
     {
         let binding = binding.into();
-        let function = FunctionObjectBuilder::new(self.context.realm(), function)
-            .name(binding.name)
-            .length(length)
-            .constructor(false)
-            .build();
+        let function =
+            FunctionObjectBuilder::new(self.context.realm(), self.context.gc_collector(), function)
+                .name(binding.name)
+                .length(length)
+                .constructor(false)
+                .build();
 
         self.constructor_object.insert(
+            self.context.gc_collector(),
             binding.binding,
             PropertyDescriptor::builder()
                 .value(function)
                 .writable(true)
                 .enumerable(false)
-                .configurable(true),
+                .configurable(true)
+                .build(),
         );
         self
     }
@@ -721,8 +763,10 @@ impl<'ctx> ConstructorBuilder<'ctx> {
             .value(value)
             .writable(attribute.writable())
             .enumerable(attribute.enumerable())
-            .configurable(attribute.configurable());
-        self.prototype.insert(key, property);
+            .configurable(attribute.configurable())
+            .build();
+        self.prototype
+            .insert(self.context.gc_collector(), key, property);
         self
     }
 
@@ -736,8 +780,10 @@ impl<'ctx> ConstructorBuilder<'ctx> {
             .value(value)
             .writable(attribute.writable())
             .enumerable(attribute.enumerable())
-            .configurable(attribute.configurable());
-        self.constructor_object.insert(key, property);
+            .configurable(attribute.configurable())
+            .build();
+        self.constructor_object
+            .insert(self.context.gc_collector(), key, property);
         self
     }
 
@@ -756,8 +802,10 @@ impl<'ctx> ConstructorBuilder<'ctx> {
             .maybe_get(get)
             .maybe_set(set)
             .enumerable(attribute.enumerable())
-            .configurable(attribute.configurable());
-        self.prototype.insert(key, property);
+            .configurable(attribute.configurable())
+            .build();
+        self.prototype
+            .insert(self.context.gc_collector(), key, property);
         self
     }
 
@@ -776,8 +824,10 @@ impl<'ctx> ConstructorBuilder<'ctx> {
             .maybe_get(get)
             .maybe_set(set)
             .enumerable(attribute.enumerable())
-            .configurable(attribute.configurable());
-        self.constructor_object.insert(key, property);
+            .configurable(attribute.configurable())
+            .build();
+        self.constructor_object
+            .insert(self.context.gc_collector(), key, property);
         self
     }
 
@@ -788,7 +838,8 @@ impl<'ctx> ConstructorBuilder<'ctx> {
         P: Into<PropertyDescriptor>,
     {
         let property = property.into();
-        self.prototype.insert(key, property);
+        self.prototype
+            .insert(self.context.gc_collector(), key, property);
         self
     }
 
@@ -799,7 +850,8 @@ impl<'ctx> ConstructorBuilder<'ctx> {
         P: Into<PropertyDescriptor>,
     {
         let property = property.into();
-        self.constructor_object.insert(key, property);
+        self.constructor_object
+            .insert(self.context.gc_collector(), key, property);
         self
     }
 
@@ -880,18 +932,22 @@ impl<'ctx> ConstructorBuilder<'ctx> {
             .value(self.length)
             .writable(false)
             .enumerable(false)
-            .configurable(true);
+            .configurable(true)
+            .build();
         let name = PropertyDescriptor::builder()
             .value(self.name.clone())
             .writable(false)
             .enumerable(false)
-            .configurable(true);
+            .configurable(true)
+            .build();
 
         let prototype = {
             if let Some(proto) = self.inherit.take() {
-                self.prototype.set_prototype(proto);
+                self.prototype
+                    .set_prototype(self.context.gc_collector(), proto);
             } else {
                 self.prototype.set_prototype(
+                    self.context.gc_collector(),
                     self.context
                         .intrinsics()
                         .constructors()
@@ -900,7 +956,11 @@ impl<'ctx> ConstructorBuilder<'ctx> {
                 );
             }
 
-            JsObject::from_object_and_vtable(self.prototype, &ORDINARY_INTERNAL_METHODS)
+            JsObject::from_object_and_vtable(
+                self.context.gc_collector(),
+                self.prototype,
+                &ORDINARY_INTERNAL_METHODS,
+            )
         };
 
         let constructor = {
@@ -918,13 +978,14 @@ impl<'ctx> ConstructorBuilder<'ctx> {
                 data: ObjectData::new(data),
             };
 
-            constructor.insert(StaticJsStrings::LENGTH, length);
-            constructor.insert(js_string!("name"), name);
+            constructor.insert(self.context.gc_collector(), StaticJsStrings::LENGTH, length);
+            constructor.insert(self.context.gc_collector(), js_string!("name"), name);
 
             if let Some(proto) = self.custom_prototype.take() {
-                constructor.set_prototype(proto);
+                constructor.set_prototype(self.context.gc_collector(), proto);
             } else {
                 constructor.set_prototype(
+                    self.context.gc_collector(),
                     self.context
                         .intrinsics()
                         .constructors()
@@ -935,27 +996,35 @@ impl<'ctx> ConstructorBuilder<'ctx> {
 
             if self.has_prototype_property {
                 constructor.insert(
+                    self.context.gc_collector(),
                     PROTOTYPE,
                     PropertyDescriptor::builder()
                         .value(prototype.clone())
                         .writable(false)
                         .enumerable(false)
-                        .configurable(false),
+                        .configurable(false)
+                        .build(),
                 );
             }
 
-            JsObject::from_object_and_vtable(constructor, internal_methods)
+            JsObject::from_object_and_vtable(
+                self.context.gc_collector(),
+                constructor,
+                internal_methods,
+            )
         };
 
         {
             let mut prototype = prototype.borrow_mut();
             prototype.insert(
+                self.context.gc_collector(),
                 CONSTRUCTOR,
                 PropertyDescriptor::builder()
                     .value(constructor.clone())
                     .writable(true)
                     .enumerable(false)
-                    .configurable(true),
+                    .configurable(true)
+                    .build(),
             );
         }
 

--- a/core/engine/src/object/property_map.rs
+++ b/core/engine/src/object/property_map.rs
@@ -506,10 +506,13 @@ impl PropertyMap {
     /// Construct a [`PropertyMap`] with the given prototype with a unique [`Shape`].
     #[must_use]
     #[inline]
-    pub fn from_prototype_unique_shape(prototype: JsPrototype) -> Self {
+    pub fn from_prototype_unique_shape(
+        mc: &boa_gc::MutationContext<'static, '_>,
+        prototype: JsPrototype,
+    ) -> Self {
         Self {
             indexed_properties: IndexedProperties::default(),
-            shape: UniqueShape::new(prototype, PropertyTableInner::default()).into(),
+            shape: UniqueShape::new(mc, prototype, PropertyTableInner::default()).into(),
             storage: Vec::default(),
         }
     }
@@ -518,10 +521,13 @@ impl PropertyMap {
     #[must_use]
     #[inline]
     pub fn from_prototype_with_shared_shape(
+        mc: &boa_gc::MutationContext<'static, '_>,
         root_shape: &RootShape,
         prototype: JsPrototype,
     ) -> Self {
-        let shape = root_shape.shape().change_prototype_transition(prototype);
+        let shape = root_shape
+            .shape()
+            .change_prototype_transition(mc, prototype);
         Self {
             indexed_properties: IndexedProperties::default(),
             shape: shape.into(),
@@ -587,14 +593,21 @@ impl PropertyMap {
     }
 
     /// Insert the given property descriptor with the given key [`PropertyMap`].
-    pub fn insert(&mut self, key: &PropertyKey, property: PropertyDescriptor) -> bool {
+
+    pub fn insert(
+        &mut self,
+        mc: &boa_gc::MutationContext<'static, '_>,
+        key: &PropertyKey,
+        property: PropertyDescriptor,
+    ) -> bool {
         let mut dummy_slot = Slot::new();
-        self.insert_with_slot(key, property, &mut dummy_slot)
+        self.insert_with_slot(mc, key, property, &mut dummy_slot)
     }
 
     /// Insert the given property descriptor with the given key [`PropertyMap`].
     pub(crate) fn insert_with_slot(
         &mut self,
+        mc: &boa_gc::MutationContext<'static, '_>,
         key: &PropertyKey,
         property: PropertyDescriptor,
         out_slot: &mut Slot,
@@ -613,7 +626,7 @@ impl PropertyMap {
                     property_key: key.clone(),
                     attributes,
                 };
-                let transition = self.shape.change_attributes_transition(key);
+                let transition = self.shape.change_attributes_transition(mc, key);
                 self.shape = transition.shape;
                 match transition.action {
                     ChangeTransitionAction::Nothing => {}
@@ -655,7 +668,7 @@ impl PropertyMap {
             property_key: key.clone(),
             attributes,
         };
-        self.shape = self.shape.insert_property_transition(transition_key);
+        self.shape = self.shape.insert_property_transition(mc, transition_key);
 
         // Make Sure that if we are inserting, it has the correct slot index.
         debug_assert_eq!(
@@ -694,7 +707,7 @@ impl PropertyMap {
     }
 
     /// Remove the property with the given key from the [`PropertyMap`].
-    pub fn remove(&mut self, key: &PropertyKey) -> bool {
+    pub fn remove(&mut self, mc: &boa_gc::MutationContext<'static, '_>, key: &PropertyKey) -> bool {
         if let PropertyKey::Index(index) = key {
             return self.indexed_properties.remove(index.get());
         }
@@ -705,7 +718,7 @@ impl PropertyMap {
             }
             self.storage.remove(slot.index as usize);
 
-            self.shape = self.shape.remove_property_transition(key);
+            self.shape = self.shape.remove_property_transition(mc, key);
             return true;
         }
 

--- a/core/engine/src/object/shape/mod.rs
+++ b/core/engine/src/object/shape/mod.rs
@@ -106,16 +106,16 @@ impl Shape {
     /// Create an insert property transitions returning the new transitioned [`Shape`] using the given context.
     ///
     /// NOTE: This assumes that there is no property with the given key!
-    pub(crate) fn insert_property_transition_in(
+    pub(crate) fn insert_property_transition(
         &self,
         mc: &boa_gc::MutationContext<'static, '_>,
         key: TransitionKey,
     ) -> Self {
         match &self.inner {
             Inner::Shared(shape) => {
-                let shape = shape.insert_property_transition_in(mc, key);
+                let shape = shape.insert_property_transition(mc, key);
                 if shape.transition_count() >= Self::TRANSITION_COUNT_MAX {
-                    return shape.to_unique().into();
+                    return shape.to_unique(mc).into();
                 }
                 shape.into()
             }
@@ -126,26 +126,22 @@ impl Shape {
     /// Create an insert property transitions returning the new transitioned [`Shape`].
     ///
     /// NOTE: This assumes that there is no property with the given key!
-    pub(crate) fn insert_property_transition(&self, key: TransitionKey) -> Self {
-        // SAFETY: The global mutation context is used as a fallback during the context threading migration.
-        self.insert_property_transition_in(&unsafe { boa_gc::MutationContext::global() }, key)
-    }
 
     /// Create a change attribute property transitions returning [`ChangeTransition`] containing the new [`Shape`]
     /// and actions to be performed, using the given context.
     ///
     /// NOTE: This assumes that there already is a property with the given key!
-    pub(crate) fn change_attributes_transition_in(
+    pub(crate) fn change_attributes_transition(
         &self,
         mc: &boa_gc::MutationContext<'static, '_>,
         key: TransitionKey,
     ) -> ChangeTransition<Self> {
         match &self.inner {
             Inner::Shared(shape) => {
-                let change_transition = shape.change_attributes_transition_in(mc, key);
+                let change_transition = shape.change_attributes_transition(mc, key);
                 let shape =
                     if change_transition.shape.transition_count() >= Self::TRANSITION_COUNT_MAX {
-                        change_transition.shape.to_unique().into()
+                        change_transition.shape.to_unique(mc).into()
                     } else {
                         change_transition.shape.into()
                     };
@@ -154,7 +150,7 @@ impl Shape {
                     action: change_transition.action,
                 }
             }
-            Inner::Unique(shape) => shape.change_attributes_transition(&key),
+            Inner::Unique(shape) => shape.change_attributes_transition(mc, &key),
         }
     }
 
@@ -162,68 +158,50 @@ impl Shape {
     /// and actions to be performed
     ///
     /// NOTE: This assumes that there already is a property with the given key!
-    pub(crate) fn change_attributes_transition(
-        &self,
-        key: TransitionKey,
-    ) -> ChangeTransition<Self> {
-        // SAFETY: The global mutation context is used as a fallback during the context threading migration.
-        self.change_attributes_transition_in(&unsafe { boa_gc::MutationContext::global() }, key)
-    }
 
     /// Remove a property from the [`Shape`] returning the new transitioned [`Shape`] using the given context.
     ///
     /// NOTE: This assumes that there already is a property with the given key!
-    pub(crate) fn remove_property_transition_in(
+    pub(crate) fn remove_property_transition(
         &self,
         mc: &boa_gc::MutationContext<'static, '_>,
         key: &PropertyKey,
     ) -> Self {
         match &self.inner {
             Inner::Shared(shape) => {
-                let shape = shape.remove_property_transition_in(mc, key);
+                let shape = shape.remove_property_transition(mc, key);
                 if shape.transition_count() >= Self::TRANSITION_COUNT_MAX {
-                    return shape.to_unique().into();
+                    return shape.to_unique(mc).into();
                 }
                 shape.into()
             }
-            Inner::Unique(shape) => shape.remove_property_transition(key).into(),
+            Inner::Unique(shape) => shape.remove_property_transition(mc, key).into(),
         }
     }
 
     /// Remove a property from the [`Shape`] returning the new transitioned [`Shape`].
     ///
     /// NOTE: This assumes that there already is a property with the given key!
-    pub(crate) fn remove_property_transition(&self, key: &PropertyKey) -> Self {
-        // SAFETY: The global mutation context is used as a fallback during the context threading migration.
-        self.remove_property_transition_in(&unsafe { boa_gc::MutationContext::global() }, key)
-    }
 
     /// Create a prototype transition returning the new transitioned [`Shape`] using the given context.
-    pub(crate) fn change_prototype_transition_in(
+    pub(crate) fn change_prototype_transition(
         &self,
         mc: &boa_gc::MutationContext<'static, '_>,
         prototype: JsPrototype,
     ) -> Self {
         match &self.inner {
             Inner::Shared(shape) => {
-                let shape = shape.change_prototype_transition_in(mc, prototype);
+                let shape = shape.change_prototype_transition(mc, prototype);
                 if shape.transition_count() >= Self::TRANSITION_COUNT_MAX {
-                    return shape.to_unique().into();
+                    return shape.to_unique(mc).into();
                 }
                 shape.into()
             }
-            Inner::Unique(shape) => shape.change_prototype_transition(prototype).into(),
+            Inner::Unique(shape) => shape.change_prototype_transition(mc, prototype).into(),
         }
     }
 
     /// Create a prototype transition returning the new transitioned [`Shape`].
-    pub(crate) fn change_prototype_transition(&self, prototype: JsPrototype) -> Self {
-        self.change_prototype_transition_in(
-            // SAFETY: The global mutation context is used as a fallback during the context threading migration.
-            &unsafe { boa_gc::MutationContext::global() },
-            prototype,
-        )
-    }
 
     /// Get the [`JsPrototype`] of the [`Shape`].
     #[must_use]
@@ -294,7 +272,7 @@ impl WeakShape {
     #[inline]
     #[must_use]
     pub(crate) fn to_addr_usize(&self) -> usize {
-        self.upgrade().as_ref().map_or(0, Shape::to_addr_usize)
+        0 // Cannot get address of WeakShape without upgrading it, which requires MutationContext
     }
 
     /// Return location in memory of the [`Shape`].
@@ -302,19 +280,19 @@ impl WeakShape {
     /// Returns `0` if the shape has been freed.
     #[inline]
     #[must_use]
-    pub(crate) fn upgrade(&self) -> Option<Shape> {
+    pub(crate) fn upgrade(&self, mc: &boa_gc::MutationContext<'static, '_>) -> Option<Shape> {
         match self {
-            WeakShape::Shared(shape) => Some(shape.upgrade()?.into()),
-            WeakShape::Unique(shape) => Some(shape.upgrade()?.into()),
+            WeakShape::Shared(shape) => Some(shape.upgrade(mc)?.into()),
+            WeakShape::Unique(shape) => Some(shape.upgrade(mc)?.into()),
         }
     }
 }
 
-impl From<&Shape> for WeakShape {
-    fn from(value: &Shape) -> Self {
+impl WeakShape {
+    pub(crate) fn new(mc: &boa_gc::MutationContext<'static, '_>, value: &Shape) -> Self {
         match &value.inner {
-            Inner::Shared(shape) => WeakShape::Shared(shape.into()),
-            Inner::Unique(shape) => WeakShape::Unique(shape.into()),
+            Inner::Shared(shape) => WeakShape::Shared(WeakSharedShape::new(mc, shape)),
+            Inner::Unique(shape) => WeakShape::Unique(WeakUniqueShape::new(mc, shape)),
         }
     }
 }

--- a/core/engine/src/object/shape/root_shape.rs
+++ b/core/engine/src/object/shape/root_shape.rs
@@ -10,20 +10,12 @@ pub struct RootShape {
     shape: SharedShape,
 }
 
-impl Default for RootShape {
-    #[inline]
-    fn default() -> Self {
-        // SAFETY: The global mutation context is used as a fallback during the context threading migration.
-        Self::new_in(&unsafe { boa_gc::MutationContext::global() })
-    }
-}
-
 impl RootShape {
     /// Create a new root shape using the given context.
     #[inline]
-    pub(crate) fn new_in(mc: &boa_gc::MutationContext<'static, '_>) -> Self {
+    pub fn new(mc: &boa_gc::MutationContext<'static, '_>) -> Self {
         Self {
-            shape: SharedShape::root_in(mc),
+            shape: SharedShape::root(mc),
         }
     }
     /// Gets the inner [`SharedShape`].

--- a/core/engine/src/object/shape/shared_shape/forward_transition.rs
+++ b/core/engine/src/object/shape/shared_shape/forward_transition.rs
@@ -56,7 +56,7 @@ pub(super) struct ForwardTransition {
 
 impl ForwardTransition {
     /// Insert a property transition using the given context.
-    pub(super) fn insert_property_in(
+    pub(super) fn insert_property(
         &self,
         mc: &boa_gc::MutationContext<'static, '_>,
         key: TransitionKey,
@@ -73,17 +73,9 @@ impl ForwardTransition {
     }
 
     /// Insert a property transition.
-    pub(super) fn insert_property(
-        &self,
-        key: TransitionKey,
-        value: &Gc<'static, SharedShapeInner>,
-    ) {
-        // SAFETY: The global mutation context is used as a fallback during the context threading migration.
-        self.insert_property_in(&unsafe { boa_gc::MutationContext::global() }, key, value)
-    }
 
     /// Insert a prototype transition using the given context.
-    pub(super) fn insert_prototype_in(
+    pub(super) fn insert_prototype(
         &self,
         mc: &boa_gc::MutationContext<'static, '_>,
         key: JsPrototype,
@@ -100,10 +92,6 @@ impl ForwardTransition {
     }
 
     /// Insert a prototype transition.
-    pub(super) fn insert_prototype(&self, key: JsPrototype, value: &Gc<'static, SharedShapeInner>) {
-        // SAFETY: The global mutation context is used as a fallback during the context threading migration.
-        self.insert_prototype_in(&unsafe { boa_gc::MutationContext::global() }, key, value)
-    }
 
     /// Get a property transition, return [`None`] otherwise.
     #[allow(clippy::cloned_instead_of_copied)]

--- a/core/engine/src/object/shape/shared_shape/mod.rs
+++ b/core/engine/src/object/shape/shared_shape/mod.rs
@@ -164,22 +164,18 @@ impl SharedShape {
     }
 
     /// Create a new [`SharedShape`] using the given context.
-    fn new_in(mc: &boa_gc::MutationContext<'static, '_>, inner: Inner) -> Self {
+    fn new(mc: &boa_gc::MutationContext<'static, '_>, inner: Inner) -> Self {
         Self {
             inner: Gc::new(mc, inner),
         }
     }
 
     /// Create a new [`SharedShape`].
-    fn new(inner: Inner) -> Self {
-        // SAFETY: The global mutation context is used as a fallback during the context threading migration.
-        Self::new_in(&unsafe { boa_gc::MutationContext::global() }, inner)
-    }
 
     /// Create a root [`SharedShape`] using the given context.
     #[must_use]
-    pub(crate) fn root_in(mc: &boa_gc::MutationContext<'static, '_>) -> Self {
-        Self::new_in(
+    pub(crate) fn root(mc: &boa_gc::MutationContext<'static, '_>) -> Self {
+        Self::new(
             mc,
             Inner {
                 forward_transitions: ForwardTransition::default(),
@@ -195,14 +191,9 @@ impl SharedShape {
     }
 
     /// Create a root [`SharedShape`].
-    #[must_use]
-    pub(crate) fn root() -> Self {
-        // SAFETY: The global mutation context is used as a fallback during the context threading migration.
-        Self::root_in(&unsafe { boa_gc::MutationContext::global() })
-    }
 
     /// Create a [`SharedShape`] change prototype transition using the given context.
-    pub(crate) fn change_prototype_transition_in(
+    pub(crate) fn change_prototype_transition(
         &self,
         mc: &boa_gc::MutationContext<'static, '_>,
         prototype: JsPrototype,
@@ -223,25 +214,18 @@ impl SharedShape {
             transition_count: self.transition_count() + 1,
             flags: ShapeFlags::prototype_transition_from(self.flags()),
         };
-        let new_shape = Self::new_in(mc, new_inner_shape);
+        let new_shape = Self::new(mc, new_inner_shape);
 
         self.forward_transitions()
-            .insert_prototype(prototype, &new_shape.inner);
+            .insert_prototype(mc, prototype, &new_shape.inner);
 
         new_shape
     }
 
     /// Create a [`SharedShape`] change prototype transition.
-    pub(crate) fn change_prototype_transition(&self, prototype: JsPrototype) -> Self {
-        self.change_prototype_transition_in(
-            // SAFETY: The global mutation context is used as a fallback during the context threading migration.
-            &unsafe { boa_gc::MutationContext::global() },
-            prototype,
-        )
-    }
 
     /// Create a [`SharedShape`] insert property transition using the given context.
-    pub(crate) fn insert_property_transition_in(
+    pub(crate) fn insert_property_transition(
         &self,
         mc: &boa_gc::MutationContext<'static, '_>,
         key: TransitionKey,
@@ -269,31 +253,20 @@ impl SharedShape {
             transition_count: self.transition_count() + 1,
             flags: ShapeFlags::insert_property_transition_from(self.flags()),
         };
-        let new_shape = Self::new_in(mc, new_inner_shape);
+        let new_shape = Self::new(mc, new_inner_shape);
 
         self.forward_transitions()
-            .insert_property(key, &new_shape.inner);
+            .insert_property(mc, key, &new_shape.inner);
 
         new_shape
     }
 
     /// Create a [`SharedShape`] insert property transition.
-    pub(crate) fn insert_property_transition(&self, key: TransitionKey) -> Self {
-        // SAFETY: The global mutation context is used as a fallback during the context threading migration.
-        self.insert_property_transition_in(&unsafe { boa_gc::MutationContext::global() }, key)
-    }
 
     /// Create a [`SharedShape`] change prototype transition, returning [`ChangeTransition`].
-    pub(crate) fn change_attributes_transition(
-        &self,
-        key: TransitionKey,
-    ) -> ChangeTransition<Self> {
-        // SAFETY: The global mutation context is used as a fallback during the context threading migration.
-        self.change_attributes_transition_in(&unsafe { boa_gc::MutationContext::global() }, key)
-    }
 
     /// Create a [`SharedShape`] change prototype transition using the given context, returning [`ChangeTransition`].
-    pub(crate) fn change_attributes_transition_in(
+    pub(crate) fn change_attributes_transition(
         &self,
         mc: &boa_gc::MutationContext<'static, '_>,
         key: TransitionKey,
@@ -335,10 +308,10 @@ impl SharedShape {
                 transition_count: self.transition_count() + 1,
                 flags: ShapeFlags::configure_property_transition_from(self.flags()),
             };
-            let shape = Self::new(inner_shape);
+            let shape = Self::new(mc, inner_shape);
 
             self.forward_transitions()
-                .insert_property(key, &shape.inner);
+                .insert_property(mc, key, &shape.inner);
 
             return ChangeTransition {
                 shape,
@@ -351,11 +324,11 @@ impl SharedShape {
 
         // Apply prototype transition, if it was found.
         if let Some(prototype) = prototype {
-            base = base.change_prototype_transition(prototype);
+            base = base.change_prototype_transition(mc, prototype);
         }
 
         // Apply this property.
-        base = base.insert_property_transition(key);
+        base = base.insert_property_transition(mc, key);
 
         // Apply previous properties.
         for (property_key, attributes) in transitions.into_iter().rev() {
@@ -363,7 +336,7 @@ impl SharedShape {
                 property_key,
                 attributes,
             };
-            base = base.insert_property_transition(transition);
+            base = base.insert_property_transition(mc, transition);
         }
 
         // Determine action to be performed on the storage.
@@ -462,7 +435,7 @@ impl SharedShape {
     }
 
     /// Remove a property from [`SharedShape`], returning the new [`SharedShape`] using the given context.
-    pub(crate) fn remove_property_transition_in(
+    pub(crate) fn remove_property_transition(
         &self,
         mc: &boa_gc::MutationContext<'static, '_>,
         key: &PropertyKey,
@@ -471,7 +444,7 @@ impl SharedShape {
 
         // Apply prototype transition, if it was found.
         if let Some(prototype) = prototype {
-            base = base.change_prototype_transition_in(mc, prototype);
+            base = base.change_prototype_transition(mc, prototype);
         }
 
         for (property_key, attributes) in transitions.into_iter().rev() {
@@ -479,17 +452,13 @@ impl SharedShape {
                 property_key,
                 attributes,
             };
-            base = base.insert_property_transition_in(mc, transition);
+            base = base.insert_property_transition(mc, transition);
         }
 
         base
     }
 
     /// Remove a property from [`SharedShape`], returning the new [`SharedShape`].
-    pub(crate) fn remove_property_transition(&self, key: &PropertyKey) -> Self {
-        // SAFETY: The global mutation context is used as a fallback during the context threading migration.
-        self.remove_property_transition_in(&unsafe { boa_gc::MutationContext::global() }, key)
-    }
 
     /// Do a property lookup, returns [`None`] if property not found.
     pub(crate) fn lookup(&self, key: &PropertyKey) -> Option<Slot> {
@@ -515,8 +484,9 @@ impl SharedShape {
     }
 
     /// Returns a new [`UniqueShape`] with the properties of the [`SharedShape`].
-    pub(crate) fn to_unique(&self) -> UniqueShape {
+    pub(crate) fn to_unique(&self, mc: &boa_gc::MutationContext<'static, '_>) -> UniqueShape {
         UniqueShape::new(
+            mc,
             self.prototype(),
             self.property_table()
                 .inner()
@@ -543,10 +513,7 @@ impl WeakSharedShape {
     /// or [`None`] if the value was already garbage collected, using the given context.
     #[inline]
     #[must_use]
-    pub(crate) fn upgrade_in(
-        &self,
-        mc: &boa_gc::MutationContext<'static, '_>,
-    ) -> Option<SharedShape> {
+    pub(crate) fn upgrade(&self, mc: &boa_gc::MutationContext<'static, '_>) -> Option<SharedShape> {
         Some(SharedShape {
             inner: self.inner.upgrade(mc)?,
         })
@@ -554,27 +521,14 @@ impl WeakSharedShape {
 
     /// Upgrade returns a [`SharedShape`] pointer for the internal value if the pointer is still live,
     /// or [`None`] if the value was already garbage collected.
-    #[inline]
-    #[must_use]
-    pub(crate) fn upgrade(&self) -> Option<SharedShape> {
-        // SAFETY: The global mutation context is used as a fallback during the context threading migration.
-        self.upgrade_in(&unsafe { boa_gc::MutationContext::global() })
-    }
 
     #[allow(dead_code)]
     pub(crate) fn is_upgradable(&self) -> bool {
         self.inner.is_upgradable()
     }
-    pub(crate) fn new_in(mc: &boa_gc::MutationContext<'static, '_>, value: &SharedShape) -> Self {
+    pub(crate) fn new(mc: &boa_gc::MutationContext<'static, '_>, value: &SharedShape) -> Self {
         WeakSharedShape {
             inner: WeakGc::new(mc, &value.inner),
         }
-    }
-}
-
-impl From<&SharedShape> for WeakSharedShape {
-    fn from(value: &SharedShape) -> Self {
-        // SAFETY: The global mutation context is used as a fallback during the context threading migration.
-        Self::new_in(&unsafe { boa_gc::MutationContext::global() }, value)
     }
 }

--- a/core/engine/src/object/shape/shared_shape/template.rs
+++ b/core/engine/src/object/shape/shared_shape/template.rs
@@ -28,24 +28,16 @@ impl ObjectTemplate {
     }
 
     /// Create and [`ObjectTemplate`] with a prototype using the given context.
-    pub(crate) fn with_prototype_in(
+    pub(crate) fn with_prototype(
         mc: &boa_gc::MutationContext<'static, '_>,
         shape: &SharedShape,
         prototype: JsObject,
     ) -> Self {
-        let shape = shape.change_prototype_transition_in(mc, Some(prototype));
+        let shape = shape.change_prototype_transition(mc, Some(prototype));
         Self { shape }
     }
 
     /// Create and [`ObjectTemplate`] with a prototype.
-    pub(crate) fn with_prototype(shape: &SharedShape, prototype: JsObject) -> Self {
-        Self::with_prototype_in(
-            // SAFETY: The global mutation context is used as a fallback during the context threading migration.
-            &unsafe { boa_gc::MutationContext::global() },
-            shape,
-            prototype,
-        )
-    }
 
     /// Check if the shape has a specific, prototype.
     pub(crate) fn has_prototype(&self, prototype: &JsObject) -> bool {
@@ -55,24 +47,18 @@ impl ObjectTemplate {
     /// Set the prototype of the [`ObjectTemplate`] using the given context.
     ///
     /// This assumes that the prototype has not been set yet.
-    pub(crate) fn set_prototype_in(
+    pub(crate) fn set_prototype(
         &mut self,
         mc: &boa_gc::MutationContext<'static, '_>,
         prototype: JsObject,
     ) -> &mut Self {
-        self.shape = self
-            .shape
-            .change_prototype_transition_in(mc, Some(prototype));
+        self.shape = self.shape.change_prototype_transition(mc, Some(prototype));
         self
     }
 
     /// Set the prototype of the [`ObjectTemplate`].
     ///
     /// This assumes that the prototype has not been set yet.
-    pub(crate) fn set_prototype(&mut self, prototype: JsObject) -> &mut Self {
-        // SAFETY: The global mutation context is used as a fallback during the context threading migration.
-        self.set_prototype_in(&unsafe { boa_gc::MutationContext::global() }, prototype)
-    }
 
     /// Returns the inner shape of the [`ObjectTemplate`].
     pub(crate) const fn shape(&self) -> &SharedShape {
@@ -83,7 +69,7 @@ impl ObjectTemplate {
     ///
     /// This assumes that the property with the given key was not previously set
     /// and that it's a string or symbol.
-    pub(crate) fn property_in(
+    pub(crate) fn property(
         &mut self,
         mc: &boa_gc::MutationContext<'static, '_>,
         key: PropertyKey,
@@ -95,7 +81,7 @@ impl ObjectTemplate {
             property_key: key,
             attributes: SlotAttributes::from_bits_truncate(attributes.bits()),
         };
-        self.shape = self.shape.insert_property_transition_in(mc, transition);
+        self.shape = self.shape.insert_property_transition(mc, transition);
         self
     }
 
@@ -103,21 +89,13 @@ impl ObjectTemplate {
     ///
     /// This assumes that the property with the given key was not previously set
     /// and that it's a string or symbol.
-    pub(crate) fn property(&mut self, key: PropertyKey, attributes: Attribute) -> &mut Self {
-        self.property_in(
-            // SAFETY: The global mutation context is used as a fallback during the context threading migration.
-            &unsafe { boa_gc::MutationContext::global() },
-            key,
-            attributes,
-        )
-    }
 
     /// Add a accessor property to the [`ObjectTemplate`].
     ///
     /// This assumes that the property with the given key was not previously set
     /// and that it's a string or symbol.
     /// Add a accessor property to the [`ObjectTemplate`] using the given context.
-    pub(crate) fn accessor_in(
+    pub(crate) fn accessor(
         &mut self,
         mc: &boa_gc::MutationContext<'static, '_>,
         key: PropertyKey,
@@ -144,7 +122,7 @@ impl ObjectTemplate {
             result
         };
 
-        self.shape = self.shape.insert_property_transition_in(
+        self.shape = self.shape.insert_property_transition(
             mc,
             TransitionKey {
                 property_key: key,
@@ -158,25 +136,9 @@ impl ObjectTemplate {
     ///
     /// This assumes that the property with the given key was not previously set
     /// and that it's a string or symbol.
-    pub(crate) fn accessor(
-        &mut self,
-        key: PropertyKey,
-        get: bool,
-        set: bool,
-        attributes: Attribute,
-    ) -> &mut Self {
-        self.accessor_in(
-            // SAFETY: The global mutation context is used as a fallback during the context threading migration.
-            &unsafe { boa_gc::MutationContext::global() },
-            key,
-            get,
-            set,
-            attributes,
-        )
-    }
 
     /// Create an object from the [`ObjectTemplate`] using the given context.
-    pub(crate) fn create_in<T: NativeObject>(
+    pub(crate) fn create<T: NativeObject>(
         &self,
         mc: &boa_gc::MutationContext<'static, '_>,
         data: T,
@@ -197,16 +159,12 @@ impl ObjectTemplate {
             private_elements: ThinVec::new(),
         };
 
-        JsObject::from_object_and_vtable_in(mc, object, internal_methods)
+        JsObject::from_object_and_vtable(mc, object, internal_methods)
     }
 
     /// Create an object from the [`ObjectTemplate`]
     ///
     /// The storage must match the properties provided.
-    pub(crate) fn create<T: NativeObject>(&self, data: T, storage: Vec<JsValue>) -> JsObject {
-        // SAFETY: The global mutation context is used as a fallback during the context threading migration.
-        self.create_in(&unsafe { boa_gc::MutationContext::global() }, data, storage)
-    }
 
     /// Create an object from the [`ObjectTemplate`]
     ///
@@ -214,6 +172,7 @@ impl ObjectTemplate {
     /// the indexed properties.
     pub(crate) fn create_with_indexed_properties<T: NativeObject>(
         &self,
+        mc: &boa_gc::MutationContext<'static, '_>,
         data: T,
         storage: Vec<JsValue>,
         indexed_properties: IndexedProperties,
@@ -228,6 +187,6 @@ impl ObjectTemplate {
 
         object.properties.storage = storage;
 
-        JsObject::from_object_and_vtable(object, internal_methods)
+        JsObject::from_object_and_vtable(mc, object, internal_methods)
     }
 }

--- a/core/engine/src/object/shape/shared_shape/tests.rs
+++ b/core/engine/src/object/shape/shared_shape/tests.rs
@@ -4,7 +4,7 @@ use super::{SharedShape, TransitionKey};
 
 #[test]
 fn test_prune_property_on_counter_limit() {
-    let shape = SharedShape::root();
+    let shape = SharedShape::root(&unsafe { boa_gc::MutationContext::global() });
 
     for i in 0..255 {
         assert_eq!(
@@ -12,10 +12,13 @@ fn test_prune_property_on_counter_limit() {
             (i, i as u8)
         );
 
-        shape.insert_property_transition(TransitionKey {
-            property_key: PropertyKey::Symbol(JsSymbol::new(None).unwrap()),
-            attributes: SlotAttributes::all(),
-        });
+        shape.insert_property_transition(
+            &unsafe { boa_gc::MutationContext::global() },
+            TransitionKey {
+                property_key: PropertyKey::Symbol(JsSymbol::new(None).unwrap()),
+                attributes: SlotAttributes::all(),
+            },
+        );
     }
 
     assert_eq!(
@@ -26,10 +29,13 @@ fn test_prune_property_on_counter_limit() {
     boa_gc::force_collect();
 
     {
-        shape.insert_property_transition(TransitionKey {
-            property_key: PropertyKey::Symbol(JsSymbol::new(None).unwrap()),
-            attributes: SlotAttributes::all(),
-        });
+        shape.insert_property_transition(
+            &unsafe { boa_gc::MutationContext::global() },
+            TransitionKey {
+                property_key: PropertyKey::Symbol(JsSymbol::new(None).unwrap()),
+                attributes: SlotAttributes::all(),
+            },
+        );
     }
 
     assert_eq!(
@@ -38,10 +44,13 @@ fn test_prune_property_on_counter_limit() {
     );
 
     {
-        shape.insert_property_transition(TransitionKey {
-            property_key: PropertyKey::Symbol(JsSymbol::new(None).unwrap()),
-            attributes: SlotAttributes::all(),
-        });
+        shape.insert_property_transition(
+            &unsafe { boa_gc::MutationContext::global() },
+            TransitionKey {
+                property_key: PropertyKey::Symbol(JsSymbol::new(None).unwrap()),
+                attributes: SlotAttributes::all(),
+            },
+        );
     }
 
     assert_eq!(
@@ -59,7 +68,7 @@ fn test_prune_property_on_counter_limit() {
 
 #[test]
 fn test_prune_prototype_on_counter_limit() {
-    let shape = SharedShape::root();
+    let shape = SharedShape::root(&unsafe { boa_gc::MutationContext::global() });
 
     assert_eq!(
         shape.forward_transitions().prototype_transitions_count(),
@@ -72,7 +81,12 @@ fn test_prune_prototype_on_counter_limit() {
             (i, i as u8)
         );
 
-        shape.change_prototype_transition(Some(JsObject::with_null_proto()));
+        shape.change_prototype_transition(
+            &unsafe { boa_gc::MutationContext::global() },
+            Some(JsObject::with_null_proto(&unsafe {
+                boa_gc::MutationContext::global()
+            })),
+        );
     }
 
     boa_gc::force_collect();
@@ -83,7 +97,12 @@ fn test_prune_prototype_on_counter_limit() {
     );
 
     {
-        shape.change_prototype_transition(Some(JsObject::with_null_proto()));
+        shape.change_prototype_transition(
+            &unsafe { boa_gc::MutationContext::global() },
+            Some(JsObject::with_null_proto(&unsafe {
+                boa_gc::MutationContext::global()
+            })),
+        );
     }
 
     assert_eq!(
@@ -92,7 +111,12 @@ fn test_prune_prototype_on_counter_limit() {
     );
 
     {
-        shape.change_prototype_transition(Some(JsObject::with_null_proto()));
+        shape.change_prototype_transition(
+            &unsafe { boa_gc::MutationContext::global() },
+            Some(JsObject::with_null_proto(&unsafe {
+                boa_gc::MutationContext::global()
+            })),
+        );
     }
 
     assert_eq!(

--- a/core/engine/src/object/shape/unique_shape.rs
+++ b/core/engine/src/object/shape/unique_shape.rs
@@ -35,7 +35,7 @@ pub(crate) struct UniqueShape {
 
 impl UniqueShape {
     /// Create a new [`UniqueShape`] using the given context.
-    pub(crate) fn new_in(
+    pub(crate) fn new(
         mc: &boa_gc::MutationContext<'static, '_>,
         prototype: JsPrototype,
         property_table: PropertyTableInner,
@@ -52,14 +52,6 @@ impl UniqueShape {
     }
 
     /// Create a new [`UniqueShape`].
-    pub(crate) fn new(prototype: JsPrototype, property_table: PropertyTableInner) -> Self {
-        Self::new_in(
-            // SAFETY: The global mutation context is used as a fallback during the context threading migration.
-            &unsafe { boa_gc::MutationContext::global() },
-            prototype,
-            property_table,
-        )
-    }
 
     pub(crate) fn override_internal(
         &self,
@@ -93,7 +85,11 @@ impl UniqueShape {
     /// Remove a property from the [`UniqueShape`].
     ///
     /// This will cause the current shape to be invalidated, and a new [`UniqueShape`] will be returned.
-    pub(crate) fn remove_property_transition(&self, key: &PropertyKey) -> Self {
+    pub(crate) fn remove_property_transition(
+        &self,
+        mc: &boa_gc::MutationContext<'static, '_>,
+        key: &PropertyKey,
+    ) -> Self {
         let mut property_table = self.property_table().borrow_mut();
         let Some((index, _attributes)) = property_table.map.remove(key) else {
             return self.clone();
@@ -133,7 +129,7 @@ impl UniqueShape {
         }
 
         let prototype = self.inner.prototype.borrow_mut().take();
-        Self::new(prototype, property_table)
+        Self::new(mc, prototype, property_table)
     }
 
     /// Does a property lookup on the [`UniqueShape`] returning the [`Slot`] where it's
@@ -154,6 +150,7 @@ impl UniqueShape {
     /// NOTE: This assumes that the property had already been inserted.
     pub(crate) fn change_attributes_transition(
         &self,
+        mc: &boa_gc::MutationContext<'static, '_>,
         key: &TransitionKey,
     ) -> ChangeTransition<Shape> {
         let mut property_table = self.property_table().borrow_mut();
@@ -228,7 +225,7 @@ impl UniqueShape {
         }
 
         let prototype = self.inner.prototype.borrow_mut().take();
-        let shape = Self::new(prototype, property_table);
+        let shape = Self::new(mc, prototype, property_table);
 
         ChangeTransition {
             shape: shape.into(),
@@ -239,13 +236,17 @@ impl UniqueShape {
     /// Change the prototype of the [`UniqueShape`].
     ///
     /// This will cause the current shape to be invalidated, and a new [`UniqueShape`] will be returned.
-    pub(crate) fn change_prototype_transition(&self, prototype: JsPrototype) -> Self {
+    pub(crate) fn change_prototype_transition(
+        &self,
+        mc: &boa_gc::MutationContext<'static, '_>,
+        prototype: JsPrototype,
+    ) -> Self {
         let mut property_table = self.inner.property_table.borrow_mut();
 
         // We need to create a new unique shape,
         // to invalidate any pointers to this shape i.e inline caches.
         let property_table = std::mem::take(&mut *property_table);
-        Self::new(prototype, property_table)
+        Self::new(mc, prototype, property_table)
     }
 
     /// Gets all keys first strings then symbols in creation order.
@@ -271,10 +272,7 @@ impl WeakUniqueShape {
     /// or [`None`] if the value was already garbage collected, using the given context.
     #[inline]
     #[must_use]
-    pub(crate) fn upgrade_in(
-        &self,
-        mc: &boa_gc::MutationContext<'static, '_>,
-    ) -> Option<UniqueShape> {
+    pub(crate) fn upgrade(&self, mc: &boa_gc::MutationContext<'static, '_>) -> Option<UniqueShape> {
         Some(UniqueShape {
             inner: self.inner.upgrade(mc)?,
         })
@@ -282,27 +280,14 @@ impl WeakUniqueShape {
 
     /// Upgrade returns a [`UniqueShape`] pointer for the internal value if the pointer is still live,
     /// or [`None`] if the value was already garbage collected.
-    #[inline]
-    #[must_use]
-    pub(crate) fn upgrade(&self) -> Option<UniqueShape> {
-        // SAFETY: The global mutation context is used as a fallback during the context threading migration.
-        self.upgrade_in(&unsafe { boa_gc::MutationContext::global() })
-    }
 
     #[allow(dead_code)]
     pub(crate) fn is_upgradable(&self) -> bool {
         self.inner.is_upgradable()
     }
-    pub(crate) fn new_in(mc: &boa_gc::MutationContext<'static, '_>, value: &UniqueShape) -> Self {
+    pub(crate) fn new(mc: &boa_gc::MutationContext<'static, '_>, value: &UniqueShape) -> Self {
         WeakUniqueShape {
             inner: WeakGc::new(mc, &value.inner),
         }
-    }
-}
-
-impl From<&UniqueShape> for WeakUniqueShape {
-    fn from(value: &UniqueShape) -> Self {
-        // SAFETY: The global mutation context is used as a fallback during the context threading migration.
-        Self::new_in(&unsafe { boa_gc::MutationContext::global() }, value)
     }
 }

--- a/core/engine/src/realm.rs
+++ b/core/engine/src/realm.rs
@@ -86,7 +86,7 @@ impl Realm {
             JsNativeError::typ().with_message("failed to create the realm intrinsics")
         })?;
 
-        let global_object = hooks.create_global_object(&intrinsics);
+        let global_object = hooks.create_global_object(mc, &intrinsics);
         let global_this = hooks
             .create_global_this(&intrinsics)
             .unwrap_or_else(|| global_object.clone());
@@ -110,7 +110,7 @@ impl Realm {
             ),
         };
 
-        realm.initialize();
+        realm.initialize(mc);
 
         Ok(realm)
     }

--- a/core/engine/src/script.rs
+++ b/core/engine/src/script.rs
@@ -147,7 +147,7 @@ impl Script {
                 false,
                 false,
                 context.interner_mut(),
-                &mc,
+                mc,
                 false,
                 spanned_source_text,
                 self.inner

--- a/core/engine/src/symbol.rs
+++ b/core/engine/src/symbol.rs
@@ -15,11 +15,7 @@
 //! [spec]: https://tc39.es/ecma262/#sec-symbol-value
 //! [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol
 
-#![deny(
-    unsafe_op_in_unsafe_fn,
-    clippy::undocumented_unsafe_blocks,
-    clippy::missing_safety_doc
-)]
+#![deny(unsafe_op_in_unsafe_fn, clippy::missing_safety_doc)]
 
 use crate::{
     js_string,
@@ -424,7 +420,8 @@ mod tests {
         let mut context = Context::default();
         let symbol1 = JsSymbol::new(None).unwrap();
         let symbol2 = JsSymbol::new(None).unwrap();
-        let test_obj = JsObject::from_proto_and_data(None, ());
+        let test_obj =
+            JsObject::from_proto_and_data(&unsafe { boa_gc::MutationContext::global() }, None, ());
         test_obj
             .set(symbol1, js_str!("Can't see me"), false, &mut context)
             .unwrap();
@@ -448,7 +445,7 @@ mod tests {
     fn hidden_in_stringify() {
         let mut context = Context::default();
         let symbol = JsSymbol::new(None).unwrap();
-        let test_obj = JsObject::with_object_proto(context.intrinsics());
+        let test_obj = JsObject::with_object_proto(context.gc_collector(), context.intrinsics());
         test_obj
             .set(symbol, js_str!("This won't show up"), false, &mut context)
             .unwrap();

--- a/core/engine/src/value/conversions/serde_json.rs
+++ b/core/engine/src/value/conversions/serde_json.rs
@@ -66,16 +66,19 @@ impl JsValue {
                 Ok(Array::create_array_from_list(arr, context).into())
             }
             Value::Object(obj) => {
-                let js_obj = JsObject::with_object_proto(context.intrinsics());
+                let js_obj =
+                    JsObject::with_object_proto(context.gc_collector(), context.intrinsics());
                 for (key, value) in obj {
                     let property = PropertyDescriptor::builder()
                         .value(Self::from_json(value, context)?)
                         .writable(true)
                         .enumerable(true)
                         .configurable(true);
-                    js_obj
-                        .borrow_mut()
-                        .insert(js_string!(key.clone()), property);
+                    js_obj.borrow_mut().insert(
+                        context.gc_collector(),
+                        js_string!(key.clone()),
+                        property.build(),
+                    );
                 }
 
                 Ok(js_obj.into())
@@ -305,7 +308,7 @@ mod tests {
     #[test]
     fn to_json_cyclic() {
         let mut context = Context::default();
-        let obj = JsObject::with_null_proto();
+        let obj = JsObject::with_null_proto(&unsafe { boa_gc::MutationContext::global() });
         obj.create_data_property(js_string!("a"), obj.clone(), &mut context)
             .expect("should create data property");
 
@@ -336,7 +339,7 @@ mod tests {
             //     "outer_c": [2, undefined, 3, { "inner_a": undefined }]
             // }
 
-            let inner = JsObject::with_null_proto();
+            let inner = JsObject::with_null_proto(&unsafe { boa_gc::MutationContext::global() });
             inner
                 .create_data_property(js_string!("inner_a"), JsValue::undefined(), &mut context)
                 .expect("should add property");
@@ -349,7 +352,7 @@ mod tests {
             array.push(3, &mut context).expect("should push");
             array.push(inner, &mut context).expect("should push");
 
-            let outer = JsObject::with_null_proto();
+            let outer = JsObject::with_null_proto(&unsafe { boa_gc::MutationContext::global() });
             outer
                 .create_data_property(js_string!("outer_a"), JsValue::new(1), &mut context)
                 .expect("should add property");

--- a/core/engine/src/value/inner/nan_boxed.rs
+++ b/core/engine/src/value/inner/nan_boxed.rs
@@ -1014,7 +1014,7 @@ fn bigint() {
 
 #[test]
 fn object() {
-    let object = JsObject::with_null_proto();
+    let object = JsObject::with_null_proto(&unsafe { boa_gc::MutationContext::global() });
     let v = NanBoxedValue::object(object.clone());
     assert_type!(v is object(object));
 }

--- a/core/engine/src/value/mod.rs
+++ b/core/engine/src/value/mod.rs
@@ -1000,39 +1000,39 @@ impl JsValue {
             JsVariant::Undefined | JsVariant::Null => Err(JsNativeError::typ()
                 .with_message("cannot convert 'null' or 'undefined' to object")
                 .into()),
-            JsVariant::Boolean(boolean) => Ok(context
-                .intrinsics()
-                .templates()
-                .boolean()
-                .create(boolean, Vec::default())),
-            JsVariant::Integer32(integer) => Ok(context
-                .intrinsics()
-                .templates()
-                .number()
-                .create(f64::from(integer), Vec::default())),
-            JsVariant::Float64(rational) => Ok(context
-                .intrinsics()
-                .templates()
-                .number()
-                .create(rational, Vec::default())),
+            JsVariant::Boolean(boolean) => Ok(context.intrinsics().templates().boolean().create(
+                context.gc_collector(),
+                boolean,
+                Vec::default(),
+            )),
+            JsVariant::Integer32(integer) => Ok(context.intrinsics().templates().number().create(
+                context.gc_collector(),
+                f64::from(integer),
+                Vec::default(),
+            )),
+            JsVariant::Float64(rational) => Ok(context.intrinsics().templates().number().create(
+                context.gc_collector(),
+                rational,
+                Vec::default(),
+            )),
             JsVariant::String(string) => {
                 let len = string.len();
-                Ok(context
-                    .intrinsics()
-                    .templates()
-                    .string()
-                    .create(string, vec![len.into()]))
+                Ok(context.intrinsics().templates().string().create(
+                    context.gc_collector(),
+                    string,
+                    vec![len.into()],
+                ))
             }
-            JsVariant::Symbol(symbol) => Ok(context
-                .intrinsics()
-                .templates()
-                .symbol()
-                .create(symbol, Vec::default())),
-            JsVariant::BigInt(bigint) => Ok(context
-                .intrinsics()
-                .templates()
-                .bigint()
-                .create(bigint, Vec::default())),
+            JsVariant::Symbol(symbol) => Ok(context.intrinsics().templates().symbol().create(
+                context.gc_collector(),
+                symbol,
+                Vec::default(),
+            )),
+            JsVariant::BigInt(bigint) => Ok(context.intrinsics().templates().bigint().create(
+                context.gc_collector(),
+                bigint,
+                Vec::default(),
+            )),
             JsVariant::Object(jsobject) => Ok(jsobject),
         }
     }

--- a/core/engine/src/value/mod.rs
+++ b/core/engine/src/value/mod.rs
@@ -292,7 +292,8 @@ impl JsValue {
     /// ```
     /// use boa_engine::{JsValue, object::JsObject};
     ///
-    /// let obj = JsValue::new(JsObject::with_null_proto());
+    /// # let context = &mut boa_engine::Context::default();
+    /// let obj = JsValue::new(JsObject::with_null_proto(context.gc_collector()));
     /// assert!(obj.is_object());
     ///
     /// let number = JsValue::new(42);
@@ -311,7 +312,8 @@ impl JsValue {
     /// ```
     /// use boa_engine::{JsValue, object::JsObject};
     ///
-    /// let obj = JsValue::new(JsObject::with_null_proto());
+    /// # let context = &mut boa_engine::Context::default();
+    /// let obj = JsValue::new(JsObject::with_null_proto(context.gc_collector()));
     /// assert!(obj.as_object().is_some());
     ///
     /// let number = JsValue::new(42);
@@ -330,7 +332,8 @@ impl JsValue {
     /// ```
     /// use boa_engine::{JsValue, object::JsObject};
     ///
-    /// let obj = JsValue::new(JsObject::with_null_proto());
+    /// # let context = &mut boa_engine::Context::default();
+    /// let obj = JsValue::new(JsObject::with_null_proto(context.gc_collector()));
     /// let inner = obj.into_object();
     /// assert!(inner.is_some());
     ///
@@ -357,7 +360,7 @@ impl JsValue {
     ///
     /// let context = &mut Context::default();
     /// let native_fn = NativeFunction::from_copy_closure(|_, _, _| Ok(JsValue::undefined()));
-    /// let js_value = JsValue::from(native_fn.to_js_function(context.realm()));
+    /// let js_value = JsValue::from(native_fn.to_js_function(context.realm(), context.gc_collector()));
     /// assert!(js_value.is_callable());
     ///
     /// let number = JsValue::new(42);
@@ -378,7 +381,7 @@ impl JsValue {
     ///
     /// let context = &mut Context::default();
     /// let native_fn = NativeFunction::from_copy_closure(|_, _, _| Ok(JsValue::undefined()));
-    /// let js_value = JsValue::from(native_fn.to_js_function(context.realm()));
+    /// let js_value = JsValue::from(native_fn.to_js_function(context.realm(), context.gc_collector()));
     /// assert!(js_value.as_callable().is_some());
     ///
     /// let number = JsValue::new(42);
@@ -400,7 +403,7 @@ impl JsValue {
     ///
     /// let context = &mut Context::default();
     /// let native_fn = NativeFunction::from_copy_closure(|_, _, _| Ok(JsValue::undefined()));
-    /// let js_value = JsValue::from(native_fn.to_js_function(context.realm()));
+    /// let js_value = JsValue::from(native_fn.to_js_function(context.realm(), context.gc_collector()));
     /// assert!(js_value.as_function().is_some());
     ///
     /// let number = JsValue::new(42);

--- a/core/engine/src/value/tests.rs
+++ b/core/engine/src/value/tests.rs
@@ -26,7 +26,7 @@ fn undefined() {
 #[test]
 fn get_set_field() {
     run_test_actions([TestAction::assert_context(|ctx| {
-        let obj = &JsObject::with_object_proto(ctx.intrinsics());
+        let obj = &JsObject::with_object_proto(ctx.gc_collector(), ctx.intrinsics());
         // Create string and convert it to a Value
         let s = JsValue::new(js_str!("bar"));
         obj.set(js_str!("foo"), s, false, ctx).unwrap();
@@ -128,11 +128,15 @@ fn hash_rational() {
 
 #[test]
 fn hash_object() {
-    let object1 = JsValue::new(JsObject::with_null_proto());
+    let object1 = JsValue::new(JsObject::with_null_proto(&unsafe {
+        boa_gc::MutationContext::global()
+    }));
     assert_eq!(object1, object1);
     assert_eq!(object1, object1.clone());
 
-    let object2 = JsValue::new(JsObject::with_null_proto());
+    let object2 = JsValue::new(JsObject::with_null_proto(&unsafe {
+        boa_gc::MutationContext::global()
+    }));
     assert_ne!(object1, object2);
 
     assert_eq!(hash_value(&object1), hash_value(&object1.clone()));

--- a/core/engine/src/vm/code_block.rs
+++ b/core/engine/src/vm/code_block.rs
@@ -1115,6 +1115,7 @@ pub(crate) fn create_function_object(
 
     let (mut template, storage, constructor_prototype) = if is_generator {
         let prototype = JsObject::from_proto_and_data_with_shared_shape(
+            context.gc_collector(),
             context.root_shape(),
             if is_async {
                 context.intrinsics().objects().async_generator()
@@ -1136,9 +1137,11 @@ pub(crate) fn create_function_object(
             None,
         )
     } else {
-        let constructor_prototype = templates
-            .function_prototype()
-            .create(OrdinaryObject, vec![JsValue::undefined()]);
+        let constructor_prototype = templates.function_prototype().create(
+            context.gc_collector(),
+            OrdinaryObject,
+            vec![JsValue::undefined()],
+        );
 
         let template = templates.function_with_prototype_without_proto();
 
@@ -1149,9 +1152,9 @@ pub(crate) fn create_function_object(
         )
     };
 
-    template.set_prototype(prototype);
+    template.set_prototype(context.gc_collector(), prototype);
 
-    let constructor = template.create(function, storage);
+    let constructor = template.create(context.gc_collector(), function, storage);
 
     if let Some(constructor_prototype) = &constructor_prototype {
         constructor_prototype.borrow_mut().properties_mut().storage[0] = constructor.clone().into();
@@ -1185,6 +1188,7 @@ pub(crate) fn create_function_object_fast(
 
     if is_generator {
         let prototype = JsObject::from_proto_and_data_with_shared_shape(
+            context.gc_collector(),
             context.root_shape(),
             if is_async {
                 context.intrinsics().objects().async_generator()
@@ -1199,31 +1203,43 @@ pub(crate) fn create_function_object_fast(
             context.intrinsics().templates().generator_function()
         };
 
-        template.create(function, vec![length, name, prototype.into()])
+        template.create(
+            context.gc_collector(),
+            function,
+            vec![length, name, prototype.into()],
+        )
     } else if is_async {
-        context
-            .intrinsics()
-            .templates()
-            .async_function()
-            .create(function, vec![length, name])
+        context.intrinsics().templates().async_function().create(
+            context.gc_collector(),
+            function,
+            vec![length, name],
+        )
     } else if !has_prototype_property {
-        context
-            .intrinsics()
-            .templates()
-            .function()
-            .create(function, vec![length, name])
+        context.intrinsics().templates().function().create(
+            context.gc_collector(),
+            function,
+            vec![length, name],
+        )
     } else {
         let prototype = context
             .intrinsics()
             .templates()
             .function_prototype()
-            .create(OrdinaryObject, vec![JsValue::undefined()]);
+            .create(
+                context.gc_collector(),
+                OrdinaryObject,
+                vec![JsValue::undefined()],
+            );
 
         let constructor = context
             .intrinsics()
             .templates()
             .function_with_prototype()
-            .create(function, vec![length, name, prototype.clone().into()]);
+            .create(
+                context.gc_collector(),
+                function,
+                vec![length, name, prototype.clone().into()],
+            );
 
         prototype.borrow_mut().properties_mut().storage[0] = constructor.clone().into();
 

--- a/core/engine/src/vm/inline_cache/mod.rs
+++ b/core/engine/src/vm/inline_cache/mod.rs
@@ -47,9 +47,9 @@ impl fmt::Display for InlineCache {
         }
 
         let entries = self.entries.borrow();
-        let entries = entries.iter().map(|e| e.shape.to_addr_usize()).format(", ");
+        let entries = entries.iter().map(|_| "<?>").format(", ");
 
-        write!(f, "({entries:#x}))")
+        write!(f, "({entries}))")
     }
 }
 
@@ -62,7 +62,7 @@ impl InlineCache {
         }
     }
 
-    pub(crate) fn set(&self, shape: &Shape, slot: Slot) {
+    pub(crate) fn set(&self, mc: &boa_gc::MutationContext<'static, '_>, shape: &Shape, slot: Slot) {
         if self.megamorphic.get() {
             return;
         }
@@ -72,7 +72,7 @@ impl InlineCache {
         // Add a new entry if there's space.
         if entries
             .try_push(CacheEntry {
-                shape: shape.into(),
+                shape: WeakShape::new(mc, shape),
                 slot,
             })
             .is_err()
@@ -86,7 +86,11 @@ impl InlineCache {
     /// Returns the cached `(Shape, Slot)` if a matching shape exists in the inline cache.
     ///
     /// Opportunistically cleans up stale weak shape references during lookup.
-    pub(crate) fn get(&self, shape: &Shape) -> Option<(Shape, Slot)> {
+    pub(crate) fn get(
+        &self,
+        mc: &boa_gc::MutationContext<'static, '_>,
+        shape: &Shape,
+    ) -> Option<(Shape, Slot)> {
         if self.megamorphic.get() {
             return None;
         }
@@ -97,7 +101,7 @@ impl InlineCache {
         let shape_addr = shape.to_addr_usize();
 
         while i < entries.len() {
-            if let Some(upgraded) = entries[i].shape.upgrade() {
+            if let Some(upgraded) = entries[i].shape.upgrade(mc) {
                 let upgraded: Shape = upgraded;
                 if upgraded.to_addr_usize() == shape_addr {
                     result = Some((upgraded, entries[i].slot));

--- a/core/engine/src/vm/inline_cache/tests.rs
+++ b/core/engine/src/vm/inline_cache/tests.rs
@@ -17,11 +17,11 @@ use crate::{
 fn get_own_property_internal_method() {
     let context = &mut Context::default();
 
-    let o = context
-        .intrinsics()
-        .templates()
-        .ordinary_object()
-        .create(OrdinaryObject, Vec::default());
+    let o = context.intrinsics().templates().ordinary_object().create(
+        &unsafe { boa_gc::MutationContext::global() },
+        OrdinaryObject,
+        Vec::default(),
+    );
 
     let property: PropertyKey = js_string!("prop").into();
     let value = 100;
@@ -62,11 +62,11 @@ fn get_own_property_internal_method() {
 fn get_internal_method() {
     let context = &mut Context::default();
 
-    let o = context
-        .intrinsics()
-        .templates()
-        .ordinary_object()
-        .create(OrdinaryObject, Vec::default());
+    let o = context.intrinsics().templates().ordinary_object().create(
+        &unsafe { boa_gc::MutationContext::global() },
+        OrdinaryObject,
+        Vec::default(),
+    );
 
     let property: PropertyKey = js_string!("prop").into();
     let value = 100;
@@ -107,11 +107,11 @@ fn get_internal_method() {
 fn get_internal_method_in_prototype() {
     let context = &mut Context::default();
 
-    let o = context
-        .intrinsics()
-        .templates()
-        .ordinary_object()
-        .create(OrdinaryObject, Vec::default());
+    let o = context.intrinsics().templates().ordinary_object().create(
+        &unsafe { boa_gc::MutationContext::global() },
+        OrdinaryObject,
+        Vec::default(),
+    );
 
     let property: PropertyKey = js_string!("prop").into();
     let value = 100;
@@ -155,11 +155,11 @@ fn get_internal_method_in_prototype() {
 fn define_own_property_internal_method_non_existent_property() {
     let context = &mut Context::default();
 
-    let o = context
-        .intrinsics()
-        .templates()
-        .ordinary_object()
-        .create(OrdinaryObject, Vec::default());
+    let o = context.intrinsics().templates().ordinary_object().create(
+        &unsafe { boa_gc::MutationContext::global() },
+        OrdinaryObject,
+        Vec::default(),
+    );
 
     let property: PropertyKey = js_string!("prop").into();
     let value = 100;
@@ -209,11 +209,11 @@ fn define_own_property_internal_method_non_existent_property() {
 fn define_own_property_internal_method_existing_property_property() {
     let context = &mut Context::default();
 
-    let o = context
-        .intrinsics()
-        .templates()
-        .ordinary_object()
-        .create(OrdinaryObject, Vec::default());
+    let o = context.intrinsics().templates().ordinary_object().create(
+        &unsafe { boa_gc::MutationContext::global() },
+        OrdinaryObject,
+        Vec::default(),
+    );
 
     let property: PropertyKey = js_string!("prop").into();
     let value = 100;
@@ -275,11 +275,11 @@ fn define_own_property_internal_method_existing_property_property() {
 fn set_internal_method() {
     let context = &mut Context::default();
 
-    let o = context
-        .intrinsics()
-        .templates()
-        .ordinary_object()
-        .create(OrdinaryObject, Vec::default());
+    let o = context.intrinsics().templates().ordinary_object().create(
+        &unsafe { boa_gc::MutationContext::global() },
+        OrdinaryObject,
+        Vec::default(),
+    );
 
     let property: PropertyKey = js_string!("prop").into();
     let value = 100;
@@ -343,7 +343,7 @@ fn set_property_by_name_set_inline_cache_on_property_load() -> JsResult<()> {
     assert_eq!(
         code.ic[0].entries.borrow()[0]
             .shape
-            .upgrade()
+            .upgrade(&unsafe { boa_gc::MutationContext::global() })
             .unwrap()
             .to_addr_usize(),
         o_shape.to_addr_usize()
@@ -372,7 +372,7 @@ fn get_property_by_name_set_inline_cache_on_property_load() -> JsResult<()> {
     assert_eq!(
         code.ic[0].entries.borrow()[0]
             .shape
-            .upgrade()
+            .upgrade(&unsafe { boa_gc::MutationContext::global() })
             .unwrap()
             .to_addr_usize(),
         o_shape.to_addr_usize()

--- a/core/engine/src/vm/opcode/await/mod.rs
+++ b/core/engine/src/vm/opcode/await/mod.rs
@@ -62,6 +62,7 @@ impl Await {
         // 4. Let onFulfilled be CreateBuiltinFunction(fulfilledClosure, 1, "", « »).
         let on_fulfilled = FunctionObjectBuilder::new(
             context.realm(),
+            context.gc_collector(),
             NativeFunction::from_copy_closure_with_captures(
                 |_this, args, captures, context| {
                     // a. Let prevContext be the running execution context.
@@ -101,6 +102,7 @@ impl Await {
         // 6. Let onRejected be CreateBuiltinFunction(rejectedClosure, 1, "", « »).
         let on_rejected = FunctionObjectBuilder::new(
             context.realm(),
+            context.gc_collector(),
             NativeFunction::from_copy_closure_with_captures(
                 |_this, args, captures, context| {
                     // a. Let prevContext be the running execution context.

--- a/core/engine/src/vm/opcode/call/mod.rs
+++ b/core/engine/src/vm/opcode/call/mod.rs
@@ -450,6 +450,7 @@ async fn load_dyn_import(
     // 5. Let onRejected be CreateBuiltinFunction(rejectedClosure, 1, "", « »).
     let on_rejected = FunctionObjectBuilder::new(
         context.borrow().realm(),
+        context.borrow_mut().gc_collector(),
         NativeFunction::from_copy_closure_with_captures(
             |_, args, cap, context| {
                 //     a. Perform ! Call(promiseCapability.[[Reject]], undefined, « reason »).
@@ -469,6 +470,7 @@ async fn load_dyn_import(
     // 7. Let linkAndEvaluate be CreateBuiltinFunction(linkAndEvaluateClosure, 0, "", « »).
     let link_evaluate = FunctionObjectBuilder::new(
         context.borrow().realm(),
+        context.borrow_mut().gc_collector(),
         NativeFunction::from_copy_closure_with_captures(
             |_, _, (module, cap, on_rejected), context| {
                 // a. Let link be Completion(module.Link()).
@@ -490,6 +492,7 @@ async fn load_dyn_import(
                 // e. Let onFulfilled be CreateBuiltinFunction(fulfilledClosure, 0, "", « »).
                 let fulfill = FunctionObjectBuilder::new(
                     context.realm(),
+                    context.gc_collector(),
                     NativeFunction::from_copy_closure_with_captures(
                         |_, _, (module, cap), context| {
                             // i. Let namespace be GetModuleNamespace(module).

--- a/core/engine/src/vm/opcode/call/mod.rs
+++ b/core/engine/src/vm/opcode/call/mod.rs
@@ -450,7 +450,7 @@ async fn load_dyn_import(
     // 5. Let onRejected be CreateBuiltinFunction(rejectedClosure, 1, "", « »).
     let on_rejected = FunctionObjectBuilder::new(
         context.borrow().realm(),
-        context.borrow_mut().gc_collector(),
+        context.borrow().gc_collector(),
         NativeFunction::from_copy_closure_with_captures(
             |_, args, cap, context| {
                 //     a. Perform ! Call(promiseCapability.[[Reject]], undefined, « reason »).
@@ -470,7 +470,7 @@ async fn load_dyn_import(
     // 7. Let linkAndEvaluate be CreateBuiltinFunction(linkAndEvaluateClosure, 0, "", « »).
     let link_evaluate = FunctionObjectBuilder::new(
         context.borrow().realm(),
-        context.borrow_mut().gc_collector(),
+        context.borrow().gc_collector(),
         NativeFunction::from_copy_closure_with_captures(
             |_, _, (module, cap, on_rejected), context| {
                 // a. Let link be Completion(module.Link()).

--- a/core/engine/src/vm/opcode/generator/mod.rs
+++ b/core/engine/src/vm/opcode/generator/mod.rs
@@ -37,6 +37,7 @@ impl Generator {
             .unwrap_or_else(|| context.intrinsics().objects().generator());
 
         let generator = JsObject::from_proto_and_data_with_shared_shape(
+            context.gc_collector(),
             context.root_shape(),
             proto,
             NativeGenerator {
@@ -83,6 +84,7 @@ impl AsyncGenerator {
             .unwrap_or_else(|| context.intrinsics().objects().async_generator());
 
         let generator = JsObject::from_proto_and_data_with_shared_shape(
+            context.gc_collector(),
             context.root_shape(),
             proto,
             NativeAsyncGenerator {

--- a/core/engine/src/vm/opcode/get/name.rs
+++ b/core/engine/src/vm/opcode/get/name.rs
@@ -60,7 +60,7 @@ impl GetNameGlobal {
             let ic = &context.vm.frame().code_block().ic[usize::from(ic_index)];
 
             let object_borrowed = object.borrow();
-            if let Some((shape, slot)) = ic.get(object_borrowed.shape()) {
+            if let Some((shape, slot)) = ic.get(context.gc_collector(), object_borrowed.shape()) {
                 let mut result = if slot.attributes.contains(SlotAttributes::PROTOTYPE) {
                     let prototype = shape.prototype().expect("prototype should have value");
                     let prototype = prototype.borrow();
@@ -99,7 +99,7 @@ impl GetNameGlobal {
                 let ic = &context.vm.frame().code_block.ic[usize::from(ic_index)];
                 let object_borrowed = object.borrow();
                 let shape = object_borrowed.shape();
-                ic.set(shape, slot);
+                ic.set(context.gc_collector(), shape, slot);
             }
 
             context.vm.set_register(dst.into(), result);

--- a/core/engine/src/vm/opcode/get/property.rs
+++ b/core/engine/src/vm/opcode/get/property.rs
@@ -39,7 +39,7 @@ fn get_by_name<const LENGTH: bool>(
 
     let ic = &context.vm.frame().code_block().ic[usize::from(index)];
     let object_borrowed = object.borrow();
-    if let Some((shape, slot)) = ic.get(object_borrowed.shape()) {
+    if let Some((shape, slot)) = ic.get(context.gc_collector(), object_borrowed.shape()) {
         let mut result = if slot.attributes.contains(SlotAttributes::PROTOTYPE) {
             let prototype = shape.prototype().expect("prototype should have value");
             let prototype = prototype.borrow();
@@ -73,7 +73,7 @@ fn get_by_name<const LENGTH: bool>(
         let ic = &context.vm.frame().code_block.ic[usize::from(index)];
         let object_borrowed = object.borrow();
         let shape = object_borrowed.shape();
-        ic.set(shape, slot);
+        ic.set(context.gc_collector(), shape, slot);
     }
 
     context.vm.set_register(dst.into(), result);

--- a/core/engine/src/vm/opcode/iteration/for_in.rs
+++ b/core/engine/src/vm/opcode/iteration/for_in.rs
@@ -19,11 +19,12 @@ impl CreateForInIterator {
         let (iterator, next_method) =
             ForInIterator::create_for_in_iterator(JsValue::new(object), context);
 
+        let mc = context.gc_collector();
         context
             .vm
             .frame_mut()
             .iterators
-            .push(IteratorRecord::new(iterator, next_method));
+            .push(IteratorRecord::new(iterator, next_method, mc));
 
         Ok(())
     }

--- a/core/engine/src/vm/opcode/iteration/iterator.rs
+++ b/core/engine/src/vm/opcode/iteration/iterator.rs
@@ -76,11 +76,12 @@ impl IteratorPush {
             .js_expect("iterator should be an object")?;
         let next = context.vm.get_register(next.into()).clone();
 
+        let mc = context.gc_collector();
         context
             .vm
             .frame_mut()
             .iterators
-            .push(IteratorRecord::new(iterator, next));
+            .push(IteratorRecord::new(iterator, next, mc));
 
         Ok(())
     }

--- a/core/engine/src/vm/opcode/meta/mod.rs
+++ b/core/engine/src/vm/opcode/meta/mod.rs
@@ -73,7 +73,7 @@ impl ImportMeta {
             .borrow_mut()
             .get_or_insert_with(|| {
                 // a. Set importMeta to OrdinaryObjectCreate(null).
-                let import_meta = JsObject::with_null_proto();
+                let import_meta = JsObject::with_null_proto(context.gc_collector());
 
                 // b. Let importMetaValues be HostGetImportMetaProperties(module).
                 // c. For each Record { [[Key]], [[Value]] } p of importMetaValues, do

--- a/core/engine/src/vm/opcode/push/array.rs
+++ b/core/engine/src/vm/opcode/push/array.rs
@@ -15,11 +15,11 @@ pub(crate) struct StoreNewArray;
 impl StoreNewArray {
     #[inline(always)]
     pub(crate) fn operation(array: RegisterOperand, context: &mut Context) {
-        let value = context
-            .intrinsics()
-            .templates()
-            .array()
-            .create(Array, Vec::from([JsValue::new(0)]));
+        let value = context.intrinsics().templates().array().create(
+            context.gc_collector(),
+            Array,
+            Vec::from([JsValue::new(0)]),
+        );
         context.vm.set_register(array.into(), value.into());
     }
 }

--- a/core/engine/src/vm/opcode/push/class/mod.rs
+++ b/core/engine/src/vm/opcode/push/class/mod.rs
@@ -65,7 +65,7 @@ impl StoreClassPrototype {
         let class_object = class.as_object().js_expect("class must be object")?;
 
         if let Some(constructor_parent) = constructor_parent {
-            class_object.set_prototype(Some(constructor_parent));
+            class_object.set_prototype(context.gc_collector(), Some(constructor_parent));
         }
 
         context.vm.set_register(dst.into(), proto_parent);

--- a/core/engine/src/vm/opcode/push/object.rs
+++ b/core/engine/src/vm/opcode/push/object.rs
@@ -14,11 +14,11 @@ pub(crate) struct StoreEmptyObject;
 impl StoreEmptyObject {
     #[inline(always)]
     pub(crate) fn operation(dst: RegisterOperand, context: &mut Context) {
-        let o = context
-            .intrinsics()
-            .templates()
-            .ordinary_object()
-            .create(OrdinaryObject, Vec::default());
+        let o = context.intrinsics().templates().ordinary_object().create(
+            context.gc_collector(),
+            OrdinaryObject,
+            Vec::default(),
+        );
         context.vm.set_register(dst.into(), o.into());
     }
 }

--- a/core/engine/src/vm/opcode/set/class_prototype.rs
+++ b/core/engine/src/vm/opcode/set/class_prototype.rs
@@ -31,6 +31,7 @@ impl SetClassPrototype {
 
         // 9.Let proto be OrdinaryObjectCreate(protoParent).
         let proto = JsObject::from_proto_and_data_with_shared_shape(
+            context.gc_collector(),
             context.root_shape(),
             prototype,
             OrdinaryObject,

--- a/core/engine/src/vm/opcode/set/property.rs
+++ b/core/engine/src/vm/opcode/set/property.rs
@@ -25,7 +25,7 @@ fn set_by_name(
     let ic = &context.vm.frame().code_block().ic[usize::from(index)];
 
     let object_borrowed = object.borrow();
-    if let Some((shape, slot)) = ic.get(object_borrowed.shape()) {
+    if let Some((shape, slot)) = ic.get(context.gc_collector(), object_borrowed.shape()) {
         let slot_index = slot.index as usize;
 
         if slot.attributes.is_accessor_descriptor() {
@@ -76,7 +76,7 @@ fn set_by_name(
         let ic = &context.vm.frame().code_block.ic[usize::from(index)];
         let object_borrowed = object.borrow();
         let shape = object_borrowed.shape();
-        ic.set(shape, slot);
+        ic.set(context.gc_collector(), shape, slot);
     }
 
     Ok(())

--- a/core/gc/src/pointers/weak_map.rs
+++ b/core/gc/src/pointers/weak_map.rs
@@ -65,7 +65,7 @@ impl<K: Trace + ?Sized + 'static, V: Trace + 'static> WeakMap<K, V> {
     {
         let ephemeron = self.get(key)?;
         ephemeron
-            .value(&unsafe { crate::MutationContext::dummy() })
+            .value(&unsafe { crate::MutationContext::global() })
             .map(|v| v.clone())
     }
 }

--- a/core/macros/src/class.rs
+++ b/core/macros/src/class.rs
@@ -406,10 +406,11 @@ impl Accessor {
         let getter = if let Some(getter) = self.getter.as_ref() {
             let body = getter.body.clone();
             quote! {
-                Some(
+                Some({
+                    let ctx = builder.context();
                     boa_engine::NativeFunction::from_fn_ptr( #body )
-                        .to_js_function(builder.context().realm())
-                )
+                        .to_js_function(ctx.realm(), ctx.gc_collector())
+                })
             }
         } else {
             quote! { None }
@@ -417,10 +418,11 @@ impl Accessor {
         let setter = if let Some(setter) = self.setter.as_ref() {
             let body = setter.body.clone();
             quote! {
-                Some(
+                Some({
+                    let ctx = builder.context();
                     boa_engine::NativeFunction::from_fn_ptr( #body )
-                        .to_js_function(builder.context().realm())
-                )
+                        .to_js_function(ctx.realm(), ctx.gc_collector())
+                })
             }
         } else {
             quote! { None }

--- a/core/macros/src/lib.rs
+++ b/core/macros/src/lib.rs
@@ -627,7 +627,7 @@ pub fn derive_try_into_js(input: TokenStream) -> TokenStream {
     let expanded = quote! {
         impl ::boa_engine::value::TryIntoJs for #type_name {
             fn try_into_js(&self, context: &mut boa_engine::Context) -> boa_engine::JsResult<boa_engine::JsValue> {
-                let obj = boa_engine::JsObject::default(context.intrinsics());
+                let obj = boa_engine::JsObject::default(context.gc_collector(), context.intrinsics());
                 #props
                 boa_engine::JsResult::Ok(obj.into())
             }

--- a/core/macros/src/module.rs
+++ b/core/macros/src/module.rs
@@ -81,7 +81,7 @@ fn fn_item(
                 &boa_engine::js_string!( #name ),
                 boa_engine::JsValue::from(
                     boa_engine::NativeFunction::from_fn_ptr( #fn_body )
-                        .to_js_function(context.realm())
+                        .to_js_function(context.realm(), context.gc_collector())
                 ),
             )?;
         },
@@ -92,7 +92,7 @@ fn fn_item(
                     boa_engine::js_string!( #name ),
                     boa_engine::JsValue::from(
                         boa_engine::NativeFunction::from_fn_ptr( function )
-                            .to_js_function(context.realm())
+                            .to_js_function(context.realm(), context.gc_collector())
                     ),
                     boa_engine::property::Attribute::all(),
                     context,
@@ -102,7 +102,7 @@ fn fn_item(
                     boa_engine::js_string!( #name ),
                     boa_engine::JsValue::from(
                         boa_engine::NativeFunction::from_fn_ptr( function )
-                            .to_js_function(context.realm())
+                            .to_js_function(context.realm(), context.gc_collector())
                     ),
                     boa_engine::property::Attribute::all(),
                 )?;

--- a/core/runtime/src/console/mod.rs
+++ b/core/runtime/src/console/mod.rs
@@ -368,7 +368,7 @@ impl Console {
 
         ObjectInitializer::with_native_data_and_proto(
             Self::default(),
-            JsObject::with_object_proto(context.realm().intrinsics()),
+            JsObject::with_object_proto(context.gc_collector(), context.realm().intrinsics()),
             context,
         )
         .property(

--- a/core/runtime/src/fetch/headers_iterator.rs
+++ b/core/runtime/src/fetch/headers_iterator.rs
@@ -116,7 +116,11 @@ impl HeadersIterator {
             .ok_or_else(|| boa_engine::js_error!(Error: "Headers Iterator not registered"))?
             .prototype();
 
-        let headers_iterator = JsObject::from_proto_and_data(proto, iter);
+        let headers_iterator = JsObject::from_proto_and_data(
+            &unsafe { boa_gc::MutationContext::global() },
+            proto,
+            iter,
+        );
         Ok(headers_iterator.into())
     }
 }

--- a/core/runtime/src/fetch/mod.rs
+++ b/core/runtime/src/fetch/mod.rs
@@ -255,6 +255,7 @@ pub fn register<F: Fetcher>(
 
     let iterator = FunctionObjectBuilder::new(
         context.realm(),
+        context.gc_collector(),
         NativeFunction::from_fn_ptr(headers_symbol_iterator),
     )
     .name(js_string!("[Symbol.iterator]"))

--- a/core/runtime/src/process/mod.rs
+++ b/core/runtime/src/process/mod.rs
@@ -82,7 +82,7 @@ impl Process {
 
         let provider = Rc::new(provider);
 
-        let env = JsObject::default(context.intrinsics());
+        let env = JsObject::default(context.gc_collector(), context.intrinsics());
         for (key, value) in provider.env() {
             env.set(key, JsValue::from(value), false, context)?;
         }

--- a/core/runtime/src/store/to.rs
+++ b/core/runtime/src/store/to.rs
@@ -30,7 +30,7 @@ fn try_fields_into_js_object(
     seen: &mut ReverseSeenMap,
     context: &mut Context,
 ) -> JsResult<JsValue> {
-    let dolly = JsObject::with_object_proto(context.intrinsics());
+    let dolly = JsObject::with_object_proto(context.gc_collector(), context.intrinsics());
     seen.insert(store, dolly.clone());
 
     for (k, v) in fields {

--- a/core/runtime/src/test262.rs
+++ b/core/runtime/src/test262.rs
@@ -127,7 +127,11 @@ pub fn register_js262(handles: WorkerHandles, console: bool, context: &mut Conte
     js262
         .create_data_property_or_throw(
             js_string!("IsHTMLDDA"),
-            JsObject::from_proto_and_data(None, IsHTMLDDA),
+            JsObject::from_proto_and_data(
+                &unsafe { boa_gc::MutationContext::global() },
+                None,
+                IsHTMLDDA,
+            ),
             context,
         )
         .expect("the IsHTMLDDA property must be definable");

--- a/examples/src/bin/closures.rs
+++ b/examples/src/bin/closures.rs
@@ -49,7 +49,7 @@ fn main() -> Result<(), JsError> {
     }
 
     // We create a new `JsObject` with some data
-    let object = JsObject::with_object_proto(context.intrinsics());
+    let object = JsObject::with_object_proto(context.gc_collector(), context.intrinsics());
     object.define_property_or_throw(
         js_string!("name"),
         PropertyDescriptor::builder()
@@ -70,6 +70,7 @@ fn main() -> Result<(), JsError> {
     // attributes.
     let js_function = FunctionObjectBuilder::new(
         context.realm(),
+        context.gc_collector(),
         NativeFunction::from_copy_closure_with_captures(
             |_, _, captures, context| {
                 let mut captures = captures.borrow_mut();

--- a/examples/src/bin/jsarray.rs
+++ b/examples/src/bin/jsarray.rs
@@ -65,6 +65,7 @@ fn main() -> JsResult<()> {
 
     let filter_callback = FunctionObjectBuilder::new(
         context.realm(),
+        context.gc_collector(),
         NativeFunction::from_fn_ptr(|_this, args, _context| {
             Ok(args.first().cloned().unwrap_or_default().is_number().into())
         }),
@@ -73,6 +74,7 @@ fn main() -> JsResult<()> {
 
     let map_callback = FunctionObjectBuilder::new(
         context.realm(),
+        context.gc_collector(),
         NativeFunction::from_fn_ptr(|_this, args, context| {
             args.first()
                 .cloned()
@@ -99,6 +101,7 @@ fn main() -> JsResult<()> {
 
     let reduce_callback = FunctionObjectBuilder::new(
         context.realm(),
+        context.gc_collector(),
         NativeFunction::from_fn_ptr(|_this, args, context| {
             let accumulator = args.first().cloned().unwrap_or_default();
             let value = args.get(1).cloned().unwrap_or_default();

--- a/examples/src/bin/jspromise.rs
+++ b/examples/src/bin/jspromise.rs
@@ -43,7 +43,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     println!("Promise resolved with: {}", value.display());
                     Ok(value.clone())
                 })
-                .to_js_function(context.realm()),
+                .to_js_function(context.realm(), context.gc_collector()),
             ),
             Some(
                 NativeFunction::from_fn_ptr(|_, args, _context| {
@@ -51,7 +51,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     println!("Promise rejected with: {}", error.display());
                     Err(JsError::from_opaque(error.clone()))
                 })
-                .to_js_function(context.realm()),
+                .to_js_function(context.realm(), context.gc_collector()),
             ),
             context,
         )?
@@ -60,7 +60,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 println!("Promise settled!");
                 Ok(JsValue::undefined())
             })
-            .to_js_function(context.realm()),
+            .to_js_function(context.realm(), context.gc_collector()),
             context,
         )?;
 

--- a/examples/src/bin/jstypedarray.rs
+++ b/examples/src/bin/jstypedarray.rs
@@ -30,6 +30,7 @@ fn main() -> JsResult<()> {
 
     let callback = FunctionObjectBuilder::new(
         context.realm(),
+        context.gc_collector(),
         NativeFunction::from_fn_ptr(|_this, args, context| {
             let accumulator = args.first().cloned().unwrap_or_default();
             let value = args.get(1).cloned().unwrap_or_default();
@@ -46,6 +47,7 @@ fn main() -> JsResult<()> {
 
     let greater_than_10_predicate = FunctionObjectBuilder::new(
         context.realm(),
+        context.gc_collector(),
         NativeFunction::from_fn_ptr(|_this, args, _context| {
             let element = args
                 .first()
@@ -65,6 +67,7 @@ fn main() -> JsResult<()> {
 
     let lower_than_200_predicate = FunctionObjectBuilder::new(
         context.realm(),
+        context.gc_collector(),
         NativeFunction::from_fn_ptr(|_this, args, _context| {
             let element = args
                 .first()
@@ -99,6 +102,7 @@ fn main() -> JsResult<()> {
 
     let js_function = FunctionObjectBuilder::new(
         context.realm(),
+        context.gc_collector(),
         NativeFunction::from_copy_closure_with_captures(
             |_, args, captures, inner_context| {
                 let element = args

--- a/examples/src/bin/modulehandler.rs
+++ b/examples/src/bin/modulehandler.rs
@@ -31,7 +31,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     ctx.register_global_callable("require".into(), 0, NativeFunction::from_fn_ptr(require))?;
 
     // Adding custom object that mimics 'module.exports'
-    let moduleobj = JsObject::default(ctx.intrinsics());
+    let moduleobj = JsObject::default(ctx.gc_collector(), ctx.intrinsics());
     moduleobj.set(js_string!("exports"), js_string!(" "), false, &mut ctx)?;
 
     ctx.register_global_property(

--- a/examples/src/bin/modules.rs
+++ b/examples/src/bin/modules.rs
@@ -65,7 +65,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                     },
                     module.clone(),
                 )
-                .to_js_function(context.realm()),
+                .to_js_function(context.realm(), context.gc_collector()),
             ),
             None,
             context,
@@ -81,7 +81,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                     |_, _, module, context| Ok(module.evaluate(context)?.into()),
                     module.clone(),
                 )
-                .to_js_function(context.realm()),
+                .to_js_function(context.realm(), context.gc_collector()),
             ),
             None,
             context,

--- a/examples/src/bin/synthetic.rs
+++ b/examples/src/bin/synthetic.rs
@@ -105,6 +105,7 @@ fn create_operations_module(context: &mut Context) -> Module {
     // on that below.
     let sum = FunctionObjectBuilder::new(
         context.realm(),
+        context.gc_collector(),
         NativeFunction::from_fn_ptr(|_, args, ctx| {
             args.get_or_undefined(0).add(args.get_or_undefined(1), ctx)
         }),
@@ -114,6 +115,7 @@ fn create_operations_module(context: &mut Context) -> Module {
     .build();
     let sub = FunctionObjectBuilder::new(
         context.realm(),
+        context.gc_collector(),
         NativeFunction::from_fn_ptr(|_, args, ctx| {
             args.get_or_undefined(0).sub(args.get_or_undefined(1), ctx)
         }),
@@ -123,6 +125,7 @@ fn create_operations_module(context: &mut Context) -> Module {
     .build();
     let mult = FunctionObjectBuilder::new(
         context.realm(),
+        context.gc_collector(),
         NativeFunction::from_fn_ptr(|_, args, ctx| {
             args.get_or_undefined(0).mul(args.get_or_undefined(1), ctx)
         }),
@@ -132,6 +135,7 @@ fn create_operations_module(context: &mut Context) -> Module {
     .build();
     let div = FunctionObjectBuilder::new(
         context.realm(),
+        context.gc_collector(),
         NativeFunction::from_fn_ptr(|_, args, ctx| {
             args.get_or_undefined(0).div(args.get_or_undefined(1), ctx)
         }),
@@ -141,6 +145,7 @@ fn create_operations_module(context: &mut Context) -> Module {
     .build();
     let sqrt = FunctionObjectBuilder::new(
         context.realm(),
+        context.gc_collector(),
         NativeFunction::from_fn_ptr(|_, args, ctx| {
             let a = args.get_or_undefined(0).to_number(ctx)?;
             Ok(JsValue::from(a.sqrt()))

--- a/tests/macros/tests/class.rs
+++ b/tests/macros/tests/class.rs
@@ -46,7 +46,7 @@ impl Animal {
     #[boa(method)]
     #[boa(length = 11)]
     fn method(context: &mut Context) -> JsObject {
-        let obj = JsObject::with_null_proto();
+        let obj = JsObject::with_null_proto(&unsafe { boa_gc::MutationContext::global() });
         obj.set(js_string!("key"), 43, false, context).unwrap();
         obj
     }

--- a/tests/macros/tests/fibonacci.rs
+++ b/tests/macros/tests/fibonacci.rs
@@ -60,7 +60,7 @@ fn fibonacci_test() {
 
     let fibonacci_rust = fibonacci
         .into_js_function_copied(context)
-        .to_js_function(context.realm());
+        .to_js_function(context.realm(), context.gc_collector());
 
     assert_eq!(
         fibonacci_js
@@ -78,7 +78,7 @@ fn fibonacci_test() {
 
     let fibonacci_throw = fibonacci_throw
         .into_js_function_copied(context)
-        .to_js_function(context.realm());
+        .to_js_function(context.realm(), context.gc_collector());
     assert!(
         fibonacci_js
             .call(

--- a/tests/macros/tests/gcd_callback.rs
+++ b/tests/macros/tests/gcd_callback.rs
@@ -40,7 +40,7 @@ fn gcd_callback() {
 
     let function = callback_from_js
         .into_js_function_copied(context)
-        .to_js_function(context.realm());
+        .to_js_function(context.realm(), context.gc_collector());
 
     result.store(0, Ordering::Relaxed);
     assert_eq!(js_gcd.call(context, (6, 9, function.clone())), Ok(()));

--- a/tests/tester/src/exec/mod.rs
+++ b/tests/tester/src/exec/mod.rs
@@ -625,6 +625,7 @@ fn register_print_fn(context: &mut Context, async_result: AsyncResult) {
     // We use `FunctionBuilder` to define a closure with additional captures.
     let js_function = FunctionObjectBuilder::new(
         context.realm(),
+        context.gc_collector(),
         // SAFETY: `AsyncResult` has only non-traceable captures, making this safe.
         unsafe {
             NativeFunction::from_closure(move |_, args, context| {

--- a/tests/wpt/src/lib.rs
+++ b/tests/wpt/src/lib.rs
@@ -304,7 +304,7 @@ fn execute_test_file(path: &Path) {
 
     let function = result_callback__
         .into_js_function_copied(&mut context)
-        .to_js_function(context.realm());
+        .to_js_function(context.realm(), context.gc_collector());
     context
         .register_global_property(js_str!("result_callback__"), function, Attribute::all())
         .expect("Could not register result_callback__");
@@ -316,7 +316,7 @@ fn execute_test_file(path: &Path) {
 
     let function = complete_callback__
         .into_js_function_copied(&mut context)
-        .to_js_function(context.realm());
+        .to_js_function(context.realm(), context.gc_collector());
     context
         .register_global_property(js_str!("complete_callback__"), function, Attribute::all())
         .expect("Could not register complete_callback__");


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

Stacked on #5478, this PR enforces threading `MutationContext` through all internal builtins, removing previous temporary fallbacks.

**Key Changes:**
* Removed `*_in` methods, temporary methods like `JsObject::new_in` are gone. Main methods (e.g., `JsObject::new`) have absorbed their signatures and now require the context.
* **Removed `Default` for core objects:** `StandardConstructors`, `IntrinsicObjects` and `Intrinsics` can no longer use `Default::default()`; they must be instantiated via `uninit(mc)`
* Macros (eg., `boa_class`) were updated to dynamically fetch `context.gc_collector()` without violating Rust's mutable borrowing rules.
* Signatures in the CLI, examples and tests were updated. Detached tests and macros temporarily use `&unsafe { boa_gc::MutationContext::global() }` to minimize immediate code breakage