### PR TITLE
fix(parser): allow HTML close comments on first line per Annex B §B.1.1

### DIFF
--- a/core/parser/src/parser/cursor/buffered_lexer/mod.rs
+++ b/core/parser/src/parser/cursor/buffered_lexer/mod.rs
@@ -30,6 +30,7 @@ pub(super) struct BufferedLexer<R> {
     read_index: usize,
     write_index: usize,
     last_linear_pos: LinearPosition,
+    first_token: bool,
 }
 
 impl<R> From<Lexer<R>> for BufferedLexer<R>
@@ -53,6 +54,7 @@ where
             read_index: 0,
             write_index: 0,
             last_linear_pos: LinearPosition::default(),
+            first_token: true,
         }
     }
 }
@@ -134,7 +136,23 @@ where
 
         let previous_index = self.write_index.checked_sub(1).unwrap_or(PEEK_BUF_SIZE - 1);
 
-        if let Some(ref token) = self.peeked[previous_index]
+        if self.first_token {
+            self.first_token = false;
+            let next = loop {
+                self.lexer.skip_html_close(interner)?;
+                let next = self.lexer.next_no_skip(interner)?;
+                if let Some(ref token) = next {
+                    match token.kind() {
+                        TokenKind::Comment => self.lexer.skip_html_close(interner)?,
+                        _ => break next,
+                    }
+                } else {
+                    break None;
+                }
+            };
+
+            self.peeked[self.write_index] = next;
+        } else if let Some(ref token) = self.peeked[previous_index]
             && token.kind() == &TokenKind::LineTerminator
         {
             // We don't want to have multiple contiguous line terminators in the buffer, since

--- a/core/parser/src/parser/cursor/buffered_lexer/tests.rs
+++ b/core/parser/src/parser/cursor/buffered_lexer/tests.rs
@@ -287,3 +287,39 @@ fn issue_1768() {
 
     assert!(cur.peek(3, true, interner).unwrap().is_none());
 }
+
+#[test]
+#[cfg(feature = "annex-b")]
+fn html_close_comment_first_line() {
+    let interner = &mut Interner::default();
+
+    // 1. Direct `-->` on the first line.
+    let mut cur = BufferedLexer::from(&b"--> comment\nA"[..]);
+    assert_eq!(
+        *cur.peek(0, true, interner)
+            .unwrap()
+            .expect("Some value expected")
+            .kind(),
+        TokenKind::identifier(interner.get_or_intern_static("A", utf16!("A")))
+    );
+
+    // 2. Spaces preceding `-->` on the first line.
+    let mut cur = BufferedLexer::from(&b"   --> comment\nB"[..]);
+    assert_eq!(
+        *cur.peek(0, true, interner)
+            .unwrap()
+            .expect("Some value expected")
+            .kind(),
+        TokenKind::identifier(interner.get_or_intern_static("B", utf16!("B")))
+    );
+
+    // 3. Single-line delimited comments and spaces preceding `-->` on the first line.
+    let mut cur = BufferedLexer::from(&b"/* comment 1 */ /* comment 2 */--> comment 3\nC"[..]);
+    assert_eq!(
+        *cur.peek(0, true, interner)
+            .unwrap()
+            .expect("Some value expected")
+            .kind(),
+        TokenKind::identifier(interner.get_or_intern_static("C", utf16!("C")))
+    );
+}

--- a/tests/tester/src/exec/mod.rs
+++ b/tests/tester/src/exec/mod.rs
@@ -602,6 +602,7 @@ fn is_error_type(error: &JsError, target_type: ErrorType, context: &mut Context)
             JsNativeErrorKind::Reference if target_type == ErrorType::ReferenceError => {}
             JsNativeErrorKind::Range if target_type == ErrorType::RangeError => {}
             JsNativeErrorKind::Type if target_type == ErrorType::TypeError => {}
+            JsNativeErrorKind::Eval if target_type == ErrorType::EvalError => {}
             _ => return false,
         }
         true


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request allows single-line HTML close comments (`-->`) to appear on the first line of a script per ECMAScript Annex B §B.1.1.

According to ECMAScript Annex B §B.1.1:
```
InputElementHashbangOrRegExp ::
    WhiteSpace
    LineTerminator
    Comment
    CommonToken
    HashbangComment
    RegularExpressionLiteral
    HTMLCloseComment

HTMLCloseComment ::
    WhiteSpaceSequence[opt] SingleLineDelimitedCommentSequence[opt] --> SingleLineCommentChars[opt]
```
An `HTMLCloseComment` is a valid input element at the start of a script under `InputElementHashbangOrRegExp`, optionally preceded by whitespace and single-line delimited comments (`/* ... */`).

Previously, `BufferedLexer` only called `skip_html_close()` after an existing `LineTerminator`, causing an initial `-->` on the first line to be lexed as punctuators `Dec` (`--`) and `GreaterThan` (`>`), resulting in an early `SyntaxError`.

It changes the following:

- Add `first_token: bool` to `BufferedLexer` to run an initial skip loop that calls `skip_html_close()` before and after consuming any initial `TokenKind::Comment` on the first line.
- Add missing `JsNativeErrorKind::Eval` match arm for `ErrorType::EvalError` in `boa_tester`'s `is_error_type` check.
- Add parser unit test `html_close_comment_first_line` in `core/parser/src/parser/cursor/buffered_lexer/tests.rs`.
- Resolves all 3 failing test262 tests in `test/annexB/language/comments/` (`single-line-html-close-first-line-1.js`, `2.js`, `3.js`), bringing `test/annexB/language/comments/` to 100% conformance (8/8 passed).
