### PR TITLE
chore: use Trusted publishing for boa_wasm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
     types: [published]
 
 permissions:
+  id-token: write # Required for OIDC auth
   contents: read
 
 jobs:
@@ -73,10 +74,9 @@ jobs:
       - name: Set-up Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
-          node-version: "20"
-
-      - name: Set-up npm config for publishing
-        run: npm config set -- '//registry.npmjs.org/:_authToken' "${{ secrets.NPM_TOKEN }}"
+          node-version: "24"
+          registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false  # never use caching in release builds
 
       - name: Check if the npm version already exists
         run: |


### PR DESCRIPTION
Setup the boa_wasm CI publish action to use Trusted Publishers.