### PR TITLE
fix(engine): return null from IsHTMLDDA [[Call]] per Annex B §B.3.6.1

### DIFF
--- a/core/engine/src/builtins/is_html_dda.rs
+++ b/core/engine/src/builtins/is_html_dda.rs
@@ -27,7 +27,7 @@ use crate::{
 /// This is used by the `$262.IsHTMLDDA` test harness object and models the
 /// legacy `document.all` behavior per ECMAScript Annex B §B.3.6.
 ///
-/// The object is callable — when called, it returns `undefined`.
+/// The object is callable — when called, it returns `null` per ECMAScript Annex B §B.3.6.1.
 #[derive(Debug, Clone, Copy, Trace, Finalize)]
 #[boa_gc(empty_trace)]
 pub struct IsHTMLDDA;
@@ -44,7 +44,7 @@ impl JsData for IsHTMLDDA {
 
 /// The `[[Call]]` internal method for `IsHTMLDDA` objects.
 ///
-/// When called, simply returns `undefined`.
+/// When called, simply returns `null` per ECMAScript Annex B §B.3.6.1.
 #[allow(clippy::unnecessary_wraps)]
 fn is_html_dda_call(
     _obj: &JsObject,
@@ -59,8 +59,8 @@ fn is_html_dda_call(
     let _func = context.vm.stack.pop();
     let _this = context.vm.stack.pop();
 
-    // Push undefined as the return value.
-    context.vm.stack.push(JsValue::undefined());
+    // Push null as the return value.
+    context.vm.stack.push(JsValue::null());
 
     Ok(CallValue::Complete)
 }


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request fixes the return value of `IsHTMLDDA`'s `[[Call]]` internal method.

According to ECMAScript Annex B §B.3.6.1 and test262's `INTERPRETING.md`, objects with the `[[IsHTMLDDA]]` internal slot (such as `$262.IsHTMLDDA` and `document.all`) must return `null` when called with no arguments or with an empty string.

It changes the following:

- Change `is_html_dda_call` in `core/engine/src/builtins/is_html_dda.rs` to return `JsValue::null()` instead of `JsValue::undefined()`.
- Update doc comments to cite Annex B §B.3.6.1.
- Resolves all 6 failing test262 tests in `test/annexB/built-ins/String/prototype/` (`replace`, `replaceAll`, `match`, `matchAll`, `split`, `search` `custom-*-emulates-undefined.js`), bringing the suite to 100% conformance (111/111 passed).
