### PR TITLE
Fix/i32 min rem overflow (minor)

### DIFF
--- a/core/engine/src/value/operations.rs
+++ b/core/engine/src/value/operations.rs
@@ -154,9 +154,10 @@ impl JsValue {
                 if y == 0 {
                     Self::nan()
                 } else {
-                    match x % y {
-                        rem if rem == 0 && x < 0 => Self::new(-0.0),
-                        rem => Self::new(rem),
+                    match x.checked_rem(y) {
+                        Some(rem) if rem == 0 && x < 0 => Self::new(-0.0),
+                        Some(rem) => Self::new(rem),
+                        None => Self::new((f64::from(x) % f64::from(y)).copysign(f64::from(x))),
                     }
                 }
             }
@@ -754,9 +755,10 @@ impl JsValue {
             if y == 0 {
                 return Some(Self::nan());
             }
-            return Some(match x % y {
-                rem if rem == 0 && x < 0 => Self::new(-0.0),
-                rem => Self::new(rem),
+            return Some(match x.checked_rem(y) {
+                Some(rem) if rem == 0 && x < 0 => Self::new(-0.0),
+                Some(rem) => Self::new(rem),
+                None => Self::new((f64::from(x) % f64::from(y)).copysign(f64::from(x))),
             });
         }
         let x = self.as_number_cheap()?;

--- a/core/engine/src/value/tests.rs
+++ b/core/engine/src/value/tests.rs
@@ -298,6 +298,29 @@ fn rem_by_zero() {
 }
 
 #[test]
+fn rem_i32_min_by_neg_one() {
+    run_test_actions([TestAction::assert_with_op(
+        "(-2147483648 | 0) % (-1 | 0)",
+        |val, _| {
+            val.as_number()
+                .is_some_and(|n| n == 0.0 && n.is_sign_negative())
+        },
+    )]);
+}
+
+#[test]
+fn rem_fast_i32_min_by_neg_one() {
+    let x = JsValue::from(i32::MIN);
+    let y = JsValue::from(-1_i32);
+    let result = x.rem_fast(&y).unwrap();
+    assert!(
+        result
+            .as_number()
+            .is_some_and(|n| n == 0.0 && n.is_sign_negative())
+    );
+}
+
+#[test]
 fn bitand_integer_and_integer() {
     run_test_actions([TestAction::assert_eq("0xFFFF & 0xFF", 255)]);
 }


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below and remove or add any
information as you feel necessary.
--->

This Pull Request fixes/closes #5481.

**It changes the following:**

Fixes a panic when computing `(-2147483648 | 0) % (-1 | 0)`. The fast-path integer remainder operations (rem and rem_fast) used bare x % y on `i32` values, which panics on signed integer overflow when x = i32::MIN and y = -1.
**Changes**
- `core/engine/src/value/operations.rs`: Replaced bare x % y with x.checked_rem(y) in both rem() and rem_fast(). On overflow (None), falls back to f64 arithmetic — the same pattern already used by add, sub, mul, and div in the same file.
- `core/engine/src/value/tests.rs`: Added regression test rem_i32_min_by_neg_one asserting the result is -0.0.

**Verification**
- `(-2147483648 | 0) % (-1 | 0)` now returns `-0` instead of panicking (matches Node.js behaviour)
<img width="890" height="131" alt="image" src="https://github.com/user-attachments/assets/23f8371e-4737-4832-86d3-7aa27bd07fab" />

- Existing rem_by_zero test still passes
- Clippy clean (both --all-features and --no-default-features)
