### PR TITLE
fix(ast): quote non-identifier object property keys in interned output

### DIFF
--- a/core/ast/src/property.rs
+++ b/core/ast/src/property.rs
@@ -72,10 +72,35 @@ impl PropertyName {
 impl ToInternedString for PropertyName {
     fn to_interned_string(&self, interner: &Interner) -> String {
         match self {
-            Self::Literal(key) => interner.resolve_expect(key.sym()).to_string(),
+            Self::Literal(key) => {
+                let name = interner.resolve_expect(key.sym()).to_string();
+                if is_identifier_name(&name) {
+                    name
+                } else {
+                    // Keys that are not a valid `IdentifierName` (e.g. `{ ':checked + div': 1 }`)
+                    // must be emitted as a quoted string literal, otherwise the output is not
+                    // parsable back as JavaScript.
+                    format!("\"{name}\"")
+                }
+            }
             Self::Computed(key) => format!("[{}]", key.to_interned_string(interner)),
         }
     }
+}
+
+/// Returns `true` if `name` can be emitted as an object property key without quotes.
+///
+/// This is a deliberately conservative ASCII check: a valid non-ASCII `IdentifierName`
+/// is treated as needing quotes. As [`ToInternedString`] is only a display/debug helper,
+/// quoting a valid identifier merely makes the output more verbose (still valid JavaScript),
+/// whereas emitting a non-identifier key unquoted would produce unparsable output.
+fn is_identifier_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    (first == '$' || first == '_' || first.is_ascii_alphabetic())
+        && chars.all(|c| c == '$' || c == '_' || c.is_ascii_alphanumeric())
 }
 
 impl From<Identifier> for PropertyName {

--- a/core/parser/src/parser/tests/format/expression.rs
+++ b/core/parser/src/parser/tests/format/expression.rs
@@ -137,6 +137,23 @@ fn object() {
 }
 
 #[test]
+fn object_non_identifier_keys() {
+    // Property keys that are not a valid `IdentifierName` must round-trip as quoted
+    // string literals, otherwise the emitted source is not parsable (see issue #3975).
+    test_formatting(
+        r#"
+        let obj = {
+            normal: 1,
+            "a-b": 2,
+            ":checked + div": 3,
+            "": 4,
+        };
+        obj;
+        "#,
+    );
+}
+
+#[test]
 fn array_literal_empty() {
     test_formatting(
         r"


### PR DESCRIPTION
**What it does:** `PropertyName::to_interned_string` emitted `Literal` keys verbatim, so object literals with keys that aren't a valid `IdentifierName` (e.g. `{ ':checked + div': 1 }`) were rendered as unparsable output (`:checked + div: 1`). This quotes such keys.

**Approach:** `Literal` keys only ever hold identifiers or string-literal keys (numeric keys are already `Computed`), so a key is emitted bare when it's a valid identifier and quoted otherwise. The identifier check is intentionally a conservative ASCII check with no new dependency — quoting a valid non-ASCII identifier only makes debug output more verbose, never invalid. Happy to switch to a full `icu_properties` `ID_Start`/`ID_Continue` check if you'd prefer stricter spec parity.

**Tests:** added `object_non_identifier_keys` (round-trips `a-b`, `:checked + div`, and the empty key). Verified it fails without the fix. `cargo fmt`, `clippy`, and the format + `boa_ast` suites are green.

Closes #3975