### PR TITLE
feat(cli): use rusty_alloc on Linux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -344,9 +344,9 @@ dependencies = [
  "boa_engine",
  "boa_runtime",
  "criterion",
- "jemallocator",
  "mimalloc-safe",
  "regex",
+ "rusty_alloc-api",
  "walkdir",
 ]
 
@@ -365,11 +365,11 @@ dependencies = [
  "cow-utils",
  "dhat",
  "futures-concurrency",
- "jemallocator",
  "mimalloc-safe",
  "phf",
  "regex",
  "rustls",
+ "rusty_alloc-api",
  "rustyline",
  "serde_json",
  "smol",
@@ -426,7 +426,6 @@ dependencies = [
  "indoc",
  "intrusive-collections",
  "itertools 0.15.0",
- "jemallocator",
  "lz4_flex",
  "num-bigint 0.5.1",
  "num-integer",
@@ -438,6 +437,7 @@ dependencies = [
  "rand",
  "regress",
  "rustc-hash 2.1.3",
+ "rusty_alloc-api",
  "ryu-js",
  "serde",
  "serde_json",
@@ -2422,26 +2422,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3667095d64c3ecffc96463a21157b04bf3e252f6e8d5750b20c02e33c194e3"
 
 [[package]]
-name = "jemalloc-sys"
-version = "0.5.4+5.3.0-patched"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac6c1946e1cea1788cbfde01c993b52a10e2da07f4bac608228d1bed20bfebf2"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
-name = "jemallocator"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0de374a9f8e63150e6f5e8a60cc14c668226d7a347d8aee1a45766e3c4dd3bc"
-dependencies = [
- "jemalloc-sys",
- "libc",
-]
-
-[[package]]
 name = "jni"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3398,6 +3378,25 @@ name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "rusty_alloc"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037acdf50c589a85578aab74b848346b353c94db19ddad4774bfa925afbd128a"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rusty_alloc-api"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02301ad2df6159237fe4087334310d48543aa626ae9b89410b38a9d5b77e04e0"
+dependencies = [
+ "rusty_alloc",
+]
 
 [[package]]
 name = "rustyline"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ iana-time-zone = "0.1.65"
 indexmap = { version = "2.14.0", default-features = false }
 indoc = "2.0.7"
 itoa = "1.0.18"
-jemallocator = "0.5.4"
+rusty_alloc-api = "=1.1.4"
 mimalloc-safe = "0.1.65"
 lz4_flex = "0.14.0"
 num-bigint = "0.5.1"

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -14,7 +14,7 @@ walkdir = "2"
 regex.workspace = true
 
 [target.x86_64-unknown-linux-gnu.dev-dependencies]
-jemallocator.workspace = true
+rusty_alloc-api.workspace = true
 
 [target.'cfg(target_os = "macos")'.dev-dependencies]
 mimalloc-safe = { workspace = true, features = ["skip_collect_on_exit"] }

--- a/benches/benches/scripts.rs
+++ b/benches/benches/scripts.rs
@@ -8,7 +8,7 @@ use std::{path::Path, time::Duration};
 
 #[cfg(all(target_arch = "x86_64", target_os = "linux", target_env = "gnu"))]
 #[global_allocator]
-static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
+static ALLOC: rusty_alloc_api::RustyAlloc = rusty_alloc_api::RustyAlloc;
 
 #[cfg(target_os = "macos")]
 #[global_allocator]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -42,11 +42,11 @@ default = [
     "fetch",
 ]
 dhat = ["dep:dhat"]
-fast-allocator = ["dep:mimalloc-safe", "dep:jemallocator"]
+fast-allocator = ["dep:mimalloc-safe", "dep:rusty_alloc-api"]
 fetch = ["boa_runtime/fetch", "boa_runtime/reqwest-blocking"]
 
 [target.x86_64-unknown-linux-gnu.dependencies]
-jemallocator = { workspace = true, optional = true }
+rusty_alloc-api = { workspace = true, optional = true }
 
 [target.'cfg(any(target_os = "windows", target_os = "macos"))'.dependencies]
 mimalloc-safe = { workspace = true, optional = true, features = [

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -53,7 +53,7 @@ use std::{
     target_env = "gnu",
     feature = "dhat"
 ))]
-use jemallocator as _;
+use rusty_alloc_api as _;
 
 #[cfg(all(
     target_arch = "x86_64",
@@ -63,7 +63,7 @@ use jemallocator as _;
     not(feature = "dhat")
 ))]
 #[global_allocator]
-static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
+static ALLOC: rusty_alloc_api::RustyAlloc = rusty_alloc_api::RustyAlloc;
 
 #[cfg(all(any(target_os = "windows", target_os = "macos"), feature = "dhat"))]
 use mimalloc_safe as _;

--- a/core/engine/Cargo.toml
+++ b/core/engine/Cargo.toml
@@ -208,7 +208,7 @@ test-case.workspace = true
 husky-rs.workspace = true
 
 [target.x86_64-unknown-linux-gnu.dev-dependencies]
-jemallocator.workspace = true
+rusty_alloc-api.workspace = true
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/core/engine/benches/full.rs
+++ b/core/engine/benches/full.rs
@@ -14,7 +14,7 @@ use std::hint::black_box;
     all(target_arch = "x86_64", target_os = "linux", target_env = "gnu"),
     global_allocator
 )]
-static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
+static ALLOC: rusty_alloc_api::RustyAlloc = rusty_alloc_api::RustyAlloc;
 
 fn create_realm(c: &mut Criterion) {
     c.bench_function("Create Realm", move |b| {

--- a/flake.nix
+++ b/flake.nix
@@ -41,8 +41,6 @@
               rust-toolchain
               pkg-config
             ];
-            # Required for jemalloc, see https://github.com/NixOS/nixpkgs/issues/370494 .
-            CFLAGS = "-DJEMALLOC_STRERROR_R_RETURNS_CHAR_WITH_GNU_SOURCE";
             LD_LIBRARY_PATH = "${lib.makeLibraryPath buildInputs}";
 
             shellHook = ''


### PR DESCRIPTION
Closes #5505.

Replaces jemallocator with rusty_alloc_api::RustyAlloc for Linux CLI and benchmarks, and removes the obsoleteCloses #5505.

Replaces jemallocator with rusty_alloc_api::RustyAlloc for Linux CLI and benchmarks, and removes the obsolete Nix jemalloc CFLAGS workaround. Windows and macOS allocator selection is unchanged.

Tests: not run locally because rustc and cargo-make are unavailable in this workspace; Cargo manifests and lockfile parse successfully, and git diff --check passes. CI pending. Nix jemalloc CFLAGS workaround. Windows and macOS allocator selection is unchanged.

Tests: not run locally because rustc and cargo-make are unavailable in this workspace; Cargo manifests and lockfile parse successfully, and git diff --check passes. CI pending.