### PR TITLE
Use downcast on Date intrinsic to ensure borrows are not extended

### DIFF
--- a/core/engine/src/builtins/date/mod.rs
+++ b/core/engine/src/builtins/date/mod.rs
@@ -857,18 +857,11 @@ impl Date {
         // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
         let object = this.as_object();
         let date = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Date>)
+            .and_then(|o| o.downcast::<Date>().ok())
             .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?;
 
         // 3. Let t be dateObject.[[DateValue]].
-        let mut t = date.0;
-
-        // NOTE (nekevss): `downcast_ref` is used and then dropped for a short lived borrow.
-        // ToNumber() may call userland code which can modify the underlying date
-        // which will cause a panic. In order to avoid this, we drop the borrow,
-        // here and only `downcast_mut` when date will be modified.
-        drop(date);
+        let mut t = date.borrow().data().0;
 
         // 4. Let dt be ? ToNumber(date).
         let dt = args.get_or_undefined(0).to_number(context)?;
@@ -897,14 +890,8 @@ impl Date {
             time_clip(new_date)
         };
 
-        let object = this.as_object();
-        let mut date_mut = object
-            .as_ref()
-            .and_then(JsObject::downcast_mut::<Date>)
-            .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?;
-
         // 9. Set dateObject.[[DateValue]] to u.
-        date_mut.0 = u;
+        date.borrow_mut().data_mut().0 = u;
 
         // 10. Return u.
         Ok(JsValue::from(u))
@@ -926,19 +913,13 @@ impl Date {
         // 1. Let dateObject be the this value.
         // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
         let object = this.as_object();
+
         let date = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Date>)
+            .and_then(|o| o.downcast::<Date>().ok())
             .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?;
 
         // 3. Let t be dateObject.[[DateValue]].
-        let t = date.0;
-
-        // NOTE (nekevss): `downcast_ref` is used and then dropped for a short lived borrow.
-        // ToNumber() may call userland code which can modify the underlying date
-        // which will cause a panic. In order to avoid this, we drop the borrow,
-        // here and only `downcast_mut` when date will be modified.
-        drop(date);
+        let t = date.borrow().data().0;
 
         let t = if LOCAL {
             // 5. If t is NaN, set t to +0𝔽; otherwise, set t to LocalTime(t).
@@ -980,14 +961,8 @@ impl Date {
             time_clip(new_date)
         };
 
-        let object = this.as_object();
-        let mut date_mut = object
-            .as_ref()
-            .and_then(JsObject::downcast_mut::<Date>)
-            .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?;
-
         // 10. Set dateObject.[[DateValue]] to u.
-        date_mut.0 = u;
+        date.borrow_mut().data_mut().0 = u;
 
         // 11. Return u.
         Ok(JsValue::from(u))
@@ -1012,18 +987,11 @@ impl Date {
         // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
         let object = this.as_object();
         let date = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Date>)
+            .and_then(|o| o.downcast::<Date>().ok())
             .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?;
 
         // 3. Let t be dateObject.[[DateValue]].
-        let mut t = date.0;
-
-        // NOTE (nekevss): `downcast_ref` is used and then dropped for a short lived borrow.
-        // ToNumber() may call userland code which can modify the underlying date
-        // which will cause a panic. In order to avoid this, we drop the borrow,
-        // here and only `downcast_mut` when date will be modified.
-        drop(date);
+        let mut t = date.borrow().data().0;
 
         // 4. Let h be ? ToNumber(hour).
         let h = args.get_or_undefined(0).to_number(context)?;
@@ -1057,24 +1025,18 @@ impl Date {
         let milli = milli.unwrap_or_else(|| ms_from_time(t).into());
 
         // 13. Let date be MakeDate(Day(t), MakeTime(h, m, s, milli)).
-        let date = make_date(day(t), make_time(h, m, s, milli));
+        let dt = make_date(day(t), make_time(h, m, s, milli));
 
         let u = if LOCAL {
             // 14. Let u be TimeClip(UTC(date)).
-            time_clip(utc_t(date, context.host_hooks().as_ref()))
+            time_clip(utc_t(dt, context.host_hooks().as_ref()))
         } else {
             // 14. Let u be TimeClip(date).
-            time_clip(date)
+            time_clip(dt)
         };
 
-        let object = this.as_object();
-        let mut date_mut = object
-            .as_ref()
-            .and_then(JsObject::downcast_mut::<Date>)
-            .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?;
-
         // 15. Set dateObject.[[DateValue]] to u.
-        date_mut.0 = u;
+        date.borrow_mut().data_mut().0 = u;
 
         // 16. Return u.
         Ok(JsValue::from(u))
@@ -1096,18 +1058,11 @@ impl Date {
         // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
         let object = this.as_object();
         let date = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Date>)
+            .and_then(|o| o.downcast::<Date>().ok())
             .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?;
 
         // 3. Let t be dateObject.[[DateValue]].
-        let mut t = date.0;
-
-        // NOTE (nekevss): `downcast_ref` is used and then dropped for a short lived borrow.
-        // ToNumber() may call userland code which can modify the underlying date
-        // which will cause a panic. In order to avoid this, we drop the borrow,
-        // here and only `downcast_mut` when date will be modified.
-        drop(date);
+        let mut t = date.borrow().data().0;
 
         // 4. Set ms to ? ToNumber(ms).
         let ms = args.get_or_undefined(0).to_number(context)?;
@@ -1141,14 +1096,8 @@ impl Date {
             time_clip(make_date(day(t), time))
         };
 
-        let object = this.as_object();
-        let mut date_mut = object
-            .as_ref()
-            .and_then(JsObject::downcast_mut::<Date>)
-            .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?;
-
         // 9. Set dateObject.[[DateValue]] to u.
-        date_mut.0 = u;
+        date.borrow_mut().data_mut().0 = u;
 
         // 10. Return u.
         Ok(JsValue::from(u))
@@ -1170,18 +1119,11 @@ impl Date {
         // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
         let object = this.as_object();
         let date = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Date>)
+            .and_then(|o| o.downcast::<Date>().ok())
             .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?;
 
         // 3. Let t be dateObject.[[DateValue]].
-        let mut t = date.0;
-
-        // NOTE (nekevss): `downcast_ref` is used and then dropped for a short lived borrow.
-        // ToNumber() may call userland code which can modify the underlying date
-        // which will cause a panic. In order to avoid this, we drop the borrow,
-        // here and only `downcast_mut` when date will be modified.
-        drop(date);
+        let mut t = date.borrow().data().0;
 
         // 4. Let m be ? ToNumber(min).
         let m = args.get_or_undefined(0).to_number(context)?;
@@ -1209,24 +1151,18 @@ impl Date {
         let milli = milli.unwrap_or_else(|| ms_from_time(t).into());
 
         // 11. Let date be MakeDate(Day(t), MakeTime(HourFromTime(t), m, s, milli)).
-        let date = make_date(day(t), make_time(hour_from_time(t).into(), m, s, milli));
+        let dt = make_date(day(t), make_time(hour_from_time(t).into(), m, s, milli));
 
         let u = if LOCAL {
             // 12. Let u be TimeClip(UTC(date)).
-            time_clip(utc_t(date, context.host_hooks().as_ref()))
+            time_clip(utc_t(dt, context.host_hooks().as_ref()))
         } else {
             // 12. Let u be TimeClip(date).
-            time_clip(date)
+            time_clip(dt)
         };
 
-        let object = this.as_object();
-        let mut date_mut = object
-            .as_ref()
-            .and_then(JsObject::downcast_mut::<Date>)
-            .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?;
-
         // 13. Set dateObject.[[DateValue]] to u.
-        date_mut.0 = u;
+        date.borrow_mut().data_mut().0 = u;
 
         // 14. Return u.
         Ok(JsValue::from(u))
@@ -1249,18 +1185,11 @@ impl Date {
         // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
         let object = this.as_object();
         let date = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Date>)
+            .and_then(|o| o.downcast::<Date>().ok())
             .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?;
 
         // 3. Let t be dateObject.[[DateValue]].
-        let mut t = date.0;
-
-        // NOTE (nekevss): `downcast_ref` is used and then dropped for a short lived borrow.
-        // ToNumber() may call userland code which can modify the underlying date
-        // which will cause a panic. In order to avoid this, we drop the borrow,
-        // here and only `downcast_mut` when date will be modified.
-        drop(date);
+        let mut t = date.borrow().data().0;
 
         // 4. Let m be ? ToNumber(month).
         let m = args.get_or_undefined(0).to_number(context)?;
@@ -1295,14 +1224,8 @@ impl Date {
             time_clip(new_date)
         };
 
-        let object = this.as_object();
-        let mut date_mut = object
-            .as_ref()
-            .and_then(JsObject::downcast_mut::<Date>)
-            .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?;
-
         // 11. Set dateObject.[[DateValue]] to u.
-        date_mut.0 = u;
+        date.borrow_mut().data_mut().0 = u;
 
         // 12. Return u.
         Ok(JsValue::from(u))
@@ -1324,18 +1247,11 @@ impl Date {
         // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
         let object = this.as_object();
         let date = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Date>)
+            .and_then(|o| o.downcast::<Date>().ok())
             .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?;
 
         // 3. Let t be dateObject.[[DateValue]].
-        let mut t = date.0;
-
-        // NOTE (nekevss): `downcast_ref` is used and then dropped for a short lived borrow.
-        // ToNumber() may call userland code which can modify the underlying date
-        // which will cause a panic. In order to avoid this, we drop the borrow,
-        // here and only `downcast_mut` when date will be modified.
-        drop(date);
+        let mut t = date.borrow().data().0;
 
         // 4. Let s be ? ToNumber(sec).
         let s = args.get_or_undefined(0).to_number(context)?;
@@ -1357,27 +1273,21 @@ impl Date {
         let milli = milli.unwrap_or_else(|| ms_from_time(t).into());
 
         // 9. Let date be MakeDate(Day(t), MakeTime(HourFromTime(t), MinFromTime(t), s, milli)).
-        let date = make_date(
+        let dt = make_date(
             day(t),
             make_time(hour_from_time(t).into(), min_from_time(t).into(), s, milli),
         );
 
         let u = if LOCAL {
             // 10. Let u be TimeClip(UTC(date)).
-            time_clip(utc_t(date, context.host_hooks().as_ref()))
+            time_clip(utc_t(dt, context.host_hooks().as_ref()))
         } else {
             // 10. Let u be TimeClip(date).
-            time_clip(date)
+            time_clip(dt)
         };
 
-        let object = this.as_object();
-        let mut date_mut = object
-            .as_ref()
-            .and_then(JsObject::downcast_mut::<Date>)
-            .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?;
-
         // 11. Set dateObject.[[DateValue]] to u.
-        date_mut.0 = u;
+        date.borrow_mut().data_mut().0 = u;
 
         // 12. Return u.
         Ok(JsValue::from(u))
@@ -1406,18 +1316,11 @@ impl Date {
         // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
         let object = this.as_object();
         let date = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Date>)
+            .and_then(|o| o.downcast::<Date>().ok())
             .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?;
 
         // 3. Let t be dateObject.[[DateValue]].
-        let t = date.0;
-
-        // NOTE (nekevss): `downcast_ref` is used and then dropped for a short lived borrow.
-        // ToNumber() may call userland code which can modify the underlying date
-        // which will cause a panic. In order to avoid this, we drop the borrow,
-        // here and only `downcast_mut` when date will be modified.
-        drop(date);
+        let t = date.borrow().data().0;
 
         // 4. Let y be ? ToNumber(year).
         let y = args.get_or_undefined(0).to_number(context)?;
@@ -1436,19 +1339,13 @@ impl Date {
         let d = make_day(yyyy, month_from_time(t).into(), date_from_time(t).into());
 
         // 8. Let date be MakeDate(d, TimeWithinDay(t)).
-        let date = make_date(d, time_within_day(t));
+        let dt = make_date(d, time_within_day(t));
 
         // 9. Let u be TimeClip(UTC(date)).
-        let u = time_clip(utc_t(date, context.host_hooks().as_ref()));
-
-        let object = this.as_object();
-        let mut date_mut = object
-            .as_ref()
-            .and_then(JsObject::downcast_mut::<Date>)
-            .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?;
+        let u = time_clip(utc_t(dt, context.host_hooks().as_ref()));
 
         // 10. Set dateObject.[[DateValue]] to u.
-        date_mut.0 = u;
+        date.borrow_mut().data_mut().0 = u;
 
         // 11. Return u.
         Ok(JsValue::from(u))
@@ -1473,30 +1370,17 @@ impl Date {
         // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).
         let object = this.as_object();
         let date = object
-            .as_ref()
-            .and_then(JsObject::downcast_ref::<Date>)
+            .and_then(|o| o.downcast::<Date>().ok())
             .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?;
 
         // 3. Let t be ? ToNumber(time).
         let t = args.get_or_undefined(0).to_number(context)?;
 
-        // NOTE (nekevss): `downcast_ref` is used and then dropped for a short lived borrow.
-        // ToNumber() may call userland code which can modify the underlying date
-        // which will cause a panic. In order to avoid this, we drop the borrow,
-        // here and only `downcast_mut` when date will be modified.
-        drop(date);
-
         // 4. Let v be TimeClip(t).
         let v = time_clip(t);
 
-        let object = this.as_object();
-        let mut date_mut = object
-            .as_ref()
-            .and_then(JsObject::downcast_mut::<Date>)
-            .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?;
-
         // 5. Set dateObject.[[DateValue]] to v.
-        date_mut.0 = v;
+        date.borrow_mut().data_mut().0 = v;
 
         // 6. Return v.
         Ok(JsValue::from(v))


### PR DESCRIPTION
Stacked on #5489.

Makes it harder to have double borrows if the borrows are immediately dropped.

Bug found by @Yanhaoxi